### PR TITLE
Agent Capabilities Track 1: Output Artifact Storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,22 +128,9 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0001_phase1_durable_execution.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0002_worker_registry.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0003_dynamic_models.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0004_timeout_reference.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0005_agents_table.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0006_runtime_state_model.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0007_scheduler_and_budgets.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0008_tool_servers.sql
+          for f in infrastructure/database/migrations/[0-9][0-9][0-9][0-9]_*.sql; do
+            psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime -f "$f"
+          done
           psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
             -f infrastructure/database/migrations/test_seed.sql
 
@@ -188,22 +175,9 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0001_phase1_durable_execution.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0002_worker_registry.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0003_dynamic_models.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0004_timeout_reference.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0005_agents_table.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0006_runtime_state_model.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0007_scheduler_and_budgets.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0008_tool_servers.sql
+          for f in infrastructure/database/migrations/[0-9][0-9][0-9][0-9]_*.sql; do
+            psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime -f "$f"
+          done
           psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
             -f infrastructure/database/migrations/test_seed.sql
 
@@ -237,6 +211,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      localstack:
+        image: localstack/localstack:3
+        env:
+          SERVICES: s3
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+        ports:
+          - 4566:4566
 
     steps:
       - uses: actions/checkout@v4
@@ -262,24 +245,18 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0001_phase1_durable_execution.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0002_worker_registry.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0003_dynamic_models.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0004_timeout_reference.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0005_agents_table.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0006_runtime_state_model.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0007_scheduler_and_budgets.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0008_tool_servers.sql
+          for f in infrastructure/database/migrations/[0-9][0-9][0-9][0-9]_*.sql; do
+            psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime -f "$f"
+          done
           psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
             -f infrastructure/database/migrations/test_seed.sql
+
+      - name: Create S3 bucket in LocalStack
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_DEFAULT_REGION: us-east-1
+        run: aws --endpoint-url=http://localhost:4566 s3 mb s3://platform-artifacts
 
       - name: Pre-build API service
         working-directory: services/api-service
@@ -295,6 +272,11 @@ jobs:
           E2E_DB_PASSWORD: postgres
           APP_DEV_TASK_CONTROLS_ENABLED: "true"
           LANGFUSE_ENABLED: "false"
+          S3_ENDPOINT_URL: http://localhost:4566
+          S3_BUCKET_NAME: platform-artifacts
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_REGION: us-east-1
           # conftest will auto-start the API via ./gradlew bootRun
         run: |
           set -o pipefail
@@ -352,22 +334,9 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0001_phase1_durable_execution.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0002_worker_registry.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0003_dynamic_models.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0004_timeout_reference.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0005_agents_table.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0006_runtime_state_model.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0007_scheduler_and_budgets.sql
-          psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
-            -f infrastructure/database/migrations/0008_tool_servers.sql
+          for f in infrastructure/database/migrations/[0-9][0-9][0-9][0-9]_*.sql; do
+            psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime -f "$f"
+          done
           psql -h localhost -p 55432 -U postgres -d persistent_agent_runtime \
             -f infrastructure/database/migrations/test_seed.sql
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ PYTHON ?= $(shell \
 	done)
 
 DB_CONTAINER_NAME ?= persistent-agent-runtime-postgres
+COMPOSE_FILE := $(ROOT_DIR)/docker-compose.yml
+LOCALSTACK_CONTAINER_NAME ?= persistent-agent-runtime-localstack
+S3_ENDPOINT_URL ?= http://localhost:4566
+S3_BUCKET_NAME ?= platform-artifacts
+AWS_ACCESS_KEY_ID ?= test
+AWS_SECRET_ACCESS_KEY ?= test
+AWS_REGION ?= us-east-1
 DB_DSN ?= postgresql://postgres:postgres@localhost:55432/persistent_agent_runtime
 DB_HOST ?= $(if $(PYTHON),$(shell $(PYTHON) -c 'import sys; from urllib.parse import urlparse; print(urlparse(sys.argv[1]).hostname or "localhost")' "$(DB_DSN)"),localhost)
 DB_PORT ?= $(if $(PYTHON),$(shell $(PYTHON) -c 'import sys; from urllib.parse import urlparse; print(urlparse(sys.argv[1]).port or 55432)' "$(DB_DSN)"),55432)
@@ -677,19 +684,14 @@ status:
 # ============================================================
 
 db-up:
-	@echo "$(YELLOW)🐳 Ensuring Database Container is running...$(NC)"
+	@echo "$(YELLOW)🐳 Ensuring Database and LocalStack containers are running...$(NC)"
 	@docker info >/dev/null 2>&1 || (echo "$(RED)❌ Docker daemon is not running. Please start Docker Desktop.$(NC)" && exit 1)
 	@if [ "$(DB_HOST)" != "localhost" ] && [ "$(DB_HOST)" != "127.0.0.1" ]; then \
-		echo "$(RED)❌ db-up only manages a Docker PostgreSQL instance on localhost. Current DB_DSN host is '$(DB_HOST)'. Start that database manually instead.$(NC)"; \
+		echo "$(RED)❌ db-up only manages Docker instances on localhost. Current DB_DSN host is '$(DB_HOST)'. Start that database manually instead.$(NC)"; \
 		exit 1; \
 	fi
-	@if ! docker ps -a --format '{{.Names}}' | grep -Eq "^$(DB_CONTAINER_NAME)$$"; then \
-		echo "$(YELLOW)Container $(DB_CONTAINER_NAME) does not exist. Creating it...$(NC)"; \
-		docker run -d --name $(DB_CONTAINER_NAME) -e POSTGRES_USER="$(DB_USER)" -e POSTGRES_PASSWORD="$(DB_PASSWORD)" -e POSTGRES_DB="$(DB_NAME)" -p $(DB_PORT):5432 postgres:16 postgres -c log_statement=all >/dev/null; \
-	fi
-	@if [ "$$(docker inspect -f '{{.State.Running}}' $(DB_CONTAINER_NAME) 2>/dev/null)" != "true" ]; then \
-		docker start $(DB_CONTAINER_NAME) >/dev/null 2>&1 || (echo "$(RED)❌ Failed to start container $(DB_CONTAINER_NAME)$(NC)" && exit 1); \
-	fi
+	@DB_USER="$(DB_USER)" DB_PASSWORD="$(DB_PASSWORD)" DB_NAME="$(DB_NAME)" DB_PORT="$(DB_PORT)" \
+		docker compose -f $(COMPOSE_FILE) up -d postgres localstack
 	@echo "$(YELLOW)⏳ Waiting for PostgreSQL to accept connections...$(NC)"
 	@attempts=0; \
 	until docker exec $(DB_CONTAINER_NAME) env PGPASSWORD="$(DB_PASSWORD)" pg_isready -h 127.0.0.1 -p 5432 -U "$(DB_USER)" -d "$(DB_NAME)" >/dev/null 2>&1; do \
@@ -700,15 +702,25 @@ db-up:
 		fi; \
 		sleep 1; \
 	done
-	@echo "$(GREEN)✅ DB is up$(NC)"
+	@echo "$(YELLOW)⏳ Waiting for LocalStack to be ready...$(NC)"
+	@attempts=0; \
+	until docker exec $(LOCALSTACK_CONTAINER_NAME) awslocal s3 ls >/dev/null 2>&1; do \
+		attempts=$$((attempts + 1)); \
+		if [ $$attempts -ge 30 ]; then \
+			echo "$(RED)❌ LocalStack did not become ready within 30 seconds$(NC)"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+	@echo "$(GREEN)✅ DB and LocalStack are up$(NC)"
 
 db-down:
-	@echo "$(YELLOW)🛑 Stopping Database Container...$(NC)"
-	@docker stop $(DB_CONTAINER_NAME) >/dev/null
-	@echo "$(GREEN)✅ DB stopped$(NC)"
+	@echo "$(YELLOW)🛑 Stopping Database and LocalStack containers...$(NC)"
+	@docker compose -f $(COMPOSE_FILE) down
+	@echo "$(GREEN)✅ Containers stopped$(NC)"
 
 db-status:
-	@docker ps -a --filter "name=$(DB_CONTAINER_NAME)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+	@docker compose -f $(COMPOSE_FILE) ps
 
 db-migrate: db-up
 	@echo "$(YELLOW)🛠️  Applying migrations to Database...$(NC)"
@@ -749,9 +761,9 @@ api-test:
 	@echo "$(CYAN)🧪 Running API tests...$(NC)"
 	@cd $(API_DIR) && ./gradlew test
 
-worker-test:
+worker-test: test-db-up
 	@echo "$(CYAN)🧪 Running Worker tests...$(NC)"
-	@$(WORKER_VENV_PYTHON) -m pytest $(WORKER_DIR)/tests -q
+	@E2E_DB_DSN=$(E2E_DB_DSN) $(WORKER_VENV_PYTHON) -m pytest $(WORKER_DIR)/tests -q
 
 console-test:
 	@echo "$(CYAN)🧪 Running Console tests...$(NC)"
@@ -789,18 +801,15 @@ test-e2e-langfuse: ## Run Langfuse E2E tests (requires: make test-langfuse-up &&
 # E2E Infrastructure (isolated from local dev)
 # ============================================================
 
-e2e-up:
-	@command -v docker >/dev/null 2>&1 || { echo "$(RED)❌ Docker is required for E2E tests$(NC)"; exit 1; }
-	@mkdir -p $(TMP_DIR)
-	@echo "$(YELLOW)🧪 Starting E2E infrastructure (DB :$(E2E_DB_PORT), API :$(E2E_API_PORT))...$(NC)"
-	@# --- Postgres ---
+test-db-up:
+	@command -v docker >/dev/null 2>&1 || { echo "$(RED)❌ Docker is required for tests$(NC)"; exit 1; }
+	@# --- Test Postgres ---
 	@if docker ps --format '{{.Names}}' | grep -qx '$(E2E_PG_CONTAINER)'; then \
-		echo "  $(GREEN)✓ E2E Postgres already running$(NC)"; \
+		true; \
 	elif docker ps -a --format '{{.Names}}' | grep -qx '$(E2E_PG_CONTAINER)'; then \
-		echo "  $(YELLOW)▶ Starting existing E2E Postgres container...$(NC)"; \
 		docker start $(E2E_PG_CONTAINER); \
 	else \
-		echo "  $(YELLOW)▶ Creating E2E Postgres container...$(NC)"; \
+		echo "$(YELLOW)▶ Creating test Postgres container (port $(E2E_DB_PORT))...$(NC)"; \
 		docker run -d --name $(E2E_PG_CONTAINER) \
 			-e POSTGRES_USER=$(E2E_DB_USER) \
 			-e POSTGRES_PASSWORD=$(E2E_DB_PASSWORD) \
@@ -808,25 +817,42 @@ e2e-up:
 			-p $(E2E_DB_PORT):5432 \
 			$(E2E_PG_IMAGE); \
 	fi
-	@echo "  $(YELLOW)⏳ Waiting for E2E Postgres...$(NC)"
 	@for i in $$(seq 1 60); do \
 		docker exec $(E2E_PG_CONTAINER) pg_isready -U $(E2E_DB_USER) >/dev/null 2>&1 && break; \
 		sleep 0.5; \
 	done
 	@docker exec $(E2E_PG_CONTAINER) pg_isready -U $(E2E_DB_USER) >/dev/null 2>&1 || \
-		(echo "$(RED)❌ E2E Postgres did not become ready$(NC)" && exit 1)
-	@echo "  $(GREEN)✓ E2E Postgres ready$(NC)"
+		(echo "$(RED)❌ Test Postgres did not become ready$(NC)" && exit 1)
 	@# --- Migrations ---
-	@echo "  $(YELLOW)▶ Applying migrations to E2E database...$(NC)"
 	@for f in $(MIGRATION_FILES); do \
 		PGPASSWORD=$(E2E_DB_PASSWORD) psql -h $(E2E_DB_HOST) -p $(E2E_DB_PORT) -U $(E2E_DB_USER) -d $(E2E_DB_NAME) -f "$$f" -q 2>/dev/null || true; \
 	done
-	@echo "  $(GREEN)✓ E2E migrations applied$(NC)"
-	@# --- Seed test models (no API keys needed) ---
-	@echo "  $(YELLOW)▶ Seeding test models...$(NC)"
+	@# --- Seed test models ---
 	@PGPASSWORD=$(E2E_DB_PASSWORD) psql -h $(E2E_DB_HOST) -p $(E2E_DB_PORT) -U $(E2E_DB_USER) -d $(E2E_DB_NAME) -q \
 		-c "INSERT INTO provider_keys (provider_id, api_key) VALUES ('anthropic', 'e2e-placeholder') ON CONFLICT (provider_id) DO NOTHING;" \
 		-c "INSERT INTO models (model_id, provider_id, display_name, is_active, input_microdollars_per_million, output_microdollars_per_million) VALUES ('claude-sonnet-4-6', 'anthropic', 'Claude Sonnet 4.6', true, 3000000, 15000000) ON CONFLICT (provider_id, model_id) DO NOTHING;"
+	@# --- LocalStack (shared, for S3 artifact storage) ---
+	@if docker ps --format '{{.Names}}' | grep -qx '$(LOCALSTACK_CONTAINER_NAME)'; then \
+		true; \
+	else \
+		DB_USER="$(DB_USER)" DB_PASSWORD="$(DB_PASSWORD)" DB_NAME="$(DB_NAME)" DB_PORT="$(DB_PORT)" \
+			docker compose -f $(COMPOSE_FILE) up -d localstack; \
+		attempts=0; \
+		until docker exec $(LOCALSTACK_CONTAINER_NAME) awslocal s3 ls >/dev/null 2>&1; do \
+			attempts=$$((attempts + 1)); \
+			if [ $$attempts -ge 30 ]; then \
+				echo "$(RED)❌ LocalStack did not become ready$(NC)"; \
+				exit 1; \
+			fi; \
+			sleep 1; \
+		done; \
+	fi
+
+e2e-up: test-db-up
+	@mkdir -p $(TMP_DIR)
+	@echo "$(YELLOW)🧪 Starting E2E infrastructure (DB :$(E2E_DB_PORT), API :$(E2E_API_PORT))...$(NC)"
+	@echo "  $(GREEN)✓ E2E Postgres ready$(NC)"
+	@echo "  $(GREEN)✓ E2E migrations applied$(NC)"
 	@echo "  $(GREEN)✓ E2E test models seeded$(NC)"
 	@# --- API ---
 	@if curl -sf http://localhost:$(E2E_API_PORT)/v1/health >/dev/null 2>&1; then \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: persistent-agent-runtime-postgres
+    environment:
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+      POSTGRES_DB: ${DB_NAME:-persistent_agent_runtime}
+    ports:
+      - "${DB_PORT:-55432}:5432"
+    command: postgres -c log_statement=all
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-persistent_agent_runtime}"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+  localstack:
+    image: localstack/localstack:3
+    container_name: persistent-agent-runtime-localstack
+    environment:
+      SERVICES: s3
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    ports:
+      - "4566:4566"
+    volumes:
+      - "./scripts/init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh"
+      - localstackdata:/var/lib/localstack
+    healthcheck:
+      test: ["CMD-SHELL", "awslocal s3 ls"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+
+volumes:
+  pgdata:
+  localstackdata:

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -238,6 +238,14 @@ npx vitest run src/features/agents/AgentDetailPage.test.tsx
 npx vitest run --reporter=verbose -t "renders budget fields"
 ```
 
+### Infrastructure prerequisites for tests
+
+**All tests use an isolated test database — never the local dev database.** Worker integration tests and E2E tests both connect to a dedicated test PostgreSQL container (`par-e2e-postgres`) on port **55433**, separate from the local dev DB on port 55432. This ensures tests never destroy your local development data.
+
+`make worker-test` automatically starts the test database container and applies migrations via the `test-db-up` dependency. If you see `N passed, 12 skipped` in worker test output, it means Docker is not running — start Docker Desktop and re-run.
+
+`make e2e-test` also depends on the test database (via `e2e-up → test-db-up`) plus an API service on port 8081. LocalStack on port 4566 must be running for artifact-related E2E tests — `make db-up` starts both the dev PostgreSQL and LocalStack containers.
+
 ### Pre-existing test failures
 
 If tests fail that are unrelated to your change, you must still fix them. Use `git stash` or a separate branch to verify the failure exists on `main` before your changes. If it does, fix it as part of your work — do not leave broken tests behind.

--- a/docs/exec-plans/active/agent-capabilities/track-1/progress.md
+++ b/docs/exec-plans/active/agent-capabilities/track-1/progress.md
@@ -2,14 +2,14 @@
 
 | Task | Component | Status | Description |
 |------|-----------|--------|-------------|
-| Task 1 | Database Migration | Pending | `task_artifacts` table |
-| Task 2 | LocalStack Docker Setup | Pending | LocalStack S3 container with bucket init |
-| Task 3 | Worker S3 Client | Pending | boto3 S3 wrapper (upload/download/delete) |
-| Task 4 | API Artifact Repo + S3 Service | Pending | JDBC queries for `task_artifacts` + S3 streaming |
-| Task 5 | API Artifact Endpoints | Pending | GET artifact list + download endpoints |
-| Task 6 | upload_artifact Tool | Pending | Built-in agent tool for output artifact production |
-| Task 7 | Console Artifacts Tab | Pending | Artifact list + download in task detail view |
-| Task 8 | Integration Tests | Pending | End-to-end output artifact flow tests |
+| Task 1 | Database Migration | Done | `task_artifacts` table |
+| Task 2 | LocalStack Docker Setup | Done | LocalStack S3 container with bucket init |
+| Task 3 | Worker S3 Client | Done | boto3 S3 wrapper (upload/download/delete) |
+| Task 4 | API Artifact Repo + S3 Service | Done | JDBC queries for `task_artifacts` + S3 streaming |
+| Task 5 | API Artifact Endpoints | Done | GET artifact list + download endpoints |
+| Task 6 | upload_artifact Tool | Done | Built-in agent tool for output artifact production |
+| Task 7 | Console Artifacts Tab | Done | Artifact list + download in task detail view |
+| Task 8 | Integration Tests | Done | End-to-end output artifact flow tests |
 
 ## Notes
 

--- a/infrastructure/database/migrations/0009_artifact_storage.sql
+++ b/infrastructure/database/migrations/0009_artifact_storage.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Migration 0009: Artifact Storage
+-- =============================================================================
+-- Track: Agent Capabilities — Track 1 (Output Artifact Storage)
+-- Adds the task_artifacts table for storing metadata about files produced by
+-- agents (output) or attached by users (input). Actual file content is stored
+-- in S3; this table holds only the metadata and S3 key reference.
+-- =============================================================================
+
+-- Step 1: Create task_artifacts table for artifact metadata
+CREATE TABLE task_artifacts (
+    artifact_id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id       UUID NOT NULL REFERENCES tasks(task_id) ON DELETE CASCADE,
+    tenant_id     TEXT NOT NULL,
+    filename      TEXT NOT NULL,
+    direction     TEXT NOT NULL CHECK (direction IN ('input', 'output')),
+    content_type  TEXT NOT NULL,
+    size_bytes    BIGINT NOT NULL,
+    s3_key        TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Step 2: Unique constraint — prevent duplicate artifacts per task/direction/filename
+ALTER TABLE task_artifacts ADD CONSTRAINT uq_task_artifacts_task_direction_filename
+    UNIQUE (task_id, direction, filename);
+
+-- Step 3: Composite index for efficient tenant-scoped artifact listing
+CREATE INDEX idx_task_artifacts_tenant_task ON task_artifacts (tenant_id, task_id);
+
+-- Step 4: Table comment
+COMMENT ON TABLE task_artifacts IS 'Metadata for files produced by agents (output) or attached by users (input). Actual file content stored in S3.';

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Initialize LocalStack S3 bucket for artifact storage.
+# This script runs automatically when LocalStack reaches the "ready" state
+# via the /etc/localstack/init/ready.d/ mount.
+
+set -euo pipefail
+
+echo "Creating platform-artifacts S3 bucket..."
+awslocal s3 mb s3://platform-artifacts 2>/dev/null || true
+echo "LocalStack S3 initialization complete."
+awslocal s3 ls

--- a/services/api-service/build.gradle
+++ b/services/api-service/build.gradle
@@ -25,6 +25,10 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.postgresql:postgresql'
 
+    // AWS SDK v2 for S3 artifact storage
+    implementation platform('software.amazon.awssdk:bom:2.29.0')
+    implementation 'software.amazon.awssdk:s3'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core:5.18.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'

--- a/services/api-service/src/main/java/com/persistentagent/api/config/ValidationConstants.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/config/ValidationConstants.java
@@ -17,7 +17,7 @@ public final class ValidationConstants {
     public static final String DEFAULT_WORKER_POOL_ID = "shared";
 
     /** Stable public tools available in all environments. */
-    public static final Set<String> ALLOWED_TOOLS = Set.of("web_search", "read_url", "calculator", "request_human_input");
+    public static final Set<String> ALLOWED_TOOLS = Set.of("web_search", "read_url", "calculator", "request_human_input", "upload_artifact");
 
     /** Dev-only task-control tools, enabled behind app.dev-task-controls.enabled. */
     public static final Set<String> DEV_TASK_CONTROL_TOOLS = Set.of("dev_sleep");

--- a/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
@@ -1,0 +1,50 @@
+package com.persistentagent.api.controller;
+
+import com.persistentagent.api.model.ArtifactMetadata;
+import com.persistentagent.api.service.ArtifactService;
+import com.persistentagent.api.service.ArtifactService.ArtifactDownload;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/tasks/{taskId}/artifacts")
+public class ArtifactController {
+
+    private final ArtifactService artifactService;
+
+    public ArtifactController(ArtifactService artifactService) {
+        this.artifactService = artifactService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ArtifactMetadata>> listArtifacts(
+            @PathVariable UUID taskId,
+            @RequestParam(name = "direction", required = false) String direction) {
+        List<ArtifactMetadata> artifacts = artifactService.listArtifacts(taskId, direction);
+        return ResponseEntity.ok(artifacts);
+    }
+
+    @GetMapping("/{filename}")
+    public ResponseEntity<InputStreamResource> downloadArtifact(
+            @PathVariable UUID taskId,
+            @PathVariable String filename,
+            @RequestParam(name = "direction", defaultValue = "output") String direction) {
+        ArtifactDownload download = artifactService.downloadArtifact(taskId, filename, direction);
+
+        ArtifactMetadata metadata = download.metadata();
+        InputStreamResource resource = new InputStreamResource(download.stream());
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(metadata.contentType()))
+                .contentLength(metadata.sizeBytes())
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + metadata.filename() + "\"")
+                .body(resource);
+    }
+}

--- a/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
@@ -40,8 +40,14 @@ public class ArtifactController {
         ArtifactMetadata metadata = download.metadata();
         InputStreamResource resource = new InputStreamResource(download.stream());
 
+        // Always include charset=utf-8 for text types since upload_artifact encodes as UTF-8
+        String contentType = metadata.contentType();
+        if (contentType.startsWith("text/") && !contentType.contains("charset")) {
+            contentType = contentType + "; charset=utf-8";
+        }
+
         return ResponseEntity.ok()
-                .contentType(MediaType.parseMediaType(metadata.contentType()))
+                .contentType(MediaType.parseMediaType(contentType))
                 .contentLength(metadata.sizeBytes())
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=\"" + metadata.filename() + "\"")

--- a/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/controller/ArtifactController.java
@@ -46,8 +46,15 @@ public class ArtifactController {
             contentType = contentType + "; charset=utf-8";
         }
 
+        MediaType mediaType;
+        try {
+            mediaType = MediaType.parseMediaType(contentType);
+        } catch (Exception e) {
+            mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        }
+
         return ResponseEntity.ok()
-                .contentType(MediaType.parseMediaType(contentType))
+                .contentType(mediaType)
                 .contentLength(metadata.sizeBytes())
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=\"" + metadata.filename() + "\"")

--- a/services/api-service/src/main/java/com/persistentagent/api/exception/GlobalExceptionHandler.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
@@ -77,6 +78,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Map<String, Object>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameter: " + ex.getName());
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        return buildErrorResponse(status, ex.getReason() != null ? ex.getReason() : ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/services/api-service/src/main/java/com/persistentagent/api/model/ArtifactMetadata.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/model/ArtifactMetadata.java
@@ -1,0 +1,17 @@
+package com.persistentagent.api.model;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Metadata for a task artifact (input or output file).
+ */
+public record ArtifactMetadata(
+    UUID artifactId,
+    UUID taskId,
+    String filename,
+    String direction,
+    String contentType,
+    long sizeBytes,
+    OffsetDateTime createdAt
+) {}

--- a/services/api-service/src/main/java/com/persistentagent/api/model/response/TaskStatusResponse.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/model/response/TaskStatusResponse.java
@@ -2,6 +2,7 @@ package com.persistentagent.api.model.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.persistentagent.api.model.ArtifactMetadata;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -32,6 +33,7 @@ public record TaskStatusResponse(
         @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("human_input_timeout_at") OffsetDateTime humanInputTimeoutAt,
         @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("pause_reason") String pauseReason,
         @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("pause_details") Object pauseDetails,
-        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("resume_eligible_at") OffsetDateTime resumeEligibleAt
+        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("resume_eligible_at") OffsetDateTime resumeEligibleAt,
+        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("artifacts") List<ArtifactMetadata> artifacts
 ) {
 }

--- a/services/api-service/src/main/java/com/persistentagent/api/repository/ArtifactRepository.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/repository/ArtifactRepository.java
@@ -1,0 +1,92 @@
+package com.persistentagent.api.repository;
+
+import com.persistentagent.api.model.ArtifactMetadata;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class ArtifactRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ArtifactRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private static final RowMapper<ArtifactMetadata> ARTIFACT_MAPPER = (ResultSet rs, int rowNum) -> {
+        return new ArtifactMetadata(
+            UUID.fromString(rs.getString("artifact_id")),
+            UUID.fromString(rs.getString("task_id")),
+            rs.getString("filename"),
+            rs.getString("direction"),
+            rs.getString("content_type"),
+            rs.getLong("size_bytes"),
+            rs.getObject("created_at", OffsetDateTime.class)
+        );
+    };
+
+    public UUID insert(UUID taskId, String tenantId, String filename, String direction,
+                       String contentType, long sizeBytes, String s3Key) {
+        String sql = """
+                INSERT INTO task_artifacts (task_id, tenant_id, filename, direction, content_type, size_bytes, s3_key)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                RETURNING artifact_id
+                """;
+
+        return jdbcTemplate.queryForObject(sql, UUID.class,
+                taskId, tenantId, filename, direction, contentType, sizeBytes, s3Key);
+    }
+
+    public List<ArtifactMetadata> findByTaskId(UUID taskId, String tenantId, String direction) {
+        if (direction != null && !direction.isBlank()) {
+            String sql = """
+                    SELECT artifact_id, task_id, filename, direction, content_type, size_bytes, created_at
+                    FROM task_artifacts
+                    WHERE task_id = ? AND tenant_id = ? AND direction = ?
+                    ORDER BY created_at ASC
+                    """;
+            return jdbcTemplate.query(sql, ARTIFACT_MAPPER, taskId, tenantId, direction);
+        }
+
+        String sql = """
+                SELECT artifact_id, task_id, filename, direction, content_type, size_bytes, created_at
+                FROM task_artifacts
+                WHERE task_id = ? AND tenant_id = ?
+                ORDER BY created_at ASC
+                """;
+        return jdbcTemplate.query(sql, ARTIFACT_MAPPER, taskId, tenantId);
+    }
+
+    public Optional<ArtifactWithS3Key> findByTaskIdAndFilename(
+            UUID taskId, String tenantId, String filename, String direction) {
+        String sql = """
+                SELECT artifact_id, task_id, filename, direction, content_type, size_bytes, s3_key, created_at
+                FROM task_artifacts
+                WHERE task_id = ? AND tenant_id = ? AND filename = ? AND direction = ?
+                """;
+        List<ArtifactWithS3Key> results = jdbcTemplate.query(sql,
+                (ResultSet rs, int rowNum) -> new ArtifactWithS3Key(
+                    new ArtifactMetadata(
+                        UUID.fromString(rs.getString("artifact_id")),
+                        UUID.fromString(rs.getString("task_id")),
+                        rs.getString("filename"),
+                        rs.getString("direction"),
+                        rs.getString("content_type"),
+                        rs.getLong("size_bytes"),
+                        rs.getObject("created_at", OffsetDateTime.class)
+                    ),
+                    rs.getString("s3_key")
+                ),
+                taskId, tenantId, filename, direction);
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+    public record ArtifactWithS3Key(ArtifactMetadata metadata, String s3Key) {}
+}

--- a/services/api-service/src/main/java/com/persistentagent/api/service/ArtifactService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/ArtifactService.java
@@ -1,0 +1,65 @@
+package com.persistentagent.api.service;
+
+import com.persistentagent.api.config.ValidationConstants;
+import com.persistentagent.api.exception.TaskNotFoundException;
+import com.persistentagent.api.model.ArtifactMetadata;
+import com.persistentagent.api.repository.ArtifactRepository;
+import com.persistentagent.api.repository.ArtifactRepository.ArtifactWithS3Key;
+import com.persistentagent.api.repository.TaskRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ArtifactService {
+
+    private final ArtifactRepository artifactRepository;
+    private final TaskRepository taskRepository;
+    private final S3StorageService s3StorageService;
+
+    public ArtifactService(ArtifactRepository artifactRepository,
+                           TaskRepository taskRepository,
+                           S3StorageService s3StorageService) {
+        this.artifactRepository = artifactRepository;
+        this.taskRepository = taskRepository;
+        this.s3StorageService = s3StorageService;
+    }
+
+    public List<ArtifactMetadata> listArtifacts(UUID taskId, String direction) {
+        String tenantId = ValidationConstants.DEFAULT_TENANT_ID;
+
+        taskRepository.findByIdAndTenant(taskId, tenantId)
+                .orElseThrow(() -> new TaskNotFoundException(taskId));
+
+        return artifactRepository.findByTaskId(taskId, tenantId, direction);
+    }
+
+    public ArtifactDownload downloadArtifact(UUID taskId, String filename, String direction) {
+        String tenantId = ValidationConstants.DEFAULT_TENANT_ID;
+
+        taskRepository.findByIdAndTenant(taskId, tenantId)
+                .orElseThrow(() -> new TaskNotFoundException(taskId));
+
+        ArtifactWithS3Key artifact = artifactRepository
+                .findByTaskIdAndFilename(taskId, tenantId, filename, direction)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Artifact not found: " + filename));
+
+        ResponseInputStream<GetObjectResponse> stream = s3StorageService
+                .download(artifact.s3Key())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Artifact file not found in storage: " + filename));
+
+        return new ArtifactDownload(artifact.metadata(), stream);
+    }
+
+    public record ArtifactDownload(
+        ArtifactMetadata metadata,
+        ResponseInputStream<GetObjectResponse> stream
+    ) {}
+}

--- a/services/api-service/src/main/java/com/persistentagent/api/service/CheckpointEventParser.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/CheckpointEventParser.java
@@ -28,6 +28,28 @@ public class CheckpointEventParser {
             Object metadataPayload,
             String fallbackNodeName,
             String checkpointId) {
+
+        // Detect follow-up resume checkpoints: source="input" with step > 0
+        // These are __start__ nodes from follow-up submissions that replay prior messages.
+        // Without this check, the last AI message from the previous run gets rendered
+        // as a duplicate "Agent Response" step.
+        Object parsedMetadata = parseJson(metadataPayload, "metadata_payload", checkpointId);
+        if (parsedMetadata instanceof Map<?, ?> metaMap) {
+            String source = asString(metaMap.get("source"));
+            Object stepObj = metaMap.get("step");
+            if ("input".equals(source) && stepObj instanceof Number step && step.intValue() > 0) {
+                return new CheckpointEventResponse(
+                        "system",
+                        "Follow-Up Received",
+                        "A follow-up message was submitted and execution resumed.",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+            }
+        }
+
         Object parsedPayload = parseJson(checkpointPayload, "checkpoint_payload", checkpointId);
         if (parsedPayload instanceof Map<?, ?> payloadMap) {
             Object channelValues = payloadMap.get("channel_values");

--- a/services/api-service/src/main/java/com/persistentagent/api/service/S3StorageService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/S3StorageService.java
@@ -1,0 +1,93 @@
+package com.persistentagent.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import jakarta.annotation.PostConstruct;
+import java.net.URI;
+import java.util.Optional;
+
+@Service
+public class S3StorageService {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3StorageService.class);
+
+    @Value("${s3.endpoint-url:#{null}}")
+    private String endpointUrl;
+
+    @Value("${s3.bucket-name:platform-artifacts}")
+    private String bucketName;
+
+    @Value("${s3.region:us-east-1}")
+    private String region;
+
+    private S3Client s3Client;
+
+    @PostConstruct
+    void init() {
+        var builder = S3Client.builder()
+                .region(Region.of(region));
+
+        if (endpointUrl != null && !endpointUrl.isBlank()) {
+            builder.endpointOverride(URI.create(endpointUrl))
+                   .forcePathStyle(true);
+        }
+
+        this.s3Client = builder.build();
+        logger.info("S3StorageService initialized: bucket={}, endpoint={}, region={}",
+                bucketName, endpointUrl != null ? endpointUrl : "default (AWS)", region);
+    }
+
+    public Optional<ResponseInputStream<GetObjectResponse>> download(String s3Key) {
+        try {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request);
+            logger.info("S3 download started: bucket={}, key={}", bucketName, s3Key);
+            return Optional.of(response);
+        } catch (NoSuchKeyException e) {
+            logger.warn("S3 object not found: bucket={}, key={}", bucketName, s3Key);
+            return Optional.empty();
+        }
+    }
+
+    public void upload(String s3Key, byte[] data, String contentType) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .contentType(contentType)
+                .contentLength((long) data.length)
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(data));
+        logger.info("S3 upload completed: bucket={}, key={}, size={}", bucketName, s3Key, data.length);
+    }
+
+    public void delete(String s3Key) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+            s3Client.deleteObject(request);
+            logger.info("S3 delete completed: bucket={}, key={}", bucketName, s3Key);
+        } catch (Exception e) {
+            logger.warn("S3 delete failed (best-effort): bucket={}, key={}, error={}",
+                    bucketName, s3Key, e.getMessage());
+        }
+    }
+}

--- a/services/api-service/src/main/java/com/persistentagent/api/service/TaskService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/TaskService.java
@@ -3,6 +3,8 @@ package com.persistentagent.api.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.persistentagent.api.config.ValidationConstants;
 import com.persistentagent.api.exception.AgentNotFoundException;
+import com.persistentagent.api.model.ArtifactMetadata;
+import com.persistentagent.api.repository.ArtifactRepository;
 import com.persistentagent.api.exception.InvalidStateTransitionException;
 import com.persistentagent.api.exception.TaskNotFoundException;
 import com.persistentagent.api.exception.ValidationException;
@@ -29,6 +31,7 @@ public class TaskService {
 
     private static final Set<String> VALID_PAUSE_REASONS = Set.of("budget_per_task", "budget_per_hour");
 
+    private final ArtifactRepository artifactRepository;
     private final TaskRepository taskRepository;
     private final AgentRepository agentRepository;
     private final ModelRepository modelRepository;
@@ -41,6 +44,7 @@ public class TaskService {
     private final boolean devTaskControlsEnabled;
 
     public TaskService(
+            ArtifactRepository artifactRepository,
             TaskRepository taskRepository,
             AgentRepository agentRepository,
             ModelRepository modelRepository,
@@ -51,6 +55,7 @@ public class TaskService {
             CheckpointEventParser checkpointEventParser,
             ConfigValidationHelper configValidationHelper,
             @Value("${app.dev-task-controls.enabled:false}") boolean devTaskControlsEnabled) {
+        this.artifactRepository = artifactRepository;
         this.taskRepository = taskRepository;
         this.agentRepository = agentRepository;
         this.modelRepository = modelRepository;
@@ -144,6 +149,8 @@ public class TaskService {
         Object pauseDetails = JsonParseUtil.parseJson(objectMapper, task.get("pause_details"), "pause_details",
                 taskId.toString());
 
+        List<ArtifactMetadata> artifacts = artifactRepository.findByTaskId(taskId, tenantId, "output");
+
         return new TaskStatusResponse(
                 (UUID) task.get("task_id"),
                 (String) task.get("agent_id"),
@@ -169,7 +176,8 @@ public class TaskService {
                 DateTimeUtil.toOffsetDateTime(task.get("human_input_timeout_at")),
                 (String) task.get("pause_reason"),
                 pauseDetails,
-                DateTimeUtil.toOffsetDateTime(task.get("resume_eligible_at")));
+                DateTimeUtil.toOffsetDateTime(task.get("resume_eligible_at")),
+                artifacts);
     }
 
     public CheckpointListResponse getCheckpoints(UUID taskId) {

--- a/services/api-service/src/main/resources/application.yml
+++ b/services/api-service/src/main/resources/application.yml
@@ -23,3 +23,8 @@ server:
 app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:3000}
+
+s3:
+  endpoint-url: ${S3_ENDPOINT_URL:#{null}}
+  bucket-name: ${S3_BUCKET_NAME:platform-artifacts}
+  region: ${AWS_REGION:us-east-1}

--- a/services/api-service/src/test/java/com/persistentagent/api/controller/ArtifactControllerTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/controller/ArtifactControllerTest.java
@@ -1,0 +1,115 @@
+package com.persistentagent.api.controller;
+
+import com.persistentagent.api.model.ArtifactMetadata;
+import com.persistentagent.api.service.ArtifactService;
+import com.persistentagent.api.service.ArtifactService.ArtifactDownload;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.ByteArrayInputStream;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ArtifactController.class)
+class ArtifactControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ArtifactService artifactService;
+
+    @Test
+    void listArtifacts_returnsArtifactList() throws Exception {
+        UUID taskId = UUID.randomUUID();
+        ArtifactMetadata artifact = new ArtifactMetadata(
+                UUID.randomUUID(), taskId, "report.pdf", "output",
+                "application/pdf", 1024L, OffsetDateTime.now());
+
+        when(artifactService.listArtifacts(eq(taskId), isNull()))
+                .thenReturn(List.of(artifact));
+
+        mockMvc.perform(get("/v1/tasks/{taskId}/artifacts", taskId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].filename").value("report.pdf"))
+                .andExpect(jsonPath("$[0].direction").value("output"))
+                .andExpect(jsonPath("$[0].contentType").value("application/pdf"))
+                .andExpect(jsonPath("$[0].sizeBytes").value(1024));
+    }
+
+    @Test
+    void listArtifacts_withDirectionFilter() throws Exception {
+        UUID taskId = UUID.randomUUID();
+
+        when(artifactService.listArtifacts(eq(taskId), eq("output")))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/v1/tasks/{taskId}/artifacts", taskId)
+                        .param("direction", "output"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void listArtifacts_taskNotFound_returns404() throws Exception {
+        UUID taskId = UUID.randomUUID();
+
+        when(artifactService.listArtifacts(eq(taskId), isNull()))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Task not found"));
+
+        mockMvc.perform(get("/v1/tasks/{taskId}/artifacts", taskId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void downloadArtifact_streamsFileWithCorrectHeaders() throws Exception {
+        UUID taskId = UUID.randomUUID();
+        byte[] content = "file content here".getBytes();
+        ArtifactMetadata metadata = new ArtifactMetadata(
+                UUID.randomUUID(), taskId, "report.pdf", "output",
+                "application/pdf", content.length, OffsetDateTime.now());
+
+        GetObjectResponse getObjectResponse = GetObjectResponse.builder()
+                .contentType("application/pdf")
+                .contentLength((long) content.length)
+                .build();
+        ResponseInputStream<GetObjectResponse> stream = new ResponseInputStream<>(
+                getObjectResponse, new ByteArrayInputStream(content));
+
+        ArtifactDownload download = new ArtifactDownload(metadata, stream);
+
+        when(artifactService.downloadArtifact(eq(taskId), eq("report.pdf"), eq("output")))
+                .thenReturn(download);
+
+        mockMvc.perform(get("/v1/tasks/{taskId}/artifacts/{filename}", taskId, "report.pdf"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/pdf"))
+                .andExpect(header().string("Content-Disposition", "attachment; filename=\"report.pdf\""))
+                .andExpect(content().bytes(content));
+    }
+
+    @Test
+    void downloadArtifact_artifactNotFound_returns404() throws Exception {
+        UUID taskId = UUID.randomUUID();
+
+        when(artifactService.downloadArtifact(eq(taskId), eq("missing.pdf"), eq("output")))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Artifact not found"));
+
+        mockMvc.perform(get("/v1/tasks/{taskId}/artifacts/{filename}", taskId, "missing.pdf"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/services/api-service/src/test/java/com/persistentagent/api/controller/TaskControllerTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/controller/TaskControllerTest.java
@@ -230,7 +230,7 @@ class TaskControllerTest {
                                 0, List.of(), 5, 12500L, "worker-abc-123",
                                 null, null, null, null, null, now, now, null,
                                 null, null, null,
-                                null, null, null);
+                                null, null, null, null);
                 when(taskService.getTaskStatus(taskId)).thenReturn(response);
 
                 mockMvc.perform(get("/v1/tasks/" + taskId))

--- a/services/api-service/src/test/java/com/persistentagent/api/repository/ArtifactRepositoryTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/repository/ArtifactRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.persistentagent.api.repository;
+
+import com.persistentagent.api.model.ArtifactMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArtifactRepositoryTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private ArtifactRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new ArtifactRepository(jdbcTemplate);
+    }
+
+    @Test
+    void insert_returnsGeneratedArtifactId() {
+        UUID taskId = UUID.randomUUID();
+        UUID expectedArtifactId = UUID.randomUUID();
+
+        when(jdbcTemplate.queryForObject(anyString(), eq(UUID.class),
+                any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(expectedArtifactId);
+
+        UUID result = repository.insert(
+                taskId, "default", "report.pdf", "output",
+                "application/pdf", 1024L, "default/task-1/output/report.pdf");
+
+        assertEquals(expectedArtifactId, result);
+        verify(jdbcTemplate).queryForObject(
+                contains("INSERT INTO task_artifacts"),
+                eq(UUID.class),
+                eq(taskId), eq("default"), eq("report.pdf"), eq("output"),
+                eq("application/pdf"), eq(1024L), eq("default/task-1/output/report.pdf"));
+    }
+
+    @Test
+    void findByTaskId_withoutDirectionFilter_returnsAllArtifacts() {
+        UUID taskId = UUID.randomUUID();
+
+        when(jdbcTemplate.query(contains("WHERE task_id = ? AND tenant_id = ?"),
+                any(RowMapper.class), eq(taskId), eq("default")))
+                .thenReturn(List.of());
+
+        List<ArtifactMetadata> result = repository.findByTaskId(taskId, "default", null);
+
+        assertNotNull(result);
+        verify(jdbcTemplate).query(
+                argThat((String sql) -> sql.contains("WHERE task_id = ?") && !sql.contains("AND direction = ?")),
+                any(RowMapper.class), eq(taskId), eq("default"));
+    }
+
+    @Test
+    void findByTaskId_withDirectionFilter_filtersResults() {
+        UUID taskId = UUID.randomUUID();
+
+        when(jdbcTemplate.query(contains("AND direction = ?"),
+                any(RowMapper.class), eq(taskId), eq("default"), eq("output")))
+                .thenReturn(List.of());
+
+        List<ArtifactMetadata> result = repository.findByTaskId(taskId, "default", "output");
+
+        assertNotNull(result);
+        verify(jdbcTemplate).query(
+                contains("AND direction = ?"),
+                any(RowMapper.class), eq(taskId), eq("default"), eq("output"));
+    }
+
+    @Test
+    void findByTaskIdAndFilename_returnsEmptyWhenNotFound() {
+        UUID taskId = UUID.randomUUID();
+
+        when(jdbcTemplate.query(contains("AND filename = ? AND direction = ?"),
+                any(RowMapper.class), eq(taskId), eq("default"), eq("report.pdf"), eq("output")))
+                .thenReturn(List.of());
+
+        var result = repository.findByTaskIdAndFilename(
+                taskId, "default", "report.pdf", "output");
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/services/api-service/src/test/java/com/persistentagent/api/service/ArtifactServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/ArtifactServiceTest.java
@@ -1,0 +1,137 @@
+package com.persistentagent.api.service;
+
+import com.persistentagent.api.exception.TaskNotFoundException;
+import com.persistentagent.api.model.ArtifactMetadata;
+import com.persistentagent.api.repository.ArtifactRepository;
+import com.persistentagent.api.repository.ArtifactRepository.ArtifactWithS3Key;
+import com.persistentagent.api.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.ByteArrayInputStream;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArtifactServiceTest {
+
+    @Mock
+    private ArtifactRepository artifactRepository;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private S3StorageService s3StorageService;
+
+    private ArtifactService artifactService;
+
+    @BeforeEach
+    void setUp() {
+        artifactService = new ArtifactService(artifactRepository, taskRepository, s3StorageService);
+    }
+
+    @Test
+    void listArtifacts_taskNotFound_throws404() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default")).thenReturn(Optional.empty());
+
+        assertThrows(TaskNotFoundException.class, () ->
+                artifactService.listArtifacts(taskId, null));
+    }
+
+    @Test
+    void listArtifacts_returnsArtifactsFromRepository() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default"))
+                .thenReturn(Optional.of(Map.of("task_id", taskId)));
+
+        ArtifactMetadata artifact = new ArtifactMetadata(
+                UUID.randomUUID(), taskId, "report.pdf", "output",
+                "application/pdf", 1024L, OffsetDateTime.now());
+        when(artifactRepository.findByTaskId(taskId, "default", null))
+                .thenReturn(List.of(artifact));
+
+        List<ArtifactMetadata> result = artifactService.listArtifacts(taskId, null);
+        assertEquals(1, result.size());
+        assertEquals("report.pdf", result.get(0).filename());
+    }
+
+    @Test
+    void downloadArtifact_taskNotFound_throws404() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default")).thenReturn(Optional.empty());
+
+        assertThrows(TaskNotFoundException.class, () ->
+                artifactService.downloadArtifact(taskId, "report.pdf", "output"));
+    }
+
+    @Test
+    void downloadArtifact_artifactNotFound_throws404() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default"))
+                .thenReturn(Optional.of(Map.of("task_id", taskId)));
+        when(artifactRepository.findByTaskIdAndFilename(taskId, "default", "report.pdf", "output"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class, () ->
+                artifactService.downloadArtifact(taskId, "report.pdf", "output"));
+    }
+
+    @Test
+    void downloadArtifact_s3KeyNotFound_throws404() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default"))
+                .thenReturn(Optional.of(Map.of("task_id", taskId)));
+
+        ArtifactMetadata metadata = new ArtifactMetadata(
+                UUID.randomUUID(), taskId, "report.pdf", "output",
+                "application/pdf", 1024L, OffsetDateTime.now());
+        when(artifactRepository.findByTaskIdAndFilename(taskId, "default", "report.pdf", "output"))
+                .thenReturn(Optional.of(new ArtifactWithS3Key(metadata, "default/task-1/output/report.pdf")));
+        when(s3StorageService.download("default/task-1/output/report.pdf"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class, () ->
+                artifactService.downloadArtifact(taskId, "report.pdf", "output"));
+    }
+
+    @Test
+    void downloadArtifact_success_returnsDownloadResult() {
+        UUID taskId = UUID.randomUUID();
+        when(taskRepository.findByIdAndTenant(taskId, "default"))
+                .thenReturn(Optional.of(Map.of("task_id", taskId)));
+
+        ArtifactMetadata metadata = new ArtifactMetadata(
+                UUID.randomUUID(), taskId, "report.pdf", "output",
+                "application/pdf", 1024L, OffsetDateTime.now());
+        when(artifactRepository.findByTaskIdAndFilename(taskId, "default", "report.pdf", "output"))
+                .thenReturn(Optional.of(new ArtifactWithS3Key(metadata, "default/task-1/output/report.pdf")));
+
+        GetObjectResponse getObjectResponse = GetObjectResponse.builder().build();
+        ResponseInputStream<GetObjectResponse> stream = new ResponseInputStream<>(
+                getObjectResponse, new ByteArrayInputStream(new byte[0]));
+        when(s3StorageService.download("default/task-1/output/report.pdf"))
+                .thenReturn(Optional.of(stream));
+
+        ArtifactService.ArtifactDownload result =
+                artifactService.downloadArtifact(taskId, "report.pdf", "output");
+
+        assertNotNull(result);
+        assertEquals("report.pdf", result.metadata().filename());
+        assertNotNull(result.stream());
+    }
+}

--- a/services/api-service/src/test/java/com/persistentagent/api/service/S3StorageServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/S3StorageServiceTest.java
@@ -1,0 +1,13 @@
+package com.persistentagent.api.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class S3StorageServiceTest {
+
+    @Test
+    void serviceClassExists() {
+        assertDoesNotThrow(() -> Class.forName("com.persistentagent.api.service.S3StorageService"));
+    }
+}

--- a/services/api-service/src/test/java/com/persistentagent/api/service/TaskServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/TaskServiceTest.java
@@ -10,6 +10,7 @@ import com.persistentagent.api.exception.ValidationException;
 import com.persistentagent.api.model.request.TaskSubmissionRequest;
 import com.persistentagent.api.model.response.*;
 import com.persistentagent.api.repository.AgentRepository;
+import com.persistentagent.api.repository.ArtifactRepository;
 import com.persistentagent.api.repository.LangfuseEndpointRepository;
 import com.persistentagent.api.repository.ModelRepository;
 import com.persistentagent.api.repository.TaskRepository;
@@ -35,6 +36,9 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TaskServiceTest {
+
+    @Mock
+    private ArtifactRepository artifactRepository;
 
     @Mock
     private TaskRepository taskRepository;
@@ -66,6 +70,7 @@ class TaskServiceTest {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         taskService = new TaskService(
+                artifactRepository,
                 taskRepository,
                 agentRepository,
                 modelRepository,

--- a/services/console/src/api/client.ts
+++ b/services/console/src/api/client.ts
@@ -1,3 +1,4 @@
+import type { ArtifactMetadata } from '@/types';
 import {
     TaskStatusResponse,
     TaskSubmissionRequest,
@@ -238,4 +239,20 @@ export const api = {
         fetchApi<ToolDiscoverResponse>(`/v1/tool-servers/${encodeURIComponent(serverId)}/discover`, {
             method: 'POST',
         }),
+
+    // Artifacts
+    listArtifacts: (taskId: string, direction?: string) => {
+        const params = new URLSearchParams();
+        if (direction) params.append('direction', direction);
+        const query = params.toString();
+        return fetchApi<ArtifactMetadata[]>(
+            `/v1/tasks/${taskId}/artifacts${query ? `?${query}` : ''}`
+        );
+    },
+
+    getArtifactDownloadUrl: (taskId: string, filename: string, direction: string = 'output') => {
+        const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+        const params = new URLSearchParams({ direction });
+        return `${baseUrl}/v1/tasks/${taskId}/artifacts/${encodeURIComponent(filename)}?${params}`;
+    },
 };

--- a/services/console/src/features/submit/schema.ts
+++ b/services/console/src/features/submit/schema.ts
@@ -18,6 +18,7 @@ export const ALLOWED_TOOLS = [
     { id: "web_search", label: "Web Search" },
     { id: "read_url", label: "Read URL" },
     { id: "calculator", label: "Calculator" },
+    { id: "upload_artifact", label: "Upload Artifact" },
     ...(devTaskControlsEnabled ? [{ id: "dev_sleep", label: "Dev Sleep" }] : [])
 ];
 

--- a/services/console/src/features/task-detail/ArtifactsTab.tsx
+++ b/services/console/src/features/task-detail/ArtifactsTab.tsx
@@ -25,7 +25,12 @@ export function ArtifactsTab({ taskId, artifacts }: ArtifactsTabProps) {
 
     const handleDownload = (filename: string, direction: string) => {
         const url = api.getArtifactDownloadUrl(taskId, filename, direction);
-        window.open(url, '_blank');
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
     };
 
     return (

--- a/services/console/src/features/task-detail/ArtifactsTab.tsx
+++ b/services/console/src/features/task-detail/ArtifactsTab.tsx
@@ -23,14 +23,18 @@ export function ArtifactsTab({ taskId, artifacts }: ArtifactsTabProps) {
         return null;
     }
 
-    const handleDownload = (filename: string, direction: string) => {
+    const handleDownload = async (filename: string, direction: string) => {
         const url = api.getArtifactDownloadUrl(taskId, filename, direction);
+        const response = await fetch(url);
+        const blob = await response.blob();
+        const blobUrl = URL.createObjectURL(blob);
         const a = document.createElement('a');
-        a.href = url;
+        a.href = blobUrl;
         a.download = filename;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
+        URL.revokeObjectURL(blobUrl);
     };
 
     return (

--- a/services/console/src/features/task-detail/ArtifactsTab.tsx
+++ b/services/console/src/features/task-detail/ArtifactsTab.tsx
@@ -1,0 +1,73 @@
+import { Download, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { api } from '@/api/client';
+import { ArtifactMetadata } from '@/types';
+
+function formatFileSize(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const k = 1024;
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const size = bytes / Math.pow(k, i);
+    return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+interface ArtifactsTabProps {
+    taskId: string;
+    artifacts: ArtifactMetadata[];
+}
+
+export function ArtifactsTab({ taskId, artifacts }: ArtifactsTabProps) {
+    if (artifacts.length === 0) {
+        return null;
+    }
+
+    const handleDownload = (filename: string, direction: string) => {
+        const url = api.getArtifactDownloadUrl(taskId, filename, direction);
+        window.open(url, '_blank');
+    };
+
+    return (
+        <Card className="console-surface border-white/10">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 border-b border-white/8">
+                <CardTitle className="text-sm font-display uppercase tracking-widest flex items-center gap-2 text-muted-foreground">
+                    <FileText className="w-4 h-4" /> Artifacts ({artifacts.length})
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-4">
+                <div className="space-y-2">
+                    {artifacts.map((artifact) => (
+                        <div
+                            key={artifact.artifactId}
+                            className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg bg-black/20 border border-white/5 hover:border-white/10 transition-colors"
+                        >
+                            <div className="flex items-center gap-3 min-w-0">
+                                <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
+                                <div className="min-w-0">
+                                    <p className="text-sm font-mono text-foreground truncate">
+                                        {artifact.filename}
+                                    </p>
+                                    <div className="flex gap-3 text-xs text-muted-foreground font-mono uppercase tracking-wider">
+                                        <span>{artifact.direction}</span>
+                                        <span>{artifact.contentType}</span>
+                                        <span>{formatFileSize(artifact.sizeBytes)}</span>
+                                        <span>{new Date(artifact.createdAt).toLocaleString()}</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="shrink-0 uppercase tracking-widest text-xs"
+                                onClick={() => handleDownload(artifact.filename, artifact.direction)}
+                            >
+                                <Download className="w-4 h-4 mr-1" /> Download
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/services/console/src/features/task-detail/TaskDetailPage.tsx
+++ b/services/console/src/features/task-detail/TaskDetailPage.tsx
@@ -11,6 +11,8 @@ import { CostSummary } from './CostSummary';
 import { CheckpointTimeline } from './CheckpointTimeline';
 import { ApprovalPanel } from './ApprovalPanel';
 import { InputResponsePanel } from './InputResponsePanel';
+import { ArtifactsTab } from './ArtifactsTab';
+import { useTaskArtifacts } from './useArtifacts';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
@@ -28,6 +30,7 @@ export function TaskDetailPage() {
     const { data: task, isLoading, isError } = useTaskStatus(taskId!);
     const { data: observability } = useTaskObservability(taskId!, task?.status);
     const { data: checkpointsData } = useCheckpoints(taskId!, task?.status, task?.checkpoint_count);
+    const { data: artifactsData } = useTaskArtifacts(taskId!, !!task);
 
     const { data: langfuseEndpoints = [] } = useLangfuseEndpoints();
     const langfuseEndpoint = task?.langfuse_endpoint_id
@@ -378,6 +381,10 @@ export function TaskDetailPage() {
                             </Card>
                         )}
                     </div>
+
+                    {artifactsData && artifactsData.length > 0 && (
+                        <ArtifactsTab taskId={taskId!} artifacts={artifactsData} />
+                    )}
 
                     {task.status === 'completed' && (
                         showFollowUp ? (

--- a/services/console/src/features/task-detail/TaskDetailPage.tsx
+++ b/services/console/src/features/task-detail/TaskDetailPage.tsx
@@ -30,7 +30,7 @@ export function TaskDetailPage() {
     const { data: task, isLoading, isError } = useTaskStatus(taskId!);
     const { data: observability } = useTaskObservability(taskId!, task?.status);
     const { data: checkpointsData } = useCheckpoints(taskId!, task?.status, task?.checkpoint_count);
-    const { data: artifactsData } = useTaskArtifacts(taskId!, !!task);
+    const { data: artifactsData } = useTaskArtifacts(taskId!, task?.status);
 
     const { data: langfuseEndpoints = [] } = useLangfuseEndpoints();
     const langfuseEndpoint = task?.langfuse_endpoint_id

--- a/services/console/src/features/task-detail/useArtifacts.ts
+++ b/services/console/src/features/task-detail/useArtifacts.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/api/client';
+
+export function useTaskArtifacts(taskId: string, enabled: boolean = true) {
+    return useQuery({
+        queryKey: ['task-artifacts', taskId],
+        queryFn: () => api.listArtifacts(taskId),
+        enabled: !!taskId && enabled,
+    });
+}

--- a/services/console/src/features/task-detail/useArtifacts.ts
+++ b/services/console/src/features/task-detail/useArtifacts.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/api/client';
 
-export function useTaskArtifacts(taskId: string, enabled: boolean = true) {
+export function useTaskArtifacts(taskId: string, taskStatus?: string) {
     return useQuery({
-        queryKey: ['task-artifacts', taskId],
+        queryKey: ['task-artifacts', taskId, taskStatus],
         queryFn: () => api.listArtifacts(taskId),
-        enabled: !!taskId && enabled,
+        enabled: !!taskId && !!taskStatus,
     });
 }

--- a/services/console/src/types/index.ts
+++ b/services/console/src/types/index.ts
@@ -326,3 +326,14 @@ export interface ToolDiscoverResponse {
     error: string | null;
     tools: DiscoveredToolInfo[];
 }
+
+// Artifact types
+export interface ArtifactMetadata {
+    artifactId: string;
+    taskId: string;
+    filename: string;
+    direction: 'input' | 'output';
+    contentType: string;
+    sizeBytes: number;
+    createdAt: string;
+}

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -6,6 +6,7 @@ Builds and executes the LangGraph state machine with the given agent configurati
 import asyncio
 import json
 import logging
+import os
 import re
 from datetime import datetime, timezone, timedelta
 from typing import Any, Awaitable
@@ -28,6 +29,7 @@ from core.config import WorkerConfig
 
 from executor.mcp_session import McpSessionManager, ToolServerConfig, McpConnectionError
 from executor.schema_converter import mcp_tools_to_structured_tools, MAX_TOOLS_PER_AGENT
+from storage.s3_client import S3Client
 from tools.definitions import (
     create_default_dependencies,
     WEB_SEARCH_TOOL,
@@ -35,6 +37,7 @@ from tools.definitions import (
     CALCULATOR_TOOL,
     DEV_SLEEP_TOOL,
     REQUEST_HUMAN_INPUT_TOOL,
+    UPLOAD_ARTIFACT_TOOL,
     WebSearchArguments,
     ReadUrlArguments,
     CalculatorArguments,
@@ -58,6 +61,12 @@ class GraphExecutor:
         self.deps = create_default_dependencies()
         # Per-model cost rate cache: {model_name: (input_rate, output_rate)}
         self._cost_rate_cache: dict[str, tuple[int, int]] = {}
+        s3_endpoint_url = os.environ.get("S3_ENDPOINT_URL")
+        s3_bucket_name = os.environ.get("S3_BUCKET_NAME", "platform-artifacts")
+        self.s3_client = S3Client(
+            endpoint_url=s3_endpoint_url,
+            bucket_name=s3_bucket_name,
+        )
 
     async def _resolve_langfuse_credentials(self, endpoint_id: str) -> dict | None:
         """Query langfuse_endpoints table for credentials. Returns {host, public_key, secret_key} or None."""
@@ -141,6 +150,7 @@ class GraphExecutor:
         *,
         cancel_event: asyncio.Event,
         task_id: str,
+        tenant_id: str = "default",
     ) -> list[StructuredTool]:
         tools = []
         if "web_search" in allowed_tools:
@@ -209,6 +219,36 @@ class GraphExecutor:
                 args_schema=DevSleepArguments
             ))
 
+        if "upload_artifact" in allowed_tools:
+            from tools.upload_artifact import (
+                UploadArtifactArguments,
+                execute_upload_artifact,
+            )
+
+            async def upload_artifact(
+                filename: str,
+                content: str,
+                content_type: str = "text/plain",
+            ):
+                return await execute_upload_artifact(
+                    filename=filename,
+                    content=content,
+                    content_type=content_type,
+                    s3_client=self.s3_client,
+                    pool=self.pool,
+                    task_id=task_id,
+                    tenant_id=tenant_id,
+                )
+
+            tools.append(
+                StructuredTool.from_function(
+                    coroutine=upload_artifact,
+                    name="upload_artifact",
+                    description=UPLOAD_ARTIFACT_TOOL.description,
+                    args_schema=UploadArtifactArguments,
+                )
+            )
+
         return tools
 
     async def _build_graph(
@@ -217,6 +257,7 @@ class GraphExecutor:
         *,
         cancel_event: asyncio.Event,
         task_id: str,
+        tenant_id: str = "default",
         custom_tools: list[StructuredTool] | None = None,
     ) -> StateGraph:
         """Assembles the LangGraph state machine and binds MCP tools."""
@@ -239,7 +280,7 @@ class GraphExecutor:
         llm = await providers.create_llm(self.pool, provider, model_name, temperature)
 
         # Register built-in tools
-        tools = self._get_tools(allowed_tools, cancel_event=cancel_event, task_id=task_id)
+        tools = self._get_tools(allowed_tools, cancel_event=cancel_event, task_id=task_id, tenant_id=tenant_id)
 
         # Merge custom tools from MCP servers
         if custom_tools:
@@ -540,6 +581,7 @@ class GraphExecutor:
                 agent_config,
                 cancel_event=cancel_event,
                 task_id=task_id,
+                tenant_id=tenant_id,
                 custom_tools=custom_tools if custom_tools else None,
             )
             compiled_graph = graph.compile(checkpointer=checkpointer)

--- a/services/worker-service/pyproject.toml
+++ b/services/worker-service/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "asyncpg>=0.29.0",
     "beautifulsoup4>=4.13.0",
+    "boto3>=1.35.0",
     "httpx>=0.28.0",
     "langchain>=0.3.0",
     "langchain-core>=0.3.0",
@@ -46,4 +47,4 @@ filterwarnings = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["core*", "checkpointer*", "tools*"]
+include = ["core*", "checkpointer*", "tools*", "storage*"]

--- a/services/worker-service/storage/s3_client.py
+++ b/services/worker-service/storage/s3_client.py
@@ -1,0 +1,119 @@
+"""S3 client wrapper for artifact storage operations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import boto3
+import structlog
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client as Boto3S3Client
+
+logger = structlog.get_logger(__name__)
+
+
+class S3Client:
+    """Async-compatible S3 client for artifact upload/download/delete.
+
+    Wraps boto3 synchronous calls with asyncio.to_thread() for async compatibility.
+    Works with both LocalStack (via endpoint_url) and real AWS (endpoint_url=None).
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str | None,
+        bucket_name: str,
+        region: str = "us-east-1",
+    ) -> None:
+        self._bucket_name = bucket_name
+        self._endpoint_url = endpoint_url
+        kwargs: dict = {
+            "region_name": region,
+        }
+        if endpoint_url is not None:
+            kwargs["endpoint_url"] = endpoint_url
+        self._client: Boto3S3Client = boto3.client("s3", **kwargs)
+        logger.info(
+            "s3_client_initialized",
+            bucket=bucket_name,
+            endpoint_url=endpoint_url or "default (AWS)",
+            region=region,
+        )
+
+    @property
+    def bucket_name(self) -> str:
+        return self._bucket_name
+
+    async def upload(self, key: str, data: bytes, content_type: str) -> None:
+        """Upload data to S3."""
+        logger.info(
+            "s3_upload_started",
+            bucket=self._bucket_name,
+            key=key,
+            size_bytes=len(data),
+            content_type=content_type,
+        )
+        await asyncio.to_thread(
+            self._client.put_object,
+            Bucket=self._bucket_name,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+        )
+        logger.info(
+            "s3_upload_completed",
+            bucket=self._bucket_name,
+            key=key,
+            size_bytes=len(data),
+        )
+
+    async def download(self, key: str) -> bytes:
+        """Download data from S3."""
+        logger.info(
+            "s3_download_started",
+            bucket=self._bucket_name,
+            key=key,
+        )
+        response = await asyncio.to_thread(
+            self._client.get_object,
+            Bucket=self._bucket_name,
+            Key=key,
+        )
+        data = response["Body"].read()
+        logger.info(
+            "s3_download_completed",
+            bucket=self._bucket_name,
+            key=key,
+            size_bytes=len(data),
+        )
+        return data
+
+    async def delete(self, key: str) -> None:
+        """Delete an object from S3."""
+        logger.info(
+            "s3_delete_started",
+            bucket=self._bucket_name,
+            key=key,
+        )
+        await asyncio.to_thread(
+            self._client.delete_object,
+            Bucket=self._bucket_name,
+            Key=key,
+        )
+        logger.info(
+            "s3_delete_completed",
+            bucket=self._bucket_name,
+            key=key,
+        )
+
+    def build_key(
+        self, tenant_id: str, task_id: str, direction: str, filename: str
+    ) -> str:
+        """Build an S3 object key from artifact metadata.
+
+        Returns:
+            S3 key in format: {tenant_id}/{task_id}/{direction}/{filename}
+        """
+        return f"{tenant_id}/{task_id}/{direction}/{filename}"

--- a/services/worker-service/tests/storage/test_s3_client.py
+++ b/services/worker-service/tests/storage/test_s3_client.py
@@ -1,0 +1,149 @@
+"""Unit tests for the S3 client wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from storage.s3_client import S3Client
+
+
+class TestS3ClientInit:
+    def test_creates_client_with_endpoint_url(self):
+        """S3Client should pass endpoint_url to boto3 when provided."""
+        with patch("storage.s3_client.boto3") as mock_boto3:
+            client = S3Client(
+                endpoint_url="http://localhost:4566",
+                bucket_name="test-bucket",
+                region="us-east-1",
+            )
+            mock_boto3.client.assert_called_once_with(
+                "s3",
+                region_name="us-east-1",
+                endpoint_url="http://localhost:4566",
+            )
+            assert client.bucket_name == "test-bucket"
+
+    def test_creates_client_without_endpoint_url(self):
+        """S3Client should not pass endpoint_url to boto3 when None."""
+        with patch("storage.s3_client.boto3") as mock_boto3:
+            client = S3Client(
+                endpoint_url=None,
+                bucket_name="prod-bucket",
+                region="us-west-2",
+            )
+            mock_boto3.client.assert_called_once_with(
+                "s3",
+                region_name="us-west-2",
+            )
+            assert client.bucket_name == "prod-bucket"
+
+
+class TestS3ClientUpload:
+    @pytest.mark.asyncio
+    async def test_upload_calls_put_object(self):
+        """upload() should call put_object with correct parameters."""
+        with patch("storage.s3_client.boto3") as mock_boto3:
+            mock_s3 = MagicMock()
+            mock_boto3.client.return_value = mock_s3
+
+            client = S3Client(
+                endpoint_url="http://localhost:4566",
+                bucket_name="test-bucket",
+            )
+
+            await client.upload(
+                key="tenant/task/output/report.pdf",
+                data=b"file content",
+                content_type="application/pdf",
+            )
+
+            mock_s3.put_object.assert_called_once_with(
+                Bucket="test-bucket",
+                Key="tenant/task/output/report.pdf",
+                Body=b"file content",
+                ContentType="application/pdf",
+            )
+
+
+class TestS3ClientDownload:
+    @pytest.mark.asyncio
+    async def test_download_calls_get_object(self):
+        """download() should call get_object and return body bytes."""
+        with patch("storage.s3_client.boto3") as mock_boto3:
+            mock_s3 = MagicMock()
+            mock_body = MagicMock()
+            mock_body.read.return_value = b"downloaded content"
+            mock_s3.get_object.return_value = {"Body": mock_body}
+            mock_boto3.client.return_value = mock_s3
+
+            client = S3Client(
+                endpoint_url="http://localhost:4566",
+                bucket_name="test-bucket",
+            )
+
+            result = await client.download(key="tenant/task/output/report.pdf")
+
+            mock_s3.get_object.assert_called_once_with(
+                Bucket="test-bucket",
+                Key="tenant/task/output/report.pdf",
+            )
+            assert result == b"downloaded content"
+
+
+class TestS3ClientDelete:
+    @pytest.mark.asyncio
+    async def test_delete_calls_delete_object(self):
+        """delete() should call delete_object with correct parameters."""
+        with patch("storage.s3_client.boto3") as mock_boto3:
+            mock_s3 = MagicMock()
+            mock_boto3.client.return_value = mock_s3
+
+            client = S3Client(
+                endpoint_url="http://localhost:4566",
+                bucket_name="test-bucket",
+            )
+
+            await client.delete(key="tenant/task/output/report.pdf")
+
+            mock_s3.delete_object.assert_called_once_with(
+                Bucket="test-bucket",
+                Key="tenant/task/output/report.pdf",
+            )
+
+
+class TestS3ClientBuildKey:
+    def test_build_key_format(self):
+        """build_key() should produce {tenant}/{task}/{direction}/{filename}."""
+        with patch("storage.s3_client.boto3"):
+            client = S3Client(
+                endpoint_url="http://localhost:4566",
+                bucket_name="test-bucket",
+            )
+
+            key = client.build_key(
+                tenant_id="tenant-1",
+                task_id="task-abc",
+                direction="output",
+                filename="report.pdf",
+            )
+
+            assert key == "tenant-1/task-abc/output/report.pdf"
+
+    def test_build_key_input_direction(self):
+        """build_key() should work with 'input' direction."""
+        with patch("storage.s3_client.boto3"):
+            client = S3Client(
+                endpoint_url=None,
+                bucket_name="prod-bucket",
+            )
+
+            key = client.build_key(
+                tenant_id="acme",
+                task_id="12345",
+                direction="input",
+                filename="invoice.pdf",
+            )
+
+            assert key == "acme/12345/input/invoice.pdf"

--- a/services/worker-service/tests/test_checkpointer_integration.py
+++ b/services/worker-service/tests/test_checkpointer_integration.py
@@ -13,7 +13,7 @@ from checkpointer.postgres import LeaseRevokedException, PostgresDurableCheckpoi
 
 DB_DSN = os.getenv(
     "E2E_DB_DSN",
-    "postgresql://postgres:postgres@localhost:55432/persistent_agent_runtime",
+    "postgresql://postgres:postgres@localhost:55433/persistent_agent_runtime_e2e",
 )
 
 

--- a/services/worker-service/tests/test_integration.py
+++ b/services/worker-service/tests/test_integration.py
@@ -18,7 +18,7 @@ import pytest_asyncio
 
 DB_DSN = os.getenv(
     "E2E_DB_DSN",
-    "postgresql://postgres:postgres@localhost:55432/persistent_agent_runtime",
+    "postgresql://postgres:postgres@localhost:55433/persistent_agent_runtime_e2e",
 )
 
 

--- a/services/worker-service/tests/tools/test_upload_artifact.py
+++ b/services/worker-service/tests/tools/test_upload_artifact.py
@@ -1,0 +1,186 @@
+"""Unit tests for the upload_artifact tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tools.upload_artifact import (
+    MAX_CONTENT_BYTES,
+    MAX_FILENAME_LENGTH,
+    UploadArtifactArguments,
+    UploadArtifactResult,
+    execute_upload_artifact,
+)
+
+
+class TestUploadArtifactArguments:
+    def test_valid_arguments(self):
+        args = UploadArtifactArguments(
+            filename="report.pdf",
+            content="file content here",
+            content_type="application/pdf",
+        )
+        assert args.filename == "report.pdf"
+        assert args.content == "file content here"
+        assert args.content_type == "application/pdf"
+
+    def test_default_content_type(self):
+        args = UploadArtifactArguments(
+            filename="output.txt",
+            content="some text",
+        )
+        assert args.content_type == "text/plain"
+
+    def test_filename_too_long_rejected(self):
+        with pytest.raises(Exception):
+            UploadArtifactArguments(
+                filename="x" * (MAX_FILENAME_LENGTH + 1),
+                content="content",
+            )
+
+    def test_empty_filename_rejected(self):
+        with pytest.raises(Exception):
+            UploadArtifactArguments(
+                filename="",
+                content="content",
+            )
+
+    def test_empty_content_rejected(self):
+        with pytest.raises(Exception):
+            UploadArtifactArguments(
+                filename="file.txt",
+                content="",
+            )
+
+
+class TestUploadArtifactResult:
+    def test_result_fields(self):
+        result = UploadArtifactResult(
+            filename="report.pdf",
+            size_bytes=1024,
+            content_type="application/pdf",
+        )
+        assert result.filename == "report.pdf"
+        assert result.size_bytes == 1024
+        assert result.content_type == "application/pdf"
+
+
+class TestExecuteUploadArtifact:
+    @pytest.mark.asyncio
+    async def test_successful_upload(self):
+        """upload_artifact should upload to S3 and insert DB row."""
+        mock_s3 = MagicMock()
+        mock_s3.upload = AsyncMock()
+        mock_s3.build_key.return_value = "tenant-1/task-abc/output/report.txt"
+
+        mock_conn = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await execute_upload_artifact(
+            filename="report.txt",
+            content="Hello, world!",
+            content_type="text/plain",
+            s3_client=mock_s3,
+            pool=mock_pool,
+            task_id="task-abc",
+            tenant_id="tenant-1",
+        )
+
+        assert result["filename"] == "report.txt"
+        assert result["size_bytes"] == len("Hello, world!".encode("utf-8"))
+        assert result["content_type"] == "text/plain"
+
+        mock_s3.build_key.assert_called_once_with(
+            tenant_id="tenant-1",
+            task_id="task-abc",
+            direction="output",
+            filename="report.txt",
+        )
+        mock_s3.upload.assert_called_once_with(
+            key="tenant-1/task-abc/output/report.txt",
+            data=b"Hello, world!",
+            content_type="text/plain",
+        )
+
+        mock_conn.execute.assert_called_once()
+        call_args = mock_conn.execute.call_args
+        assert "INSERT INTO task_artifacts" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_content_too_large_raises_error(self):
+        """upload_artifact should reject content exceeding 50 MB."""
+        mock_s3 = MagicMock()
+        mock_s3.build_key.return_value = "key"
+        mock_pool = MagicMock()
+
+        large_content = "x" * (MAX_CONTENT_BYTES + 1)
+
+        with pytest.raises(ValueError, match="Artifact content too large"):
+            await execute_upload_artifact(
+                filename="huge.txt",
+                content=large_content,
+                content_type="text/plain",
+                s3_client=mock_s3,
+                pool=mock_pool,
+                task_id="task-abc",
+                tenant_id="tenant-1",
+            )
+
+        mock_s3.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upsert_on_duplicate_filename(self):
+        """upload_artifact should use ON CONFLICT to handle duplicate filenames."""
+        mock_s3 = MagicMock()
+        mock_s3.upload = AsyncMock()
+        mock_s3.build_key.return_value = "tenant-1/task-abc/output/data.csv"
+
+        mock_conn = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await execute_upload_artifact(
+            filename="data.csv",
+            content="col1,col2\n1,2",
+            content_type="text/csv",
+            s3_client=mock_s3,
+            pool=mock_pool,
+            task_id="task-abc",
+            tenant_id="tenant-1",
+        )
+
+        call_args = mock_conn.execute.call_args
+        assert "ON CONFLICT" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_default_content_type(self):
+        """upload_artifact should default to text/plain when content_type not specified."""
+        mock_s3 = MagicMock()
+        mock_s3.upload = AsyncMock()
+        mock_s3.build_key.return_value = "t/task/output/file.txt"
+
+        mock_conn = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await execute_upload_artifact(
+            filename="file.txt",
+            content="hello",
+            s3_client=mock_s3,
+            pool=mock_pool,
+            task_id="task",
+            tenant_id="t",
+        )
+
+        assert result["content_type"] == "text/plain"
+        mock_s3.upload.assert_called_once_with(
+            key="t/task/output/file.txt",
+            data=b"hello",
+            content_type="text/plain",
+        )

--- a/services/worker-service/tools/definitions.py
+++ b/services/worker-service/tools/definitions.py
@@ -15,6 +15,7 @@ from tools.calculator import MAX_EXPRESSION_LENGTH, evaluate_expression
 from tools.providers.search import SearchProvider, SearchResult, TavilySearchProvider
 from tools.read_url import ReadUrlFetcher
 from tools.runtime_logging import get_tools_logger
+from tools.upload_artifact import UploadArtifactArguments, UploadArtifactResult
 
 
 SEARCH_QUERY = Annotated[
@@ -171,6 +172,12 @@ DEV_SLEEP_TOOL = ToolDefinition(
     description="Dev-only control tool that sleeps for a bounded duration before returning.",
     input_model=DevSleepArguments,
     output_model=DevSleepResult,
+)
+UPLOAD_ARTIFACT_TOOL = ToolDefinition(
+    name="upload_artifact",
+    description="Save content as an output artifact file. The file will be available for download via the API after task completion.",
+    input_model=UploadArtifactArguments,
+    output_model=UploadArtifactResult,
 )
 
 TOOL_DEFINITIONS = (WEB_SEARCH_TOOL, READ_URL_TOOL, CALCULATOR_TOOL)

--- a/services/worker-service/tools/upload_artifact.py
+++ b/services/worker-service/tools/upload_artifact.py
@@ -1,0 +1,128 @@
+"""upload_artifact built-in tool — allows agents to produce output files."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import asyncpg
+import structlog
+from pydantic import BaseModel, Field
+
+from storage.s3_client import S3Client
+
+logger = structlog.get_logger(__name__)
+
+MAX_CONTENT_BYTES = 52_428_800  # 50 MB
+MAX_FILENAME_LENGTH = 255
+MAX_CONTENT_TYPE_LENGTH = 100
+
+
+class UploadArtifactArguments(BaseModel):
+    filename: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=MAX_FILENAME_LENGTH,
+            description="Name for the output file (e.g., 'report.pdf', 'data.csv').",
+        ),
+    ]
+    content: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description="The file content as a string. For binary files, use base64 encoding.",
+        ),
+    ]
+    content_type: Annotated[
+        str,
+        Field(
+            max_length=MAX_CONTENT_TYPE_LENGTH,
+            default="text/plain",
+            description="MIME type of the content (e.g., 'text/plain', 'application/json', 'text/csv').",
+        ),
+    ]
+
+
+class UploadArtifactResult(BaseModel):
+    filename: str
+    size_bytes: int
+    content_type: str
+
+
+async def execute_upload_artifact(
+    *,
+    filename: str,
+    content: str,
+    content_type: str = "text/plain",
+    s3_client: S3Client,
+    pool: asyncpg.Pool,
+    task_id: str,
+    tenant_id: str,
+) -> dict:
+    """Execute the upload_artifact tool."""
+    # Encode content to bytes
+    data = content.encode("utf-8")
+    size_bytes = len(data)
+
+    # Validate size
+    if size_bytes > MAX_CONTENT_BYTES:
+        raise ValueError(
+            f"Artifact content too large: {size_bytes} bytes "
+            f"(maximum {MAX_CONTENT_BYTES} bytes / 50 MB)"
+        )
+
+    # Build S3 key
+    s3_key = s3_client.build_key(
+        tenant_id=tenant_id,
+        task_id=task_id,
+        direction="output",
+        filename=filename,
+    )
+
+    logger.info(
+        "upload_artifact_started",
+        task_id=task_id,
+        tenant_id=tenant_id,
+        filename=filename,
+        content_type=content_type,
+        size_bytes=size_bytes,
+        s3_key=s3_key,
+    )
+
+    # Upload to S3
+    await s3_client.upload(key=s3_key, data=data, content_type=content_type)
+
+    # Insert artifact metadata into database
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO task_artifacts (task_id, tenant_id, filename, direction,
+                                        content_type, size_bytes, s3_key)
+            VALUES ($1, $2, $3, 'output', $4, $5, $6)
+            ON CONFLICT (task_id, direction, filename)
+            DO UPDATE SET content_type = EXCLUDED.content_type,
+                          size_bytes = EXCLUDED.size_bytes,
+                          s3_key = EXCLUDED.s3_key,
+                          created_at = NOW()
+            """,
+            task_id,
+            tenant_id,
+            filename,
+            content_type,
+            size_bytes,
+            s3_key,
+        )
+
+    logger.info(
+        "upload_artifact_completed",
+        task_id=task_id,
+        tenant_id=tenant_id,
+        filename=filename,
+        size_bytes=size_bytes,
+    )
+
+    return {
+        "filename": filename,
+        "size_bytes": size_bytes,
+        "content_type": content_type,
+    }

--- a/tests/backend-integration/conftest.py
+++ b/tests/backend-integration/conftest.py
@@ -44,6 +44,11 @@ API_PORT = int(os.getenv("E2E_API_PORT", "8081"))
 API_BASE = os.getenv("E2E_API_BASE", f"http://localhost:{API_PORT}/v1")
 
 os.environ.setdefault("APP_DEV_TASK_CONTROLS_ENABLED", "true")
+os.environ.setdefault("S3_ENDPOINT_URL", "http://localhost:4566")
+os.environ.setdefault("S3_BUCKET_NAME", "platform-artifacts")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_REGION", "us-east-1")
 
 PG_CONTAINER = os.getenv("E2E_PG_CONTAINER", "par-e2e-postgres")
 PG_IMAGE = os.getenv("E2E_PG_IMAGE", "postgres:16")
@@ -126,6 +131,11 @@ def _start_api_process() -> subprocess.Popen[str]:
             "LANGFUSE_HOST": os.getenv("E2E_LANGFUSE_HOST", os.getenv("LANGFUSE_HOST", "http://127.0.0.1:3300")),
             "LANGFUSE_PUBLIC_KEY": os.getenv("E2E_LANGFUSE_PUBLIC_KEY", os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-local")),
             "LANGFUSE_SECRET_KEY": os.getenv("E2E_LANGFUSE_SECRET_KEY", os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-local")),
+            "S3_ENDPOINT_URL": os.getenv("S3_ENDPOINT_URL", "http://localhost:4566"),
+            "S3_BUCKET_NAME": os.getenv("S3_BUCKET_NAME", "platform-artifacts"),
+            "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID", "test"),
+            "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+            "AWS_REGION": os.getenv("AWS_REGION", "us-east-1"),
         }
     )
     log_file = REPO_ROOT / ".tmp" / "e2e-api-service.log"
@@ -347,6 +357,7 @@ async def _do_clean(conn: asyncpg.Connection) -> None:
     await conn.execute("DELETE FROM task_events")
     await conn.execute("DELETE FROM checkpoint_writes")
     await conn.execute("DELETE FROM checkpoints")
+    await conn.execute("DELETE FROM task_artifacts")
     await conn.execute("DELETE FROM tasks")
     await conn.execute("DELETE FROM agent_runtime_state")
     await conn.execute("DELETE FROM agents")

--- a/tests/backend-integration/helpers/api_client.py
+++ b/tests/backend-integration/helpers/api_client.py
@@ -284,6 +284,47 @@ class ApiClient:
         """GET /v1/tasks/{task_id}/events"""
         return self._request("GET", f"/tasks/{task_id}/events?limit={limit}", expected_status=expected_status, raise_for_status=raise_for_status)
 
+    def list_artifacts(self, task_id, direction=None, expected_status=200, raise_for_status=True):
+        """List artifacts for a task."""
+        params = {}
+        if direction:
+            params["direction"] = direction
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        path = f"/tasks/{task_id}/artifacts{'?' + query if query else ''}"
+        return self._request("GET", path, expected_status=expected_status,
+                           raise_for_status=raise_for_status)
+
+    def download_artifact(self, task_id, filename, direction="output",
+                         expected_status=200, raise_for_status=True):
+        """Download an artifact file. Returns dict with status_code, body (bytes), content_type."""
+        params = {"direction": direction}
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        path = f"/tasks/{task_id}/artifacts/{filename}?{query}"
+
+        url = f"{self.base}{path}"
+        request = urllib.request.Request(url, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self.request_timeout) as response:
+                status_code = response.status
+                content_type = response.headers.get("Content-Type", "")
+                body = response.read()
+                if raise_for_status and status_code != expected_status:
+                    raise ApiError(status_code, {"error": body.decode("utf-8", errors="replace")})
+                return {
+                    "status_code": status_code,
+                    "body": body,
+                    "content_type": content_type,
+                }
+        except urllib.error.HTTPError as exc:
+            body = exc.read()
+            if raise_for_status and exc.code != expected_status:
+                raise ApiError(exc.code, {"error": body.decode("utf-8", errors="replace")})
+            return {
+                "status_code": exc.code,
+                "body": body,
+                "content_type": "",
+            }
+
     def poll_until(
         self,
         task_id: str,

--- a/tests/backend-integration/helpers/mock_llm.py
+++ b/tests/backend-integration/helpers/mock_llm.py
@@ -139,3 +139,24 @@ def dev_sleep_tool_call(seconds: int = 10, final_answer: str = "done after sleep
     mock = _new_mock()
     mock.ainvoke = AsyncMock(side_effect=[call_msg, final_msg])
     return mock
+
+
+def upload_artifact_call(filename: str, content: str, content_type: str = "text/plain",
+                         final_answer: str = "Artifact uploaded successfully.") -> MagicMock:
+    """Create a mock LLM that calls upload_artifact, then responds with a final answer."""
+    call_msg = AIMessage(
+        content="",
+        tool_calls=[ToolCall(
+            name="upload_artifact",
+            args={
+                "filename": filename,
+                "content": content,
+                "content_type": content_type,
+            },
+            id="call_upload_artifact",
+        )],
+    )
+    final_msg = AIMessage(content=final_answer)
+    mock = _new_mock()
+    mock.ainvoke = AsyncMock(side_effect=[call_msg, final_msg])
+    return mock

--- a/tests/backend-integration/test_artifacts.py
+++ b/tests/backend-integration/test_artifacts.py
@@ -1,0 +1,167 @@
+"""Integration tests for Track 1: Output Artifact Storage.
+
+Tests the end-to-end artifact flow:
+1. Agent calls upload_artifact tool during task execution
+2. Artifact metadata appears in list endpoint
+3. Artifact file can be downloaded with correct content
+"""
+
+import pytest
+
+from helpers.mock_llm import upload_artifact_call, simple_response
+
+
+@pytest.mark.asyncio
+async def test_upload_and_list_artifact(e2e):
+    """Agent uploads an artifact via upload_artifact tool.
+    Verify it appears in the artifact list endpoint."""
+
+    artifact_content = "# Analysis Report\n\nThis is a test report.\n"
+    artifact_filename = "report.md"
+
+    e2e.use_llm(upload_artifact_call(
+        filename=artifact_filename,
+        content=artifact_content,
+        content_type="text/markdown",
+        final_answer="Report has been saved as report.md.",
+    ))
+    await e2e.start_worker("e2e-artifact-worker")
+
+    e2e.ensure_agent(agent_config={
+        "system_prompt": "You are a test assistant that produces reports.",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.5,
+        "allowed_tools": ["upload_artifact"],
+    })
+
+    task_id = e2e.submit_task(input="Write a short analysis report.")
+
+    completed = await e2e.wait_for_status(task_id, "completed", timeout=30.0)
+    assert "report" in str(completed["output"]["result"]).lower()
+
+    # List artifacts
+    artifacts_response = e2e.api.list_artifacts(task_id)
+    artifacts = artifacts_response["body"]
+    assert len(artifacts) == 1
+
+    artifact = artifacts[0]
+    assert artifact["filename"] == artifact_filename
+    assert artifact["direction"] == "output"
+    assert artifact["contentType"] == "text/markdown"
+    assert artifact["sizeBytes"] == len(artifact_content.encode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_download_artifact_content(e2e):
+    """After an artifact is uploaded, download it and verify the content matches."""
+
+    artifact_content = "col1,col2,col3\n1,2,3\n4,5,6\n"
+    artifact_filename = "data.csv"
+
+    e2e.use_llm(upload_artifact_call(
+        filename=artifact_filename,
+        content=artifact_content,
+        content_type="text/csv",
+    ))
+    await e2e.start_worker("e2e-artifact-dl-worker")
+
+    e2e.ensure_agent(agent_config={
+        "system_prompt": "You are a test assistant.",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.5,
+        "allowed_tools": ["upload_artifact"],
+    })
+
+    task_id = e2e.submit_task(input="Generate a CSV file.")
+    await e2e.wait_for_status(task_id, "completed", timeout=30.0)
+
+    # Download artifact
+    download = e2e.api.download_artifact(task_id, artifact_filename)
+    assert download["status_code"] == 200
+    assert download["body"].decode("utf-8") == artifact_content
+    assert "text/csv" in download["content_type"]
+
+
+@pytest.mark.asyncio
+async def test_list_artifacts_empty(e2e):
+    """List artifacts for a task with no artifacts returns empty list."""
+
+    e2e.use_llm(simple_response("Done, no artifacts."))
+    await e2e.start_worker("e2e-artifact-empty-worker")
+
+    e2e.ensure_agent(agent_config={
+        "system_prompt": "You are a test assistant.",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.5,
+        "allowed_tools": [],
+    })
+
+    task_id = e2e.submit_task(input="Just respond.")
+    await e2e.wait_for_status(task_id, "completed", timeout=20.0)
+
+    # List artifacts — should be empty
+    artifacts_response = e2e.api.list_artifacts(task_id)
+    artifacts = artifacts_response["body"]
+    assert artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_download_nonexistent_artifact_returns_404(e2e):
+    """Download a non-existent artifact returns 404."""
+
+    e2e.use_llm(simple_response("Done."))
+    await e2e.start_worker("e2e-artifact-404-worker")
+
+    e2e.ensure_agent(agent_config={
+        "system_prompt": "You are a test assistant.",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.5,
+        "allowed_tools": [],
+    })
+
+    task_id = e2e.submit_task(input="Just respond.")
+    await e2e.wait_for_status(task_id, "completed", timeout=20.0)
+
+    # Download non-existent artifact — should be 404
+    download = e2e.api.download_artifact(
+        task_id, "nonexistent.pdf",
+        expected_status=404, raise_for_status=False,
+    )
+    assert download["status_code"] == 404
+
+
+@pytest.mark.asyncio
+async def test_list_artifacts_with_direction_filter(e2e):
+    """List artifacts with direction filter returns only matching artifacts."""
+
+    artifact_content = "Test content"
+
+    e2e.use_llm(upload_artifact_call(
+        filename="filtered.txt",
+        content=artifact_content,
+        content_type="text/plain",
+    ))
+    await e2e.start_worker("e2e-artifact-filter-worker")
+
+    e2e.ensure_agent(agent_config={
+        "system_prompt": "You are a test assistant.",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.5,
+        "allowed_tools": ["upload_artifact"],
+    })
+
+    task_id = e2e.submit_task(input="Create a text file.")
+    await e2e.wait_for_status(task_id, "completed", timeout=30.0)
+
+    # Filter by output — should return the artifact
+    output_artifacts = e2e.api.list_artifacts(task_id, direction="output")
+    assert len(output_artifacts["body"]) == 1
+
+    # Filter by input — should return empty (no input artifacts in Track 1)
+    input_artifacts = e2e.api.list_artifacts(task_id, direction="input")
+    assert len(input_artifacts["body"]) == 0


### PR DESCRIPTION
## Summary

- End-to-end output artifact support: agents produce files via `upload_artifact` tool, users list and download them through API and Console
- Infrastructure: docker-compose with PostgreSQL + LocalStack S3, migration 0009 (`task_artifacts` table)
- Worker: boto3 S3Client wrapper, `upload_artifact` built-in tool (50MB limit, ON CONFLICT upsert)
- API: `ArtifactRepository`, `S3StorageService` (AWS SDK v2), list + download endpoints, artifacts in task status response
- Console: `ArtifactsTab` component with download buttons in task detail view
- Test isolation: worker integration tests now use dedicated test DB (port 55433), not dev DB; `test-db-up` target auto-starts test Postgres + LocalStack
- CI: migrations now use glob pattern (auto-picks up new files), LocalStack added to E2E job

## Test plan

- [x] `make test` — 284 worker + 179 API + 51 console = 514 unit tests, 0 skipped
- [x] `make e2e-test` — 89 E2E tests including 5 new artifact flow tests
- [x] Manual: `make start`, create agent with `upload_artifact` tool, submit task (Chinese content), verify artifacts tab appears on completion, download produces correct file with proper encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)