### PR TITLE
Add execution sandbox design and human-in-the-loop input

### DIFF
--- a/docs/design/DESIGN_NOTES_PHASE3_PLUS.md
+++ b/docs/design/DESIGN_NOTES_PHASE3_PLUS.md
@@ -77,3 +77,46 @@ Phase 2 uses platform-owned LLM API keys (see [PHASE2_MULTI_AGENT.md, Section 6]
 
 This is feasible on top of the dynamic provider registry architecture but adds significant complexity to secret management and billing.
 
+---
+
+## 6. Execution Sandbox
+
+Phase 2 BYOT isolates customer-provided MCP servers in separate ECS tasks with network restrictions. Phase 3+ extends this with deeper sandboxing for all tool execution, particularly important if the platform adds a `code_interpreter` tool or allows agents to run LLM-generated code.
+
+### Threat model
+
+| Threat | Example | Current mitigation |
+|--------|---------|-------------------|
+| Code escape to host | LLM-generated code accesses host filesystem or network | None — Phase 1 tools run in-process |
+| Secret exfiltration | Compromised tool reads worker's DB credentials or API keys | None — co-located tools share the worker's process memory |
+| Resource exhaustion | Runaway tool consumes unbounded CPU/memory/time | None — no per-tool resource limits |
+| Lateral movement | Tool accesses other tenants' containers or internal services | Phase 2 BYOT network policy (customer tools only) |
+
+### Sandbox layers
+
+**Process-level isolation:** Run each tool invocation in a sandboxed process (e.g., gVisor, Firecracker microVM, or at minimum a restricted container) with no access to the worker's filesystem or memory. The worker communicates with the sandbox over a local socket or stdio pipe using the MCP protocol.
+
+**Network policy per tool:** Each tool execution gets a network policy specifying exactly which external endpoints it may reach. Built-in tools like `web_search` get outbound HTTPS only. `calculator` gets no network access. Customer tools get their registered endpoint allowlist.
+
+**Resource quotas:** Per-tool-invocation limits on CPU time, memory, and wall-clock duration. Exceeded limits kill the sandbox and return a structured error to the graph executor for retry/dead-letter classification.
+
+**Filesystem restrictions:** Tool sandboxes get an ephemeral scratch directory only. No access to the worker's checkpoint data, configuration, or credentials. Credentials needed by the tool (e.g., API keys) are injected as environment variables into the sandbox, scoped to the minimum required.
+
+### Migration path
+
+- **Phase 2:** BYOT isolation (already designed) covers customer tools. Built-in tools remain co-located but are limited to the read-only set (`web_search`, `read_url`, `calculator`).
+- **Phase 3:** Move built-in tools into sandboxed execution. Add `code_interpreter` tool with full sandbox isolation. This is a prerequisite for any tool that executes LLM-generated code.
+- **Phase 3+:** Per-tenant sandbox policies, audit logging of sandbox escapes, and integration with cloud-native security tooling (e.g., AWS Nitro Enclaves for sensitive workloads).
+
+---
+
+## 7. Orchestrator Component Rewrites (Poller, Heartbeat, Reaper)
+
+Currently, the entire worker service (orchestrator + LangGraph executor) is written in Python to maintain architectural simplicity and allow AI agents (like Claude) to easily reason about the entire codebase. 
+
+If performance, concurrency, or footprint becomes a significant issue at scale, Phase 3+ could consider:
+- Rewriting the **Poller**, **Heartbeat**, and **Reaper** components in **Go** or **Java** for true multi-threading and lower resource overhead.
+- Keeping the LangGraph **Executor** in Python.
+- Establishing an IPC or local RPC layer between the Go/Java orchestrator and the Python executor.
+
+This is a heavy architectural shift and should only be pursued if the Python `asyncio` event loop becomes a demonstrable bottleneck.

--- a/docs/design/PHASE2_MULTI_AGENT.md
+++ b/docs/design/PHASE2_MULTI_AGENT.md
@@ -14,7 +14,7 @@
 - Cost-aware scheduling: per-agent budgets, tasks paused (not failed) when budget is exceeded
 - Long-term memory: append-only S3 entries with LLM-based compaction
 - Custom Tool Runtime (BYOT): customer-provided MCP servers running in platform-managed isolated containers
-- `waiting_for_approval` task status for human-in-the-loop workflows
+- `waiting_for_approval` and `waiting_for_input` task statuses for human-in-the-loop workflows
 - Non-idempotent tool guards: `idempotent: true|false` annotation on MCP tool schema, checkpoint-before-call for mutable tools, dead-letter on re-execution after crash
 - Redrive checkpoint rollback: `rollback_last_checkpoint` option on `POST /redrive`
 - Mid-node task cancellation during in-flight LLM/tool calls
@@ -268,7 +268,34 @@ Even after migration to Secrets Manager, secrets remain operational configuratio
 
 ---
 
-## 7. Reliability Additions
+## 7. Human-in-the-Loop Input
+
+Phase 2 adds two distinct human-in-the-loop mechanisms, both built on LangGraph's `interrupt()` primitive.
+
+### Approval gates (`waiting_for_approval`)
+
+When a non-idempotent tool is about to execute, the graph executor pauses the task and transitions it to `waiting_for_approval`. A human reviews the pending action and either approves or rejects it via the API.
+
+- `POST /v1/tasks/{id}/approve` — resumes execution, the tool call proceeds
+- `POST /v1/tasks/{id}/reject` — resumes execution with the rejection reason injected as a tool error, allowing the agent to adjust its plan
+
+### Freeform input (`waiting_for_input`)
+
+When the agent determines it needs clarification or additional information from the user, it can invoke a built-in `request_human_input` tool. This pauses the task and transitions it to `waiting_for_input`, surfacing a prompt message to the user.
+
+- `POST /v1/tasks/{id}/respond` — accepts `{ "message": "..." }`, injects the human response into the conversation as a `HumanMessage`, and resumes graph execution
+- The prompt message is stored on the task record (e.g., `pending_input_prompt`) so the Console and API can display what the agent is asking
+
+### Shared semantics
+
+- Both `waiting_for_approval` and `waiting_for_input` are durable pause states — the task holds its lease, heartbeat continues, and the checkpoint is persisted before pausing
+- Tasks in either state do not count against the agent's `max_concurrent_tasks` limit (they are not consuming compute)
+- A configurable timeout (default: 24 hours) auto-transitions unanswered tasks to `dead_letter` with reason `human_input_timeout`
+- The Console UI surfaces pending approval/input tasks in a dedicated queue with the agent's prompt and action context
+
+---
+
+## 8. Reliability Additions
 
 Phase 2 extends the Phase 1 recovery model with:
 


### PR DESCRIPTION
## Summary
- Add Phase 3+ execution sandbox design with threat model, sandbox layers (process isolation, network policy, resource quotas, filesystem restrictions), and migration path
- Add Phase 3+ orchestrator component rewrite considerations (Go/Java for poller/heartbeat/reaper)
- Add Phase 2 human-in-the-loop input mechanism (`waiting_for_input` status) with `POST /v1/tasks/{id}/respond` endpoint, alongside existing approval gates
- Define shared semantics for durable pause states (lease retention, timeout behavior, concurrent task accounting)

## Test plan
- [ ] Review sandbox threat model for completeness
- [ ] Verify section numbering in PHASE2_MULTI_AGENT.md is consistent
- [ ] Confirm design aligns with existing Phase 1/Phase 2 architecture decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)