### PR TITLE
Fix LLM retry stacking, tool error routing, and checkpoint race

### DIFF
--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -69,6 +69,14 @@ from tools.errors import ToolExecutionError, ToolTransportError
 logger = logging.getLogger(__name__)
 
 
+def _handle_tool_error(e: Exception) -> str:
+    """Route tool errors: re-raise infra failures for task-level retry,
+    return user-fixable errors as messages so the LLM can self-correct."""
+    if isinstance(e, ToolTransportError):
+        raise e
+    return f"Error: {e}\nPlease fix the error and try again."
+
+
 class GraphExecutor:
     """Orchestrates LangGraph execution for a claimed task."""
 
@@ -451,7 +459,7 @@ class GraphExecutor:
 
         if tools:
             # LangGraph handles routing the LLM's ToolCall directly to our python functions
-            tool_node = ToolNode(tools, handle_tool_errors=ToolExecutionError)
+            tool_node = ToolNode(tools, handle_tool_errors=_handle_tool_error)
             workflow.add_node("tools", tool_node)
             workflow.add_edge("tools", "agent")
             workflow.add_conditional_edges("agent", tools_condition)
@@ -1010,7 +1018,9 @@ class GraphExecutor:
                 hourly_cost = 0
 
                 # Executing super-steps via astream
-                async for event in compiled_graph.astream(initial_input, config=config, stream_mode="updates"):
+                # durability="sync" ensures checkpoints are committed before astream
+                # yields, so the cost-ledger SELECT always finds the correct checkpoint_id.
+                async for event in compiled_graph.astream(initial_input, config=config, stream_mode="updates", durability="sync"):
                     # Step 6: Cancellation Awareness
                     if cancel_event.is_set():
                         logger.warning("Task %s cancelled or lease revoked during execution.", task_id)
@@ -1412,12 +1422,29 @@ class GraphExecutor:
             cancel_task.cancel()
             await asyncio.gather(cancel_task, return_exceptions=True)
 
-    def _get_retry_after(self, e: Exception) -> float | None:
-        """Extract retry-after seconds from the error's HTTP response headers."""
-        # Walk the exception chain to find an API error with a response
+    @staticmethod
+    def _walk_exception_chain(e: Exception):
+        """Yield each exception in the __cause__/__context__ chain (including e itself)."""
         current = e
         for _ in range(5):
-            resp = getattr(current, "response", None)
+            if current is None:
+                break
+            yield current
+            current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+
+    def _extract_status_code(self, e: Exception) -> int | None:
+        """Walk the exception chain to find an HTTP status code.
+        Works with both anthropic.APIStatusError and openai.APIStatusError."""
+        for exc in self._walk_exception_chain(e):
+            code = getattr(exc, "status_code", None)
+            if isinstance(code, int):
+                return code
+        return None
+
+    def _get_retry_after(self, e: Exception) -> float | None:
+        """Extract retry-after seconds from the error's HTTP response headers."""
+        for exc in self._walk_exception_chain(e):
+            resp = getattr(exc, "response", None)
             if resp is not None:
                 retry_after = getattr(resp, "headers", {}).get("retry-after")
                 if retry_after:
@@ -1426,19 +1453,19 @@ class GraphExecutor:
                     except (ValueError, TypeError):
                         pass
                 return None
-            current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
-            if current is None:
-                break
         return None
+
+    # Status codes that are safe to retry (transient server / rate-limit errors)
+    _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}
 
     def _is_rate_limit_error(self, e: Exception) -> bool:
         """Check if the exception is a rate limit error (429)."""
-        error_str = str(e).lower()
-        if "429" in error_str or "rate limit" in error_str or "rate exceeded" in error_str:
+        status = self._extract_status_code(e)
+        if status == 429:
             return True
-        # Check for Anthropic/OpenAI RateLimitError types
-        type_name = type(e).__name__
-        if "RateLimit" in type_name:
+        # Fallback: string heuristics for wrapped/unknown providers
+        error_str = str(e).lower()
+        if "rate limit" in error_str or "rate exceeded" in error_str:
             return True
         return False
 
@@ -1450,24 +1477,24 @@ class GraphExecutor:
         if isinstance(e, (ConnectionError, TimeoutError)):
             return True
 
+        # Use HTTP status code from the provider exception if available
+        status = self._extract_status_code(e)
+        if status is not None:
+            return status in self._RETRYABLE_STATUS_CODES
+
+        # Fallback: string heuristics for errors without a status code
         error_str = str(e).lower()
 
-        # 429 and 5xx are retryable — checked before string heuristics to avoid
-        # false negatives (e.g. "invalid request rate exceeded" contains "invalid")
         if "429" in error_str or "rate limit" in error_str or "rate exceeded" in error_str:
             return True
         if re.search(r'\b50[0234]\b', error_str):
             return True
-
-        # Non-retryable validation and client errors
         if "validation" in error_str or "invalid" in error_str or "unsupported" in error_str or "pydantic" in error_str:
             return False
-
-        # 4xx HTTP responses (usually fatal)
         if re.search(r'\b40[0-4]\b', error_str):
             return False
 
-        # For Phase 1, default unknown exceptions to non-retryable
+        # Default unknown exceptions to non-retryable
         return False
 
     async def _check_budget_and_pause(

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -65,6 +65,7 @@ from tools.sandbox_tools import (
     create_sandbox_download_fn,
 )
 from tools.errors import ToolExecutionError, ToolTransportError
+from executor.mcp_session import McpToolCallError
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ logger = logging.getLogger(__name__)
 def _handle_tool_error(e: Exception) -> str:
     """Route tool errors: re-raise infra failures for task-level retry,
     return user-fixable errors as messages so the LLM can self-correct."""
-    if isinstance(e, ToolTransportError):
+    if isinstance(e, (ToolTransportError, McpToolCallError)):
         raise e
     return f"Error: {e}\nPlease fix the error and try again."
 
@@ -1465,7 +1466,7 @@ class GraphExecutor:
             return True
         # Fallback: string heuristics for wrapped/unknown providers
         error_str = str(e).lower()
-        if "rate limit" in error_str or "rate exceeded" in error_str:
+        if "429" in error_str or "rate limit" in error_str or "rate exceeded" in error_str:
             return True
         return False
 

--- a/services/worker-service/executor/providers.py
+++ b/services/worker-service/executor/providers.py
@@ -23,5 +23,7 @@ async def create_llm(
         model=model_name,
         model_provider=provider,
         temperature=temperature,
-        api_key=api_key
+        api_key=api_key,
+        max_retries=0,
+        timeout=300,
     )

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, AsyncMock, patch, MagicMock
 
 from core.worker import WorkerService
 from core.config import WorkerConfig
-from executor.graph import GraphExecutor
+from executor.graph import GraphExecutor, _handle_tool_error
 from executor.mcp_session import McpConnectionError
 from executor.schema_converter import MAX_TOOLS_PER_AGENT
 from langchain_core.tools import StructuredTool
@@ -157,7 +157,26 @@ async def test_build_graph_configures_tool_node_for_expected_tool_errors(mock_wo
             )
 
     _, kwargs = MockToolNode.call_args
-    assert kwargs["handle_tool_errors"] is ToolExecutionError
+    assert kwargs["handle_tool_errors"] is _handle_tool_error
+
+
+def test_handle_tool_error_returns_message_for_validation_errors():
+    """Validation errors (e.g. missing tool args) are fed back to the LLM."""
+    result = _handle_tool_error(ValueError("content: Field required"))
+    assert "Field required" in result
+    assert "fix the error" in result.lower()
+
+
+def test_handle_tool_error_reraises_transport_errors():
+    """Infrastructure errors propagate for task-level retry."""
+    with pytest.raises(ToolTransportError):
+        _handle_tool_error(ToolTransportError("S3 unreachable"))
+
+
+def test_handle_tool_error_returns_message_for_tool_execution_errors():
+    """Non-transport ToolExecutionError is recoverable by the LLM."""
+    result = _handle_tool_error(ToolExecutionError("invalid file path"))
+    assert "invalid file path" in result
 
 
 @pytest.mark.asyncio
@@ -753,6 +772,51 @@ def test_real_validation_errors_are_not_retryable(mock_worker):
     assert executor._is_retryable_error(ValueError("pydantic validation error")) is False
     assert executor._is_retryable_error(ValueError("invalid schema property")) is False
     assert executor._is_retryable_error(ValueError("unsupported model")) is False
+
+
+def _make_api_error(status_code: int, message: str = "error") -> Exception:
+    """Create a fake provider exception with a status_code, wrapped by LangChain."""
+    class FakeAPIStatusError(Exception):
+        pass
+    inner = FakeAPIStatusError(message)
+    inner.status_code = status_code
+    outer = Exception(f"Error code: {status_code} - {message}")
+    outer.__cause__ = inner
+    return outer
+
+
+def test_extract_status_code_from_cause_chain(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    assert executor._extract_status_code(_make_api_error(429)) == 429
+    assert executor._extract_status_code(_make_api_error(400)) == 400
+    assert executor._extract_status_code(_make_api_error(500)) == 500
+    assert executor._extract_status_code(ValueError("no status code")) is None
+
+
+def test_retryable_by_status_code(mock_worker):
+    """Status codes from provider exceptions take precedence over string heuristics."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    # Retryable status codes
+    for code in [429, 500, 502, 503, 504, 529]:
+        assert executor._is_retryable_error(_make_api_error(code)) is True, f"{code} should be retryable"
+    # Non-retryable status codes
+    for code in [400, 401, 403, 404, 422]:
+        assert executor._is_retryable_error(_make_api_error(code)) is False, f"{code} should not be retryable"
+
+
+def test_rate_limit_by_status_code(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    assert executor._is_rate_limit_error(_make_api_error(429)) is True
+    assert executor._is_rate_limit_error(_make_api_error(400)) is False
+    assert executor._is_rate_limit_error(_make_api_error(500)) is False
+
+
+def test_out_of_credits_is_not_retryable(mock_worker):
+    """Anthropic out-of-credits returns 400 — must not retry."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    err = _make_api_error(400, "Your credit balance is too low to access the Anthropic API")
+    assert executor._is_retryable_error(err) is False
+    assert executor._is_rate_limit_error(err) is False
 
 
 @pytest.mark.asyncio

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, AsyncMock, patch, MagicMock
 from core.worker import WorkerService
 from core.config import WorkerConfig
 from executor.graph import GraphExecutor, _handle_tool_error
-from executor.mcp_session import McpConnectionError
+from executor.mcp_session import McpConnectionError, McpToolCallError
 from executor.schema_converter import MAX_TOOLS_PER_AGENT
 from langchain_core.tools import StructuredTool
 from langgraph.errors import GraphRecursionError
@@ -832,6 +832,12 @@ def test_handle_tool_error_returns_message_for_generic_exception():
     """Generic exceptions during tool execution are sent back to the LLM."""
     result = _handle_tool_error(Exception("something unexpected"))
     assert "something unexpected" in result
+
+
+def test_handle_tool_error_reraises_mcp_tool_call_errors():
+    """MCP tool call failures (timeouts, network) propagate for task-level retry."""
+    with pytest.raises(McpToolCallError):
+        _handle_tool_error(McpToolCallError("my-server", "my-tool", "timeout"))
 
 
 # ─── _get_retry_after tests ─────────────────────────────────────────────────

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -11,7 +11,7 @@ from executor.schema_converter import MAX_TOOLS_PER_AGENT
 from langchain_core.tools import StructuredTool
 from langgraph.errors import GraphRecursionError
 from checkpointer.postgres import LeaseRevokedException
-from tools.errors import ToolExecutionError, ToolTransportError
+from tools.errors import ToolExecutionError, ToolInputError, ToolTransportError
 from sandbox.provisioner import SandboxProvisionError, SandboxConnectionError
 
 
@@ -817,6 +817,181 @@ def test_out_of_credits_is_not_retryable(mock_worker):
     err = _make_api_error(400, "Your credit balance is too low to access the Anthropic API")
     assert executor._is_retryable_error(err) is False
     assert executor._is_rate_limit_error(err) is False
+
+
+# ─── _handle_tool_error edge cases ──────────────────────────────────────────
+
+
+def test_handle_tool_error_returns_message_for_tool_input_error():
+    """ToolInputError (tool-specific validation) is recoverable by the LLM."""
+    result = _handle_tool_error(ToolInputError("filename must end with .py"))
+    assert "filename must end with .py" in result
+
+
+def test_handle_tool_error_returns_message_for_generic_exception():
+    """Generic exceptions during tool execution are sent back to the LLM."""
+    result = _handle_tool_error(Exception("something unexpected"))
+    assert "something unexpected" in result
+
+
+# ─── _get_retry_after tests ─────────────────────────────────────────────────
+
+
+def _make_api_error_with_retry_after(retry_after_value: str) -> Exception:
+    """Create a fake provider exception with a response carrying a Retry-After header."""
+    class FakeResponse:
+        headers = {"retry-after": retry_after_value}
+    class FakeAPIError(Exception):
+        pass
+    inner = FakeAPIError("rate limited")
+    inner.response = FakeResponse()
+    outer = Exception("Error code: 429")
+    outer.__cause__ = inner
+    return outer
+
+
+def test_get_retry_after_extracts_header(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    err = _make_api_error_with_retry_after("30")
+    assert executor._get_retry_after(err) == 30.0
+
+
+def test_get_retry_after_handles_float_header(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    err = _make_api_error_with_retry_after("2.5")
+    assert executor._get_retry_after(err) == 2.5
+
+
+def test_get_retry_after_returns_none_for_invalid_header(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    err = _make_api_error_with_retry_after("not-a-number")
+    assert executor._get_retry_after(err) is None
+
+
+def test_get_retry_after_returns_none_when_no_response(mock_worker):
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    assert executor._get_retry_after(ValueError("plain error")) is None
+
+
+# ─── String fallback tests (no status_code) ─────────────────────────────────
+
+
+def test_retryable_string_fallback_without_status_code(mock_worker):
+    """When no status_code is available, string heuristics still work."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    # These are plain exceptions — no __cause__ with status_code
+    assert executor._is_retryable_error(Exception("502 Bad Gateway")) is True
+    assert executor._is_retryable_error(Exception("503 Service Unavailable")) is True
+    assert executor._is_retryable_error(Exception("504 Gateway Timeout")) is True
+    assert executor._is_retryable_error(Exception("rate limit exceeded")) is True
+
+
+def test_non_retryable_string_fallback_without_status_code(mock_worker):
+    """Plain exceptions with 4xx messages are non-retryable via fallback."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    assert executor._is_retryable_error(Exception("401 Unauthorized")) is False
+    assert executor._is_retryable_error(Exception("403 Forbidden")) is False
+
+
+def test_rate_limit_string_fallback_without_status_code(mock_worker):
+    """_is_rate_limit_error falls back to string matching without status_code."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    assert executor._is_rate_limit_error(Exception("rate limit exceeded")) is True
+    assert executor._is_rate_limit_error(Exception("rate exceeded for model")) is True
+    assert executor._is_rate_limit_error(Exception("something else")) is False
+
+
+# ─── _extract_status_code edge cases ────────────────────────────────────────
+
+
+def test_extract_status_code_ignores_non_int_status_code(mock_worker):
+    """Non-integer status_code attributes are ignored."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    err = Exception("error")
+    err.status_code = "not-an-int"
+    assert executor._extract_status_code(err) is None
+
+
+def test_extract_status_code_deeply_nested(mock_worker):
+    """Status code found multiple levels deep in the cause chain."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+    inner = Exception("root cause")
+    inner.status_code = 503
+    mid = Exception("wrapped")
+    mid.__cause__ = inner
+    outer = Exception("top level")
+    outer.__cause__ = mid
+    assert executor._extract_status_code(outer) == 503
+
+
+# ─── providers.py tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_llm_passes_retry_and_timeout():
+    """Verify max_retries=0 and timeout=300 are passed to init_chat_model."""
+    with patch("executor.providers.init_chat_model") as mock_init:
+        mock_init.return_value = MagicMock()
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchval = AsyncMock(return_value="fake-api-key")
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value = mock_cm
+
+        from executor.providers import create_llm
+        await create_llm(mock_pool, "anthropic", "claude-3-5-sonnet-latest", 0.5)
+
+        mock_init.assert_called_once_with(
+            model="claude-3-5-sonnet-latest",
+            model_provider="anthropic",
+            temperature=0.5,
+            api_key="fake-api-key",
+            max_retries=0,
+            timeout=300,
+        )
+
+
+# ─── durability="sync" test ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_astream_called_with_sync_durability(mock_worker, task_data):
+    """Verify astream is called with durability='sync' to prevent checkpoint race."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+
+    with patch.object(executor, "_build_graph") as mock_build:
+        mock_graph = MagicMock()
+        mock_compiled = MagicMock()
+        mock_graph.compile.return_value = mock_compiled
+        mock_build.return_value = mock_graph
+
+        with patch("executor.graph.PostgresDurableCheckpointer") as MockCheckpointer:
+            mock_ckpt = AsyncMock()
+            mock_ckpt.aget_tuple.return_value = None
+            MockCheckpointer.return_value = mock_ckpt
+
+            astream_kwargs_capture = {}
+
+            async def mock_astream(*args, **kwargs):
+                astream_kwargs_capture.update(kwargs)
+                return
+                yield  # make it an async generator
+
+            mock_compiled.astream = mock_astream
+
+            mock_state = MagicMock()
+            mock_state.values = {"messages": [MagicMock(content="done")]}
+            mock_state.tasks = []
+            mock_compiled.aget_state = AsyncMock(return_value=mock_state)
+
+            await executor.execute_task(task_data, mock_worker.heartbeat.start_heartbeat.return_value.cancel_event)
+
+            assert astream_kwargs_capture.get("durability") == "sync"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes three production issues that caused tasks to hang or crash unnecessarily:

### 1. LLM retry stacking (tasks hanging up to 3 hours)
The Anthropic SDK has internal retries (default 2 attempts with exponential backoff up to 40s) that are invisible to application code. These stacked with our app-level 5-retry loop, causing worst-case latency of ~3 hours on rate limits before a task would surface an error.

**Fix:** Disable SDK-level retries (`max_retries=0`) and cap per-request timeout at 5 minutes (`timeout=300`) in `providers.py`. All retry logic is now exclusively handled by the app-level retry loop in `_run_execution_loop`, which has proper backoff, budget tracking, and dead-letter semantics.

### 2. Tool error routing (valid errors crashing tasks as `fatal_error`)
When the LLM made a bad tool call (e.g., missing a required argument), the resulting `ValidationError` was not caught by `handle_tool_errors=ToolExecutionError` because Pydantic's `ValidationError` doesn't extend `ToolExecutionError`. This caused the entire task to crash as `fatal_error` instead of letting the LLM retry with corrected arguments.

**Fix:** Replace the type-based filter with a callable `_handle_tool_error` that routes errors intelligently:
- **Infrastructure failures** (`ToolTransportError`, `McpToolCallError`) → re-raised for task-level retry with backoff
- **All other tool errors** (validation, bad arguments, runtime errors) → returned as a message to the LLM so it can self-correct

### 3. Status-code-based error classification (replacing fragile string matching)
`_is_retryable_error` and `_is_rate_limit_error` relied on string matching against error messages (e.g., looking for "rate limit" or "overloaded"). This is brittle — different providers format messages differently, and LangChain wraps exceptions in varying ways.

**Fix:** Added `_extract_status_code` that walks the `__cause__`/`__context__` exception chain to find the actual HTTP status code from the underlying provider SDK exception (Anthropic `APIStatusError`, OpenAI errors, etc.). Error classification now checks status codes first (`{429, 500, 502, 503, 504, 529}` for retryable, `429` for rate limit), falling back to string matching only when no status code is available.

### 4. Checkpoint race condition
`astream` defaults to `durability="async"`, which fires checkpoint writes but doesn't await them. The cost-ledger `SELECT` that runs after yielding could read a stale `checkpoint_id` if the checkpoint write hadn't committed yet.

**Fix:** Set `durability="sync"` on the `astream` call so checkpoints are fully committed before the next iteration.

## Changed files
- `services/worker-service/executor/providers.py` — `max_retries=0`, `timeout=300`
- `services/worker-service/executor/graph.py` — `_handle_tool_error`, `_extract_status_code`, `_walk_exception_chain`, refactored `_is_retryable_error`/`_is_rate_limit_error`, `durability="sync"`
- `services/worker-service/tests/test_executor.py` — 19 new tests covering all changes

## Test plan
- [x] All 395 worker unit tests pass (`make worker-test`)
- [x] Out-of-credits (400) immediately dead-lettered without retry — verified task went from `claimed` to `dead_lettered` in ~1 second
- [x] Rate-limited tasks no longer hang — previously task hung 25+ minutes in SDK retry loop; after fix, errors surface immediately to the app-level retry loop
- [x] Tool-use tasks complete successfully via API — task used calculator + upload_artifact end-to-end
- [x] CI passing (unit, integration, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)