### PR TITLE
Gate cost-ledger writes on lease ownership to close eviction race

### DIFF
--- a/docs/design-docs/phase-3-plus/design-notes.md
+++ b/docs/design-docs/phase-3-plus/design-notes.md
@@ -252,3 +252,43 @@ Allow agents to specify an expected JSON output schema:
 - **Batch:** when customers need to process large volumes of similar tasks (document processing, data extraction)
 - **Webhooks:** when polling becomes impractical (high task volume, downstream automation)
 - **Structured output:** when customers need machine-readable results for pipeline integration
+
+---
+
+## 11. Lease Race Hardening Under Load
+
+Follow-ups to the lease-CAS work already in place on cost-ledger writes, checkpoint writes, and task state transitions. All the items below are load-triggered: they don't bite until worker concurrency or DB contention crosses a threshold we haven't hit yet. The theme is: instrument first, fix second.
+
+### 11.1 Heartbeat pool isolation
+
+**Risk.** `HeartbeatManager` and the `GraphExecutor` share the same `asyncpg.Pool`. Under heavy worker concurrency or slow DB writes, executor transactions can hold all connections long enough for the heartbeat's `pool.acquire()` to miss its window. The scheduler then evicts a healthy worker — a false-positive lease revocation that forces an unnecessary handoff and duplicates any mid-flight work.
+
+**Planned approach.**
+1. Add a structured warning log and a `heartbeat.acquire_wait_ms` gauge at `core/heartbeat.py` when acquire latency exceeds a fraction of `heartbeat_interval_seconds`.
+2. If the metric shows the symptom under real load, give `HeartbeatManager` its own 1–2 connection pool at worker startup. Mechanically small (additive constructor arg); the reason to defer is sizing and Postgres `max_connections` budgeting at fleet scale.
+
+**Trigger conditions.** Observed false-positive evictions correlated with pool saturation, or onboarding a customer whose concurrency projection pushes worker pool sizing beyond current defaults.
+
+### 11.2 Pre-action lease check for high-stakes tools
+
+**Risk.** Between a heartbeat miss and the executor noticing the `cancel_event`, an in-flight tool call will run to completion. For idempotent tools that's fine — the new owner replays the step and nothing is double-counted. For tools with unrecoverable external effects (send email, charge card, webhook POST) the evicted worker's call is a duplicate side effect.
+
+**Planned approach.** Extend the tool schema with an `idempotent: true | false` flag (tracked in Section 9). For tools declared non-idempotent, the executor performs an explicit `SELECT lease_expiry, lease_owner` immediately before firing the call and aborts if the lease is already gone or within a small safety margin. This dramatically shrinks the race window without touching the global lease duration. This is *complementary* to the dead-letter-on-crash approach in Section 9, not a replacement.
+
+**Trigger conditions.** First customer registering a BYOT tool with unrecoverable side effects. Until then the platform keeps its "idempotent tools only" contract.
+
+### 11.3 Metrics export
+
+**Risk.** `MetricsCollector` at `core/logging.py` collects counters and gauges in-process but there is no exporter wired up — only structured JSON logs reach operators. Any leading-indicator metric we add today (e.g., 11.1's acquire-wait gauge) is invisible until an exporter exists.
+
+**Planned approach.** Add an OpenTelemetry exporter (OTLP → Prometheus or hosted collector) at worker startup. A few hours of work; deferred because the log-based observability story is sufficient for current scale.
+
+**Trigger conditions.** First real operational use that requires dashboards or alerts on worker health (paid customer SLAs, on-call rotation).
+
+### 11.4 Idempotency keys on the tool protocol
+
+**Risk.** Even with 11.2's pre-action check, a tool call initiated in the final milliseconds before eviction can reach the downstream service twice (once from evicted worker, once from new owner's replay). A protocol-level idempotency key would let the downstream service dedupe.
+
+**Planned approach.** Every tool call carries `(task_id, checkpoint_id, tool_call_id)` as an idempotency key in the tool invocation contract. MCP clients and the built-in tool runtime forward it to the downstream service as an `Idempotency-Key` header or equivalent. Cross-service change; document before implementing.
+
+**Trigger conditions.** Sufficient non-idempotent-tool volume that duplicate side effects (from the narrow remaining race window) become a real operational concern.

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -517,15 +517,36 @@ class GraphExecutor:
         self, conn, task_id: str, tenant_id: str, agent_id: str,
         checkpoint_id: str, cost_microdollars: int,
         execution_metadata: dict | None = None,
+        *,
+        worker_id: str,
     ) -> tuple:
         """Record step cost in a single transaction.
 
-        1. Update checkpoints.cost_microdollars and execution_metadata for the given checkpoint_id
-        2. INSERT into agent_cost_ledger
-        3. UPSERT agent_runtime_state.hour_window_cost_microdollars (increment)
-        4. Return (cumulative_task_cost, hourly_window_cost)
+        Gated on the worker still owning the task lease. If the lease has been
+        revoked or reassigned (heartbeat missed → scheduler evicted this worker)
+        the function raises LeaseRevokedException without writing anything. Must
+        be called inside an active transaction on `conn`.
+
+        1. Validate lease (SELECT ... FOR UPDATE on tasks)
+        2. Update checkpoints.cost_microdollars and execution_metadata for the given checkpoint_id
+        3. INSERT into agent_cost_ledger
+        4. UPSERT agent_runtime_state.hour_window_cost_microdollars (increment)
+        5. Return (cumulative_task_cost, hourly_window_cost)
         """
-        # 1. Update the checkpoint with the step cost and execution metadata
+        lease_ok = await conn.fetchval(
+            '''SELECT 1 FROM tasks
+               WHERE task_id = $1::uuid
+                 AND tenant_id = $2
+                 AND status = 'running'
+                 AND lease_owner = $3
+               FOR UPDATE''',
+            task_id, tenant_id, worker_id,
+        )
+        if lease_ok is None:
+            raise LeaseRevokedException(
+                f"Lease revoked before cost write for task {task_id}"
+            )
+
         import json as _json
         await conn.execute(
             '''UPDATE checkpoints
@@ -1074,30 +1095,49 @@ class GraphExecutor:
                                                         cumulative_task_cost, hourly_cost = await self._record_step_cost(
                                                             cost_conn, task_id, tenant_id, agent_id, checkpoint_id, step_cost,
                                                             execution_metadata=execution_metadata,
+                                                            worker_id=worker_id,
                                                         )
                                                     logger.debug(
                                                         "Task %s step cost: %d microdollars (cumulative: %d, hourly: %d)",
                                                         task_id, step_cost, cumulative_task_cost, hourly_cost,
                                                     )
+                                                except LeaseRevokedException:
+                                                    raise
                                                 except Exception:
                                                     logger.warning("Per-step cost recording failed for task %s", task_id, exc_info=True)
                                                     cumulative_task_cost = 0
                                             else:
                                                 # Cost is zero (unknown model or rounding), but still persist token metadata
                                                 try:
-                                                    await cost_conn.execute(
-                                                        '''UPDATE checkpoints
-                                                           SET execution_metadata = $1::jsonb
-                                                           WHERE checkpoint_id = $2
-                                                             AND task_id = $3::uuid''',
-                                                        json.dumps(execution_metadata),
-                                                        checkpoint_id,
-                                                        task_id,
-                                                    )
+                                                    async with cost_conn.transaction():
+                                                        lease_ok = await cost_conn.fetchval(
+                                                            '''SELECT 1 FROM tasks
+                                                               WHERE task_id = $1::uuid
+                                                                 AND tenant_id = $2
+                                                                 AND status = 'running'
+                                                                 AND lease_owner = $3
+                                                               FOR UPDATE''',
+                                                            task_id, tenant_id, worker_id,
+                                                        )
+                                                        if lease_ok is None:
+                                                            raise LeaseRevokedException(
+                                                                f"Lease revoked before metadata write for task {task_id}"
+                                                            )
+                                                        await cost_conn.execute(
+                                                            '''UPDATE checkpoints
+                                                               SET execution_metadata = $1::jsonb
+                                                               WHERE checkpoint_id = $2
+                                                                 AND task_id = $3::uuid''',
+                                                            json.dumps(execution_metadata),
+                                                            checkpoint_id,
+                                                            task_id,
+                                                        )
                                                     logger.debug(
                                                         "Task %s step cost: 0 microdollars (metadata persisted)",
                                                         task_id,
                                                     )
+                                                except LeaseRevokedException:
+                                                    raise
                                                 except Exception:
                                                     logger.warning("Execution metadata write failed for task %s", task_id, exc_info=True)
                                                 cumulative_task_cost = 0

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -1177,6 +1177,11 @@ class GraphExecutor:
                                                         await provisioner.pause(sandbox)
                                                         sandbox = None  # Prevent double-destroy in finally
                                                     return  # Stop execution — task is now paused
+                                except LeaseRevokedException:
+                                    # Propagate to the outer astream handler so the evicted worker
+                                    # stops all further model/tool work instead of silently eating
+                                    # the lease check and continuing the loop.
+                                    raise
                                 except Exception:
                                     logger.warning("Per-step cost tracking failed for task %s", task_id, exc_info=True)
 

--- a/services/worker-service/tests/test_cost_ledger_integration.py
+++ b/services/worker-service/tests/test_cost_ledger_integration.py
@@ -1,0 +1,218 @@
+"""Integration tests for lease-CAS gating of cost-ledger writes.
+
+Covers the race where a worker's heartbeat has missed and its lease was
+stripped, but it is still mid-flight recording step cost. Without a lease
+check the evicted worker would charge tokens for a task it no longer owns.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from checkpointer.postgres import LeaseRevokedException
+from core.config import WorkerConfig
+from executor.graph import GraphExecutor
+
+
+DB_DSN = os.getenv(
+    "E2E_DB_DSN",
+    "postgresql://postgres:postgres@localhost:55433/persistent_agent_runtime_e2e",
+)
+
+TENANT_ID = "default"
+AGENT_ID = "cost-ledger-test-agent"
+WORKER_A = "worker-a"
+WORKER_B = "worker-b"
+
+
+@pytest.fixture
+async def integration_pool():
+    try:
+        pool = await asyncpg.create_pool(DB_DSN, min_size=1, max_size=2)
+    except Exception as exc:
+        pytest.skip(f"PostgreSQL test database is not available: {exc}")
+
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM agent_cost_ledger")
+        await conn.execute("DELETE FROM agent_runtime_state")
+        await conn.execute("DELETE FROM task_events")
+        await conn.execute("DELETE FROM checkpoint_writes")
+        await conn.execute("DELETE FROM checkpoints")
+        await conn.execute("DELETE FROM tasks")
+        await conn.execute("DELETE FROM agents")
+
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _seed_task_with_checkpoint(
+    pool: asyncpg.Pool,
+    *,
+    task_id: str,
+    checkpoint_id: str,
+    lease_owner: str | None = WORKER_A,
+) -> None:
+    agent_config = {
+        "system_prompt": "test",
+        "model": "claude-sonnet-4-6",
+        "temperature": 0.1,
+        "allowed_tools": [],
+    }
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO agents (tenant_id, agent_id, display_name, agent_config, status)
+            VALUES ($1, $2, 'Test Agent', $3::jsonb, 'active')
+            ON CONFLICT (tenant_id, agent_id) DO NOTHING
+            """,
+            TENANT_ID, AGENT_ID, json.dumps(agent_config),
+        )
+        await conn.execute(
+            """
+            INSERT INTO tasks (
+                task_id, tenant_id, agent_id, agent_config_snapshot,
+                status, input, lease_owner, lease_expiry, version
+            ) VALUES ($1::uuid, $2, $3, $4::jsonb, 'running', 'input', $5,
+                      NOW() + INTERVAL '60 seconds', 1)
+            """,
+            task_id, TENANT_ID, AGENT_ID, json.dumps(agent_config), lease_owner,
+        )
+        await conn.execute(
+            """
+            INSERT INTO checkpoints (
+                task_id, checkpoint_ns, checkpoint_id, worker_id, thread_ts,
+                checkpoint_payload, metadata_payload
+            ) VALUES ($1::uuid, '', $2, $3, '2026-04-16T00:00:00Z',
+                      '{}'::jsonb, '{}'::jsonb)
+            """,
+            task_id, checkpoint_id, WORKER_A,
+        )
+
+
+def _make_executor(pool: asyncpg.Pool) -> GraphExecutor:
+    config = WorkerConfig(worker_id=WORKER_A)
+    return GraphExecutor(config, pool)
+
+
+@pytest.mark.asyncio
+async def test_record_step_cost_succeeds_when_lease_is_held(
+    integration_pool: asyncpg.Pool,
+) -> None:
+    task_id = str(uuid.uuid4())
+    checkpoint_id = "cp-happy"
+    await _seed_task_with_checkpoint(
+        integration_pool, task_id=task_id, checkpoint_id=checkpoint_id
+    )
+
+    executor = _make_executor(integration_pool)
+    async with integration_pool.acquire() as conn:
+        async with conn.transaction():
+            cumulative, hourly = await executor._record_step_cost(
+                conn, task_id, TENANT_ID, AGENT_ID, checkpoint_id, 1000,
+                execution_metadata={"input_tokens": 10, "output_tokens": 5},
+                worker_id=WORKER_A,
+            )
+
+    assert cumulative == 1000
+    assert hourly == 1000
+
+    async with integration_pool.acquire() as conn:
+        ledger_rows = await conn.fetch(
+            "SELECT cost_microdollars FROM agent_cost_ledger WHERE task_id=$1::uuid",
+            task_id,
+        )
+        cp_cost = await conn.fetchval(
+            "SELECT cost_microdollars FROM checkpoints WHERE task_id=$1::uuid",
+            task_id,
+        )
+
+    assert [r["cost_microdollars"] for r in ledger_rows] == [1000]
+    assert cp_cost == 1000
+
+
+@pytest.mark.asyncio
+async def test_record_step_cost_rejects_when_lease_revoked(
+    integration_pool: asyncpg.Pool,
+) -> None:
+    task_id = str(uuid.uuid4())
+    checkpoint_id = "cp-revoked"
+    await _seed_task_with_checkpoint(
+        integration_pool, task_id=task_id, checkpoint_id=checkpoint_id
+    )
+
+    async with integration_pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE tasks SET lease_owner = NULL WHERE task_id = $1::uuid",
+            task_id,
+        )
+
+    executor = _make_executor(integration_pool)
+    with pytest.raises(LeaseRevokedException):
+        async with integration_pool.acquire() as conn:
+            async with conn.transaction():
+                await executor._record_step_cost(
+                    conn, task_id, TENANT_ID, AGENT_ID, checkpoint_id, 1000,
+                    execution_metadata={"input_tokens": 10, "output_tokens": 5},
+                    worker_id=WORKER_A,
+                )
+
+    async with integration_pool.acquire() as conn:
+        ledger_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM agent_cost_ledger WHERE task_id=$1::uuid",
+            task_id,
+        )
+        cp_cost = await conn.fetchval(
+            "SELECT cost_microdollars FROM checkpoints WHERE task_id=$1::uuid",
+            task_id,
+        )
+        hourly = await conn.fetchval(
+            "SELECT hour_window_cost_microdollars FROM agent_runtime_state "
+            "WHERE tenant_id=$1 AND agent_id=$2",
+            TENANT_ID, AGENT_ID,
+        )
+
+    assert ledger_count == 0, "evicted worker must not insert cost ledger rows"
+    assert cp_cost == 0, "evicted worker must not update checkpoint cost"
+    assert hourly in (None, 0), "evicted worker must not bump agent_runtime_state"
+
+
+@pytest.mark.asyncio
+async def test_record_step_cost_rejects_when_lease_reassigned(
+    integration_pool: asyncpg.Pool,
+) -> None:
+    task_id = str(uuid.uuid4())
+    checkpoint_id = "cp-reassigned"
+    await _seed_task_with_checkpoint(
+        integration_pool, task_id=task_id, checkpoint_id=checkpoint_id
+    )
+
+    async with integration_pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE tasks SET lease_owner = $1 WHERE task_id = $2::uuid",
+            WORKER_B, task_id,
+        )
+
+    executor = _make_executor(integration_pool)
+    with pytest.raises(LeaseRevokedException):
+        async with integration_pool.acquire() as conn:
+            async with conn.transaction():
+                await executor._record_step_cost(
+                    conn, task_id, TENANT_ID, AGENT_ID, checkpoint_id, 1000,
+                    execution_metadata={"input_tokens": 10, "output_tokens": 5},
+                    worker_id=WORKER_A,
+                )
+
+    async with integration_pool.acquire() as conn:
+        ledger_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM agent_cost_ledger WHERE task_id=$1::uuid",
+            task_id,
+        )
+
+    assert ledger_count == 0

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -261,6 +261,94 @@ async def test_execute_task_persists_checkpoint_cost(mock_worker, task_data):
 
 
 @pytest.mark.asyncio
+async def test_lease_revoked_during_cost_tracking_stops_execution(mock_worker, task_data):
+    """Regression: LeaseRevokedException from _record_step_cost must propagate
+    past the cost-tracking block's outer `except Exception`, not be swallowed.
+
+    Without the explicit `except LeaseRevokedException: raise` guard before the
+    generic handler, an evicted worker would log the failure and continue running
+    subsequent super-steps — defeating the lease gate and producing duplicate
+    external side effects.
+    """
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+
+    with patch.object(executor, "_build_graph") as mock_build:
+        mock_graph = MagicMock()
+        mock_compiled = AsyncMock()
+        mock_graph.compile.return_value = mock_compiled
+        mock_build.return_value = mock_graph
+
+        with patch("executor.graph.PostgresDurableCheckpointer") as MockCheckpointer:
+            mock_ckpt = AsyncMock()
+            mock_ckpt.aget_tuple.return_value = None
+            MockCheckpointer.return_value = mock_ckpt
+
+            # Build AI messages for two super-steps; after the first one raises
+            # LeaseRevokedException the second must NOT be processed.
+            def _make_msg():
+                msg = MagicMock()
+                msg.type = "ai"
+                msg.content = "partial"
+                msg.response_metadata = {"usage": {"input_tokens": 10, "output_tokens": 5}}
+                return msg
+
+            events_yielded = 0
+
+            async def mock_astream(*args, **kwargs):
+                nonlocal events_yielded
+                events_yielded += 1
+                yield {"agent": {"messages": [_make_msg()]}}
+                events_yielded += 1
+                yield {"agent": {"messages": [_make_msg()]}}
+
+            mock_compiled.astream = mock_astream
+            mock_state = MagicMock()
+            mock_state.values = {"messages": []}
+            mock_state.tasks = []
+            mock_compiled.aget_state.return_value = mock_state
+
+            with patch.object(
+                executor,
+                "_calculate_step_cost",
+                new_callable=AsyncMock,
+                return_value=(150, {"input_tokens": 10, "output_tokens": 5, "model": "claude-3-5-sonnet-latest"}),
+            ):
+                with patch.object(
+                    executor,
+                    "_record_step_cost",
+                    new_callable=AsyncMock,
+                    side_effect=LeaseRevokedException("lease stripped"),
+                ) as mock_record:
+                    # execute_task must not raise: the top-level
+                    # `except LeaseRevokedException` catches and stops gracefully.
+                    await executor.execute_task(
+                        task_data,
+                        mock_worker.heartbeat.start_heartbeat.return_value.cancel_event,
+                    )
+
+                    # _record_step_cost was called once (on the first event) and raised.
+                    assert mock_record.call_count == 1
+
+            # Only the first super-step yielded; astream was abandoned after the
+            # exception instead of running through both events.
+            assert events_yielded == 1, (
+                f"astream processed {events_yielded} events; expected 1 before bailing"
+            )
+
+            # Completion UPDATE must NOT have been issued — the evicted worker
+            # cannot mark the task completed.
+            mock_conn = mock_worker.pool.acquire.return_value.__aenter__.return_value
+            fetchval_calls = mock_conn.fetchval.call_args_list
+            completion_calls = [
+                c for c in fetchval_calls
+                if "UPDATE tasks" in str(c) and "status='completed'" in str(c)
+            ]
+            assert len(completion_calls) == 0, (
+                "evicted worker must not issue completion UPDATE after LeaseRevokedException"
+            )
+
+
+@pytest.mark.asyncio
 async def test_timeout_dead_letter(mock_worker, task_data):
     executor = GraphExecutor(mock_worker.config, mock_worker.pool)
     task_data["task_timeout_seconds"] = 1


### PR DESCRIPTION
## Summary

The cost-recording path between LangGraph super-steps was not lease-gated. A worker whose lease had been stripped (heartbeat missed → scheduler eviction) could still write to `agent_cost_ledger`, bump `agent_runtime_state.hour_window_cost_microdollars`, and update `checkpoints.cost_microdollars` while a new owner was already executing the same step. Result: **duplicated billing** and a **corrupted hourly budget window**.

Mirrors the pattern `PostgresDurableCheckpointer` already uses — `SELECT 1 ... FOR UPDATE` on `tasks` inside the same transaction as the writes, raising `LeaseRevokedException` when the check fails. The existing handler at the astream loop catches it and exits gracefully.

- Applies to `_record_step_cost` and the zero-cost execution-metadata UPDATE path
- Pause-path inline INSERTs at [graph.py:1124](services/worker-service/executor/graph.py#L1124) / [1186](services/worker-service/executor/graph.py#L1186) intentionally unchanged — they only run after the CAS inside `_check_budget_and_pause` / `_handle_interrupt_from_state` succeeds, so they're already protected

Also adds Section 11 to the Phase 3+ design notes documenting remaining load-triggered hardening items (heartbeat pool isolation, pre-action lease check for non-idempotent tools, metrics export, tool-protocol idempotency keys) with trigger conditions.

## Test plan

- [x] 3 new integration tests in `test_cost_ledger_integration.py`: happy path, lease revoked, lease reassigned
- [x] Full worker test suite: `make worker-test` — 399 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)