### PR TITLE
Rename artifact tools and prevent context window bloat

### DIFF
--- a/services/api-service/src/main/java/com/persistentagent/api/config/ValidationConstants.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/config/ValidationConstants.java
@@ -19,16 +19,16 @@ public final class ValidationConstants {
 
     /** All valid tool names accepted by the API (for validation only). */
     public static final Set<String> ALLOWED_TOOLS = Set.of(
-            "web_search", "read_url", "request_human_input", "upload_artifact",
-            "sandbox_exec", "sandbox_read_file", "sandbox_write_file", "sandbox_download");
+            "web_search", "read_url", "request_human_input", "create_text_artifact",
+            "sandbox_exec", "sandbox_read_file", "sandbox_write_file", "export_sandbox_file");
 
     /** Platform tools auto-enabled for every agent. */
     public static final List<String> BASE_PLATFORM_TOOLS = List.of(
-            "web_search", "read_url", "upload_artifact", "request_human_input");
+            "web_search", "read_url", "create_text_artifact", "request_human_input");
 
     /** Sandbox tools auto-enabled when sandbox.enabled is true. */
     public static final List<String> SANDBOX_TOOLS = List.of(
-            "sandbox_exec", "sandbox_read_file", "sandbox_write_file", "sandbox_download");
+            "sandbox_exec", "sandbox_read_file", "sandbox_write_file", "export_sandbox_file");
 
     /** Dev-only task-control tools, enabled behind app.dev-task-controls.enabled. */
     public static final Set<String> DEV_TASK_CONTROL_TOOLS = Set.of("dev_sleep");

--- a/services/console/src/features/agents/AgentDetailPage.tsx
+++ b/services/console/src/features/agents/AgentDetailPage.tsx
@@ -176,7 +176,7 @@ export function AgentDetailPage() {
     // Auto-managed tools are implied by sandbox/HITL config — don't clutter the overview
     const AUTO_MANAGED_TOOLS = new Set([
         HUMAN_INPUT_TOOL_ID,
-        'sandbox_exec', 'sandbox_read_file', 'sandbox_write_file', 'sandbox_download',
+        'sandbox_exec', 'sandbox_read_file', 'sandbox_write_file', 'export_sandbox_file',
     ]);
     const toolLabels = (agent.agent_config.allowed_tools ?? [])
         .filter(t => !AUTO_MANAGED_TOOLS.has(t))

--- a/services/console/src/features/submit/SubmitTaskPage.tsx
+++ b/services/console/src/features/submit/SubmitTaskPage.tsx
@@ -190,7 +190,7 @@ export function SubmitTaskPage() {
                                                     <span className="text-foreground/80 whitespace-pre-wrap line-clamp-3">{selectedAgent.agent_config.system_prompt}</span>
                                                 </div>
                                                 {(() => {
-                                                    const autoManaged = new Set(['request_human_input', 'sandbox_exec', 'sandbox_read_file', 'sandbox_write_file', 'sandbox_download']);
+                                                    const autoManaged = new Set(['request_human_input', 'sandbox_exec', 'sandbox_read_file', 'sandbox_write_file', 'export_sandbox_file']);
                                                     const userTools = (selectedAgent.agent_config.allowed_tools ?? []).filter(t => !autoManaged.has(t));
                                                     return userTools.length > 0 ? (
                                                         <div className="md:col-span-2">

--- a/services/console/src/features/submit/schema.ts
+++ b/services/console/src/features/submit/schema.ts
@@ -31,8 +31,8 @@ export const ALL_TOOL_LABELS: Record<string, string> = {
     sandbox_exec: "Sandbox Exec",
     sandbox_read_file: "Sandbox Read File",
     sandbox_write_file: "Sandbox Write File",
-    sandbox_download: "Sandbox Download",
-    upload_artifact: "Upload Artifact",
+    export_sandbox_file: "Export Sandbox File",
+    create_text_artifact: "Create Text Artifact",
     request_human_input: "Human Input",
     dev_sleep: "Dev Sleep",
 };

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -42,11 +42,11 @@ from tools.definitions import (
     READ_URL_TOOL,
     DEV_SLEEP_TOOL,
     REQUEST_HUMAN_INPUT_TOOL,
-    UPLOAD_ARTIFACT_TOOL,
+    CREATE_TEXT_ARTIFACT_TOOL,
     SANDBOX_EXEC_TOOL,
     SANDBOX_READ_FILE_TOOL,
     SANDBOX_WRITE_FILE_TOOL,
-    SANDBOX_DOWNLOAD_TOOL,
+    EXPORT_SANDBOX_FILE_TOOL,
     WebSearchArguments,
     ReadUrlArguments,
     DevSleepArguments,
@@ -58,11 +58,11 @@ from tools.sandbox_tools import (
     SandboxExecArguments,
     SandboxReadFileArguments,
     SandboxWriteFileArguments,
-    SandboxDownloadArguments,
+    ExportSandboxFileArguments,
     create_sandbox_exec_fn,
     create_sandbox_read_file_fn,
     create_sandbox_write_file_fn,
-    create_sandbox_download_fn,
+    create_export_sandbox_file_fn,
 )
 from tools.errors import ToolExecutionError, ToolTransportError
 from executor.mcp_session import McpToolCallError
@@ -250,18 +250,22 @@ class GraphExecutor:
                 args_schema=DevSleepArguments
             ))
 
-        if "upload_artifact" in allowed_tools:
+        # create_text_artifact is only offered when there is NO sandbox.
+        # When a sandbox is available, the agent should use export_sandbox_file instead
+        # to avoid sending file content through the LLM context window.
+        has_sandbox = sandbox is not None and "export_sandbox_file" in allowed_tools
+        if "create_text_artifact" in allowed_tools and not has_sandbox:
             from tools.upload_artifact import (
-                UploadArtifactArguments,
-                execute_upload_artifact,
+                CreateTextArtifactArguments,
+                execute_create_text_artifact,
             )
 
-            async def upload_artifact(
+            async def create_text_artifact(
                 filename: str,
                 content: str,
                 content_type: str = "text/plain",
             ):
-                return await execute_upload_artifact(
+                return await execute_create_text_artifact(
                     filename=filename,
                     content=content,
                     content_type=content_type,
@@ -273,10 +277,10 @@ class GraphExecutor:
 
             tools.append(
                 StructuredTool.from_function(
-                    coroutine=upload_artifact,
-                    name="upload_artifact",
-                    description=UPLOAD_ARTIFACT_TOOL.description,
-                    args_schema=UploadArtifactArguments,
+                    coroutine=create_text_artifact,
+                    name="create_text_artifact",
+                    description=CREATE_TEXT_ARTIFACT_TOOL.description,
+                    args_schema=CreateTextArtifactArguments,
                 )
             )
 
@@ -335,8 +339,8 @@ class GraphExecutor:
                 args_schema=SandboxWriteFileArguments,
             ))
 
-        if sandbox is not None and "sandbox_download" in allowed_tools and s3_client is not None:
-            download_fn = create_sandbox_download_fn(
+        if sandbox is not None and "export_sandbox_file" in allowed_tools and s3_client is not None:
+            export_fn = create_export_sandbox_file_fn(
                 sandbox,
                 s3_client=s3_client,
                 pool=self.pool,
@@ -344,19 +348,19 @@ class GraphExecutor:
                 tenant_id=tenant_id,
             )
 
-            async def sandbox_download_wrapper(path: str, filename: str | None = None):
+            async def export_sandbox_file_wrapper(path: str, filename: str | None = None):
                 return await self._await_or_cancel(
-                    download_fn(path, filename),
+                    export_fn(path, filename),
                     cancel_event,
                     task_id=task_id,
-                    operation="sandbox_download",
+                    operation="export_sandbox_file",
                 )
 
             tools.append(StructuredTool.from_function(
-                coroutine=sandbox_download_wrapper,
-                name="sandbox_download",
-                description=SANDBOX_DOWNLOAD_TOOL.description,
-                args_schema=SandboxDownloadArguments,
+                coroutine=export_sandbox_file_wrapper,
+                name="export_sandbox_file",
+                description=EXPORT_SANDBOX_FILE_TOOL.description,
+                args_schema=ExportSandboxFileArguments,
             ))
 
         return tools
@@ -684,19 +688,19 @@ class GraphExecutor:
                 "This will pause execution and wait for the user to respond."
             )
 
-        sandbox_tools = {"sandbox_exec", "sandbox_read_file", "sandbox_write_file", "sandbox_download"}
+        sandbox_tools = {"sandbox_exec", "sandbox_read_file", "sandbox_write_file", "export_sandbox_file"}
         if sandbox_tools.intersection(allowed_tools):
             template_note = f" running the `{sandbox_template}` environment" if sandbox_template else ""
             sections.append(
                 f"You have access to a sandbox environment{template_note} for code execution. "
                 "Use `sandbox_exec` to run shell commands, `sandbox_write_file` to create files, "
-                "`sandbox_read_file` to read files, and `sandbox_download` to save files as output artifacts. "
+                "`sandbox_read_file` to read files, and `export_sandbox_file` to save files as output artifacts. "
                 "Write code to files first, then execute them with sandbox_exec."
             )
 
-        if "upload_artifact" in allowed_tools:
+        if "create_text_artifact" in allowed_tools and not sandbox_tools.intersection(allowed_tools):
             sections.append(
-                "You can save output files using the `upload_artifact` tool. "
+                "You can save output files using the `create_text_artifact` tool. "
                 "Use this to produce reports, data files, or other deliverables."
             )
 

--- a/services/worker-service/tests/test_sandbox_integration.py
+++ b/services/worker-service/tests/test_sandbox_integration.py
@@ -308,7 +308,7 @@ class TestNonSandboxAgentIntegration:
         agent_config = {
             "allowed_tools": ["web_search", "calculator"],
         }
-        sandbox_tools = {"sandbox_exec", "sandbox_read_file", "sandbox_write_file", "sandbox_download"}
+        sandbox_tools = {"sandbox_exec", "sandbox_read_file", "sandbox_write_file", "export_sandbox_file"}
         agent_tools = set(agent_config.get("allowed_tools", []))
         assert agent_tools.isdisjoint(sandbox_tools)
 

--- a/services/worker-service/tests/test_sandbox_tools.py
+++ b/services/worker-service/tests/test_sandbox_tools.py
@@ -207,7 +207,7 @@ class TestCreateSandboxReadFileFn:
             result = await read_fn("/home/user/image.png")
 
         assert "Binary file" in result["content"]
-        assert "sandbox_download" in result["content"]
+        assert "export_sandbox_file" in result["content"]
 
     @pytest.mark.asyncio
     async def test_read_bytes_utf8_decodable(self):

--- a/services/worker-service/tools/definitions.py
+++ b/services/worker-service/tools/definitions.py
@@ -15,7 +15,7 @@ from tools.calculator import MAX_EXPRESSION_LENGTH, evaluate_expression
 from tools.providers.search import DuckDuckGoSearchProvider, SearchProvider, SearchResult
 from tools.read_url import ReadUrlFetcher
 from tools.runtime_logging import get_tools_logger
-from tools.upload_artifact import UploadArtifactArguments, UploadArtifactResult
+from tools.upload_artifact import CreateTextArtifactArguments, CreateTextArtifactResult
 from tools.sandbox_tools import (
     SandboxExecArguments,
     SandboxExecResult,
@@ -23,8 +23,8 @@ from tools.sandbox_tools import (
     SandboxReadFileResult,
     SandboxWriteFileArguments,
     SandboxWriteFileResult,
-    SandboxDownloadArguments,
-    SandboxDownloadResult,
+    ExportSandboxFileArguments,
+    ExportSandboxFileResult,
 )
 
 
@@ -183,11 +183,11 @@ DEV_SLEEP_TOOL = ToolDefinition(
     input_model=DevSleepArguments,
     output_model=DevSleepResult,
 )
-UPLOAD_ARTIFACT_TOOL = ToolDefinition(
-    name="upload_artifact",
-    description="Save content as an output artifact file. The file will be available for download via the API after task completion.",
-    input_model=UploadArtifactArguments,
-    output_model=UploadArtifactResult,
+CREATE_TEXT_ARTIFACT_TOOL = ToolDefinition(
+    name="create_text_artifact",
+    description="Create an output artifact from inline text content. The file will be available for download via the API after task completion. Only use this when you need to produce a file from content you composed — if a sandbox is available, write the file there and use export_sandbox_file instead.",
+    input_model=CreateTextArtifactArguments,
+    output_model=CreateTextArtifactResult,
 )
 SANDBOX_EXEC_TOOL = ToolDefinition(
     name="sandbox_exec",
@@ -207,11 +207,11 @@ SANDBOX_WRITE_FILE_TOOL = ToolDefinition(
     input_model=SandboxWriteFileArguments,
     output_model=SandboxWriteFileResult,
 )
-SANDBOX_DOWNLOAD_TOOL = ToolDefinition(
-    name="sandbox_download",
-    description="Download a file from the sandbox and save it as an output artifact. The file will be available via the task artifacts API.",
-    input_model=SandboxDownloadArguments,
-    output_model=SandboxDownloadResult,
+EXPORT_SANDBOX_FILE_TOOL = ToolDefinition(
+    name="export_sandbox_file",
+    description="Export a file from the sandbox and save it as an output artifact. The file will be available via the task artifacts API.",
+    input_model=ExportSandboxFileArguments,
+    output_model=ExportSandboxFileResult,
 )
 
 TOOL_DEFINITIONS = (WEB_SEARCH_TOOL, READ_URL_TOOL, CALCULATOR_TOOL)

--- a/services/worker-service/tools/sandbox_tools.py
+++ b/services/worker-service/tools/sandbox_tools.py
@@ -150,7 +150,7 @@ def create_sandbox_read_file_fn(sandbox):
                 try:
                     content = content.decode("utf-8")
                 except UnicodeDecodeError:
-                    content = f"[Binary file: {len(content)} bytes. Use sandbox_download to retrieve binary files.]"
+                    content = f"[Binary file: {len(content)} bytes. Use export_sandbox_file to retrieve binary files.]"
 
             logger.info(
                 "sandbox_read_file_completed",
@@ -263,15 +263,15 @@ def create_sandbox_write_file_fn(sandbox):
     return sandbox_write_file
 
 
-# --- sandbox_download ---
+# --- export_sandbox_file ---
 
-class SandboxDownloadArguments(BaseModel):
+class ExportSandboxFileArguments(BaseModel):
     path: Annotated[
         str,
         Field(
             min_length=1,
             max_length=1000,
-            description="Path in the sandbox filesystem to download as an output artifact.",
+            description="Path in the sandbox filesystem to export as an output artifact.",
         ),
     ]
     filename: Annotated[
@@ -284,14 +284,21 @@ class SandboxDownloadArguments(BaseModel):
     ] = None
 
 
-class SandboxDownloadResult(BaseModel):
+# Keep old name as alias for backward compatibility in tests
+SandboxDownloadArguments = ExportSandboxFileArguments
+
+
+class ExportSandboxFileResult(BaseModel):
     filename: str
     size_bytes: int
     content_type: str
 
 
-def create_sandbox_download_fn(sandbox, *, s3_client, pool, task_id: str, tenant_id: str):
-    """Create the sandbox_download async function with dependencies bound via closure.
+SandboxDownloadResult = ExportSandboxFileResult
+
+
+def create_export_sandbox_file_fn(sandbox, *, s3_client, pool, task_id: str, tenant_id: str):
+    """Create the export_sandbox_file async function with dependencies bound via closure.
 
     Args:
         sandbox: E2B Sandbox instance
@@ -305,7 +312,7 @@ def create_sandbox_download_fn(sandbox, *, s3_client, pool, task_id: str, tenant
     """
     import os
 
-    async def sandbox_download(path: str, filename: str | None = None) -> dict:
+    async def export_sandbox_file(path: str, filename: str | None = None) -> dict:
         start_time = time.monotonic()
         try:
             # 1. Read file from sandbox
@@ -351,7 +358,7 @@ def create_sandbox_download_fn(sandbox, *, s3_client, pool, task_id: str, tenant
             duration_ms = int((time.monotonic() - start_time) * 1000)
 
             logger.info(
-                "sandbox_download_completed",
+                "export_sandbox_file_completed",
                 extra={
                     "sandbox_id": sandbox.sandbox_id,
                     "task_id": task_id,
@@ -372,7 +379,7 @@ def create_sandbox_download_fn(sandbox, *, s3_client, pool, task_id: str, tenant
         except Exception as e:
             duration_ms = int((time.monotonic() - start_time) * 1000)
             logger.error(
-                "sandbox_download_error",
+                "export_sandbox_file_error",
                 extra={
                     "sandbox_id": sandbox.sandbox_id,
                     "task_id": task_id,
@@ -387,4 +394,8 @@ def create_sandbox_download_fn(sandbox, *, s3_client, pool, task_id: str, tenant
                 "content_type": "application/octet-stream",
             }
 
-    return sandbox_download
+    return export_sandbox_file
+
+
+# Keep old factory name as alias for backward compatibility
+create_sandbox_download_fn = create_export_sandbox_file_fn

--- a/services/worker-service/tools/upload_artifact.py
+++ b/services/worker-service/tools/upload_artifact.py
@@ -1,4 +1,4 @@
-"""upload_artifact built-in tool — allows agents to produce output files."""
+"""create_text_artifact built-in tool — allows agents to produce output files from inline content."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ MAX_FILENAME_LENGTH = 255
 MAX_CONTENT_TYPE_LENGTH = 100
 
 
-class UploadArtifactArguments(BaseModel):
+class CreateTextArtifactArguments(BaseModel):
     filename: Annotated[
         str,
         Field(
@@ -43,13 +43,20 @@ class UploadArtifactArguments(BaseModel):
     ]
 
 
-class UploadArtifactResult(BaseModel):
+# Keep old names as aliases for backward compatibility
+UploadArtifactArguments = CreateTextArtifactArguments
+
+
+class CreateTextArtifactResult(BaseModel):
     filename: str
     size_bytes: int
     content_type: str
 
 
-async def execute_upload_artifact(
+UploadArtifactResult = CreateTextArtifactResult
+
+
+async def execute_create_text_artifact(
     *,
     filename: str,
     content: str,
@@ -59,7 +66,7 @@ async def execute_upload_artifact(
     task_id: str,
     tenant_id: str,
 ) -> dict:
-    """Execute the upload_artifact tool."""
+    """Execute the create_text_artifact tool."""
     # Encode content to bytes
     data = content.encode("utf-8")
     size_bytes = len(data)
@@ -80,7 +87,7 @@ async def execute_upload_artifact(
     )
 
     logger.info(
-        "upload_artifact_started",
+        "create_text_artifact_started",
         task_id=task_id,
         tenant_id=tenant_id,
         filename=filename,
@@ -114,7 +121,7 @@ async def execute_upload_artifact(
         )
 
     logger.info(
-        "upload_artifact_completed",
+        "create_text_artifact_completed",
         task_id=task_id,
         tenant_id=tenant_id,
         filename=filename,
@@ -126,3 +133,7 @@ async def execute_upload_artifact(
         "size_bytes": size_bytes,
         "content_type": content_type,
     }
+
+
+# Keep old name as alias for backward compatibility
+execute_upload_artifact = execute_create_text_artifact

--- a/tests/backend-integration/helpers/mock_llm.py
+++ b/tests/backend-integration/helpers/mock_llm.py
@@ -148,22 +148,26 @@ def dev_sleep_tool_call(seconds: int = 10, final_answer: str = "done after sleep
     return mock
 
 
-def upload_artifact_call(filename: str, content: str, content_type: str = "text/plain",
-                         final_answer: str = "Artifact uploaded successfully.") -> MagicMock:
-    """Create a mock LLM that calls upload_artifact, then responds with a final answer."""
+def create_text_artifact_call(filename: str, content: str, content_type: str = "text/plain",
+                              final_answer: str = "Artifact created successfully.") -> MagicMock:
+    """Create a mock LLM that calls create_text_artifact, then responds with a final answer."""
     call_msg = AIMessage(
         content="",
         tool_calls=[ToolCall(
-            name="upload_artifact",
+            name="create_text_artifact",
             args={
                 "filename": filename,
                 "content": content,
                 "content_type": content_type,
             },
-            id="call_upload_artifact",
+            id="call_create_text_artifact",
         )],
     )
     final_msg = AIMessage(content=final_answer)
     mock = _new_mock()
     mock.ainvoke = AsyncMock(side_effect=[call_msg, final_msg])
     return mock
+
+
+# Keep old name as alias for backward compatibility
+upload_artifact_call = create_text_artifact_call

--- a/tests/backend-integration/test_artifacts.py
+++ b/tests/backend-integration/test_artifacts.py
@@ -1,25 +1,25 @@
 """Integration tests for Track 1: Output Artifact Storage.
 
 Tests the end-to-end artifact flow:
-1. Agent calls upload_artifact tool during task execution
+1. Agent calls create_text_artifact tool during task execution
 2. Artifact metadata appears in list endpoint
 3. Artifact file can be downloaded with correct content
 """
 
 import pytest
 
-from helpers.mock_llm import upload_artifact_call, simple_response
+from helpers.mock_llm import create_text_artifact_call, simple_response
 
 
 @pytest.mark.asyncio
 async def test_upload_and_list_artifact(e2e):
-    """Agent uploads an artifact via upload_artifact tool.
+    """Agent uploads an artifact via create_text_artifact tool.
     Verify it appears in the artifact list endpoint."""
 
     artifact_content = "# Analysis Report\n\nThis is a test report.\n"
     artifact_filename = "report.md"
 
-    e2e.use_llm(upload_artifact_call(
+    e2e.use_llm(create_text_artifact_call(
         filename=artifact_filename,
         content=artifact_content,
         content_type="text/markdown",
@@ -32,7 +32,7 @@ async def test_upload_and_list_artifact(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["upload_artifact"],
+        "allowed_tools": ["create_text_artifact"],
     })
 
     task_id = e2e.submit_task(input="Write a short analysis report.")
@@ -59,7 +59,7 @@ async def test_download_artifact_content(e2e):
     artifact_content = "col1,col2,col3\n1,2,3\n4,5,6\n"
     artifact_filename = "data.csv"
 
-    e2e.use_llm(upload_artifact_call(
+    e2e.use_llm(create_text_artifact_call(
         filename=artifact_filename,
         content=artifact_content,
         content_type="text/csv",
@@ -71,7 +71,7 @@ async def test_download_artifact_content(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["upload_artifact"],
+        "allowed_tools": ["create_text_artifact"],
     })
 
     task_id = e2e.submit_task(input="Generate a CSV file.")
@@ -140,7 +140,7 @@ async def test_list_artifacts_with_direction_filter(e2e):
 
     artifact_content = "Test content"
 
-    e2e.use_llm(upload_artifact_call(
+    e2e.use_llm(create_text_artifact_call(
         filename="filtered.txt",
         content=artifact_content,
         content_type="text/plain",
@@ -152,7 +152,7 @@ async def test_list_artifacts_with_direction_filter(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["upload_artifact"],
+        "allowed_tools": ["create_text_artifact"],
     })
 
     task_id = e2e.submit_task(input="Create a text file.")

--- a/tests/e2e-langfuse/test_langfuse_e2e.py
+++ b/tests/e2e-langfuse/test_langfuse_e2e.py
@@ -118,7 +118,7 @@ async def test_traces_published_to_langfuse(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["web_search", "read_url", "upload_artifact", "request_human_input"],
+        "allowed_tools": ["web_search", "read_url", "create_text_artifact", "request_human_input"],
     })
     task_id = e2e.submit_task(
         input="Say hello for trace verification",
@@ -153,7 +153,7 @@ async def test_task_without_langfuse_completes_with_cost(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["web_search", "read_url", "upload_artifact", "request_human_input"],
+        "allowed_tools": ["web_search", "read_url", "create_text_artifact", "request_human_input"],
     })
     task_id = e2e.submit_task(
         input="Hello without observability",
@@ -200,7 +200,7 @@ async def test_bad_credentials_task_still_completes(e2e):
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "temperature": 0.5,
-        "allowed_tools": ["web_search", "read_url", "upload_artifact", "request_human_input"],
+        "allowed_tools": ["web_search", "read_url", "create_text_artifact", "request_human_input"],
     })
     task_id = e2e.submit_task(
         input="Test graceful degradation",


### PR DESCRIPTION
## Summary
- Renames `upload_artifact` → `create_text_artifact` and `sandbox_download` → `export_sandbox_file` for clearer tool semantics
- When a sandbox is available, `create_text_artifact` is no longer offered to the agent — only `export_sandbox_file` is available, which routes content directly from sandbox to S3 without passing through the LLM context window
- This prevents agents from accidentally bloating the context window by sending file content inline when the efficient sandbox→S3 path exists

## Motivation
Observed a task that used `upload_artifact` to re-upload files already in the sandbox, causing input tokens to grow from 18k to 27k per call. The old tool names were also confusing — `upload_artifact` sounded like the general "upload a file" tool, and `sandbox_download` sounded like downloading to the user's machine.

## Test plan
- [x] Worker-service unit tests: 63 passed, 2 skipped
- [x] Executor tests: 64 passed
- [x] Java API service compiles and tests pass
- [x] Backward-compat aliases in place for old class/function names used by tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)