### PR TITLE
Fix Claude Code action permissions to enable PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Change `pull-requests: read` → `write` in both Claude Code workflows so the bot can actually post review comments
- Change `issues: read` → `write` in `claude.yml` so `@claude` can respond on issues

Without write permissions, both actions ran successfully but silently discarded their output.

## Test plan
- [x] Merge this PR, then open a new PR to verify the review bot posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)