### PR TITLE
Propose Agent Capabilities Track 3: coding-agent primitives (design only)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -24,7 +24,7 @@ Bird's-eye view of where the project stands. For navigation and structure, see [
 | Initiative | Status | Design |
 |------------|--------|--------|
 | Langfuse Customer Integration | Complete | [plan](docs/exec-plans/completed/langfuse/plan.md) |
-| Agent Capabilities (sandbox, artifacts, file input) | Complete | [design](docs/design-docs/agent-capabilities/design.md) |
+| Agent Capabilities (sandbox, artifacts, file input, coding primitives) | Tracks 1 & 2 complete; Track 3 proposed | [design](docs/design-docs/agent-capabilities/design.md) |
 
 #### Agent Capabilities Tracks
 
@@ -32,3 +32,4 @@ Bird's-eye view of where the project stands. For navigation and structure, see [
 |-------|------|--------|------|----------|
 | Track 1 | Output Artifact Storage | Complete | [plan](docs/exec-plans/completed/agent-capabilities/track-1/plan.md) | [progress](docs/exec-plans/completed/agent-capabilities/track-1/progress.md) |
 | Track 2 | E2B Sandbox & File Input | Complete | [plan](docs/exec-plans/completed/agent-capabilities/track-2/plan.md) | [progress](docs/exec-plans/completed/agent-capabilities/track-2/progress.md) |
+| Track 3 | Coding-Agent Primitives | Proposed (design only) | — | — |

--- a/docs/design-docs/agent-capabilities/design.md
+++ b/docs/design-docs/agent-capabilities/design.md
@@ -325,7 +325,7 @@ The API service (Java/Spring Boot) needs these changes:
 
 ## Implementation Tracks
 
-Implementation is split into two sequential tracks. Track 2 depends on Track 1.
+Tracks 1 and 2 are complete and delivered the sandbox + artifact foundation. Track 3 (proposed) extends the sandbox tool surface with coding-agent primitives and depends on Track 2.
 
 ### Track 1 — Output Artifact Storage
 
@@ -362,11 +362,90 @@ Delivers sandbox code execution and file input. Agents can receive files, execut
 
 **Exec plan:** `docs/exec-plans/completed/agent-capabilities/track-2/`
 
+### Track 3 — Coding-Agent Primitives (proposed)
+
+Extends the sandbox tool surface so agents doing real iterative coding (edit → run test → read stack trace → edit again) can work without blowing through the context window on every turn. The Track 2 tools are sufficient to "run a script"; Track 3 is what makes "iterate on a codebase" practical. Depends on Track 2.
+
+**Scope boundary:** This track is strictly in-sandbox tooling. Phase 2 Track 6 (GitHub Integration) owns the repo ingress/egress story — `git clone` at task start, branch push, PR creation. Track 3 does not duplicate any of that; agents can still `sandbox_exec("git clone ...")` in the meantime.
+
+#### Motivation
+
+Observed gaps with the Track 2 tool set, each exercised many times per coding turn:
+
+1. **No surgical edit.** Every file change requires `sandbox_write_file` with the full new contents. For a 2k-line file, that's ~8k tokens per change, and long edit sessions drift — the LLM silently mutates unrelated code.
+2. **No partial file read.** `sandbox_read_file` returns the whole file. Reading a 10k-line file to locate one stack frame costs ~40k tokens.
+3. **No first-class search.** Agents fall back to `sandbox_exec("rg ...")`, which wraps the search in shell scaffolding, loses structured output, and has no cap on how much ripgrep can dump into the context.
+4. **No background processes.** `sandbox_exec` is blocking. Agents can't start a dev server and then run tests against it, tail logs while work continues, or run a long-running suite without holding the tool slot.
+5. **No output truncation.** A failing webpack build emits 50 MB of stderr. One bad run can evict the entire recent context.
+
+Each of these is individually cheap to close; the impact is multiplicative because coding agents hit every one of them within a single turn.
+
+#### New tools
+
+| Tool | Description |
+|------|-------------|
+| `sandbox_edit` | Exact-string replacement in a file. Inputs: `path`, `old_string`, `new_string`, optional `replace_all` (default false). Fails when `old_string` is non-unique and `replace_all` is false, when `old_string` is absent, or when `path` doesn't exist. Mirrors Claude Code's Edit. |
+| `sandbox_grep` | Ripgrep-backed content search. Inputs: `pattern`, optional `path`, `glob`, `output_mode` (one of `files_with_matches` \| `content` \| `count`; default `files_with_matches`), `head_limit` (default ~250). Output always capped by `head_limit`. |
+| `sandbox_glob` | Glob-style file path match, sorted by mtime (most recent first). Inputs: `pattern`, optional `path`, `head_limit`. |
+| `sandbox_process_read` | Read accumulated stdout/stderr from a backgrounded process by `process_id`. Returns new output since the last read and the process's current running/exited state. Output is truncated to a per-call byte cap. |
+| `sandbox_process_kill` | Terminate a backgrounded process by `process_id`. |
+
+#### Modified tools
+
+| Tool | Change |
+|------|--------|
+| `sandbox_exec` | Add optional `run_in_background` (default false). When true, returns `{process_id, started_at}` immediately instead of blocking; agent retrieves output via `sandbox_process_read`. Add `max_output_bytes` with head/tail/mixed truncation so one noisy command can't destroy the context. |
+| `sandbox_read_file` | Add optional `offset` (1-based line number, default 1) and `limit` (lines, default whole file but capped at a configurable maximum). Response includes total line count so the agent knows when more remains. |
+
+#### Explicitly out of scope
+
+- **`git clone` at task start / GitHub PR tool** — owned by Phase 2 Track 6.
+- **`apply_patch` (multi-file diff apply)** — redundant once `sandbox_edit` ships. Revisit only if agents show need for multi-file atomic edits.
+- **Todo/plan tracking tool** — potentially useful, but not sandbox-coupled; belongs to a separate cross-cutting design.
+- **HTTP/fetch tool with POST/PUT/DELETE** — `sandbox_exec("curl ...")` is adequate. Upgrade only if logs show it's a hot path.
+- **Interactive stdin / TTY / debugger attach** — E2B's process API doesn't cleanly support interactive sessions. Out of scope; revisit if needed.
+
+#### Task sketch
+
+| # | Task | Service | Description |
+|---|------|---------|-------------|
+| 1 | `sandbox_edit` tool | Worker | String-replace with uniqueness check, via `sbx.files.read` / `sbx.files.write` |
+| 2 | `sandbox_read_file` offset/limit | Worker | Extend Track 2 tool with line-range params |
+| 3 | `sandbox_grep` tool | Worker | Wrap `rg` in the sandbox with structured output and `head_limit` truncation |
+| 4 | `sandbox_glob` tool | Worker | Wrap glob + stat, sort by mtime |
+| 5 | `sandbox_exec` output truncation | Worker | Add `max_output_bytes` with head/tail/mixed modes |
+| 6 | `sandbox_exec` background mode | Worker | Add `run_in_background`; return `process_id`; integrate with E2B process API |
+| 7 | `sandbox_process_read` + `sandbox_process_kill` | Worker | Tools that reattach to backgrounded processes by `process_id` |
+| 8 | Sandbox template: install `ripgrep` | Infrastructure | Add `rg` to the platform's E2B template so `sandbox_grep` can rely on it |
+| 9 | Crash-recovery test for backgrounded processes | Cross-service | Verify that on worker crash + reconnect, an agent can still read output from a process launched before the crash (E2B keeps it alive) |
+| 10 | Integration tests | Cross-service | End-to-end coding loop: clone (via exec), edit, grep, run tests, read output |
+
+#### Crash-recovery implications
+
+Background processes introduce per-sandbox state **not** captured in Postgres checkpoints:
+
+- The E2B sandbox persists across worker crashes, and processes inside it keep running. On reconnect, the worker re-attaches to the sandbox by `sandbox_id` (already implemented in Track 2) and to individual processes by their E2B-assigned `process_id`.
+- If the sandbox itself was destroyed (TTL expired during outage), the backgrounded processes die with it — same failure mode as Track 2's sandbox loss; the task dead-letters with `sandbox_lost`.
+- **Idempotency:** if a checkpoint is re-executed after a crash (Phase 1 allows re-running an interrupted in-flight node), an agent's `sandbox_exec(..., run_in_background=True)` call could double-launch the same process. This is the same non-idempotent-tool concern Phase 1 already flags; `sandbox_exec` is already non-idempotent, and background mode does not make it worse. A follow-up in Phase 3 non-idempotent-tool guards would address it alongside the existing foreground case.
+
+#### Template dependency
+
+Ripgrep is not in every E2B template. Options:
+
+- **(A) Pre-install `rg` in the platform's custom E2B template.** Simple, matches the Claude-Code-cloud pattern of pre-baked templates. Preferred.
+- **(B) Auto-fallback to `grep -r` when `rg` is absent.** Keeps the tool usable on third-party templates at the cost of worse output quality and performance.
+
+Track 3 adopts (A) as the default; (B) is a considered fallback if customers pin arbitrary templates.
+
+**Exec plan:** TBD — created after design approval.
+
 ### Track sequencing
 
 Track 1 is self-contained — when complete, agents can produce output artifacts and users can download them. No sandbox concepts leak into Track 1.
 
 Track 2 adds sandbox and file input. It uses Track 1's S3 client for `sandbox_download` and artifact storage for input file injection. The `sandbox_id` column, `dead_letter_reason` extension, sandbox agent config, multipart submission, and file attachment UI all live in Track 2.
+
+Track 3 (proposed) extends the sandbox tool surface. It depends on Track 2's sandbox provisioner, `sandbox_id` persistence, and the existing sandbox tool registration pattern. It is independent of Track 1 (no artifact changes) and independent of Phase 2 Track 6 (GitHub work is strictly repo ingress/egress).
 
 ## Dependencies
 

--- a/docs/design-docs/phase-2/design.md
+++ b/docs/design-docs/phase-2/design.md
@@ -116,11 +116,18 @@ For implementation planning, the safest order is:
 2. Track 2 — Runtime State Model ✅
 3. Track 3 — Scheduler and Budgets ✅
 4. Track 4 — Custom Tool Runtime (BYOT) ✅
-5. **Agent Capabilities (cross-cutting)** — E2B sandbox, artifact storage, file input. See [agent-capabilities/design.md](../agent-capabilities/design.md).
+5. **Agent Capabilities (cross-cutting)** — see [agent-capabilities/design.md](../agent-capabilities/design.md):
+   - AC Track 1 — Output Artifact Storage ✅
+   - AC Track 2 — E2B Sandbox & File Input ✅
+   - **AC Track 3 — Coding-Agent Primitives (proposed; must land before Phase 3)**
 6. Track 5 — Memory
 7. Track 6 — GitHub Integration
 
-Tracks 1–4 are complete. The cross-cutting agent-capabilities work is the next priority. It provides the sandbox and artifact foundation that enables the platform to run real workloads (coding agents, document processing). Tracks 5 and 6 build on a platform that can already do meaningful work.
+Phase 2 Tracks 1–4 and Agent Capabilities Tracks 1 & 2 are complete — the platform can now run coding and document-processing workloads end-to-end with sandbox execution and artifact storage.
+
+**AC Track 3 is gating for Phase 3.** The Track 2 sandbox tool surface is sufficient to run a script but not to iterate on a codebase — every edit re-sends the full file, every search goes through `sandbox_exec` with no output cap, long-running processes block the tool slot. Phase 3 work (batch APIs, webhooks, structured output, scaling) should be built on top of a mature coding-agent tool surface rather than ship on top of token-burning primitives that would then need to be rolled back later. See [agent-capabilities/design.md#track-3-coding-agent-primitives-proposed](../agent-capabilities/design.md) for the detailed proposal.
+
+Tracks 5 (Memory) and 6 (GitHub Integration) can be sequenced alongside AC Track 3 as independent initiatives — they have no blocking dependency in either direction.
 
 ---
 


### PR DESCRIPTION
Design-only proposal for a follow-on agent-capabilities track. No code changes, no exec plan yet — opens the design for review.

## Motivation

The Track 2 sandbox tool surface is sufficient to "run a script" but not to iterate on a codebase. Concrete gaps observed when a coding agent runs through an edit / test / fix loop:

1. **No surgical edit** — every file change requires \`sandbox_write_file\` with the full contents (~8k tokens for a 2k-line file, plus drift risk on long sessions)
2. **No partial file read** — \`sandbox_read_file\` returns whole files; reading a 10k-line file to look at one stack frame costs ~40k tokens
3. **No first-class search** — agents shell out via \`sandbox_exec(\"rg ...\")\` with no output capping
4. **No background processes** — \`sandbox_exec\` is blocking, so agents can't run a dev server + tests concurrently or tail logs while work continues
5. **No output truncation** — one failing build dumping 50 MB of stderr can evict the recent context

Each is cheap to close individually; the impact is multiplicative because coding agents hit every one within a single turn.

## Proposed tools

**New:**

- \`sandbox_edit\` — exact-string replacement with uniqueness check (mirrors Claude Code's Edit)
- \`sandbox_grep\` — ripgrep-backed search with structured output and \`head_limit\` truncation
- \`sandbox_glob\` — glob-style path match sorted by mtime
- \`sandbox_process_read\` — read accumulated output from a backgrounded process by \`process_id\`
- \`sandbox_process_kill\` — terminate a backgrounded process by \`process_id\`

**Modified:**

- \`sandbox_exec\` gains \`run_in_background\` (returns \`process_id\`) and \`max_output_bytes\` with head/tail truncation
- \`sandbox_read_file\` gains \`offset\` (1-based line) and \`limit\` parameters

## Scope boundary

Strictly in-sandbox tooling. The design explicitly keeps repo ingress/egress (\`git clone\` at task start, branch push, PR creation) with Phase 2 Track 6 (GitHub Integration) — no duplication. \`apply_patch\`, todo/plan tracking, HTTP POST tools, and interactive stdin are out of scope with rationale.

## Crash-recovery angle

Background processes introduce per-sandbox state not captured in Postgres checkpoints. The design doc notes:

- E2B sandbox persistence already handles reconnect by \`sandbox_id\` (Track 2); process reattach by \`process_id\` is the natural extension
- Background-mode \`sandbox_exec\` is already non-idempotent, so re-execution after a checkpoint crash is the same concern Phase 1 flags — not new risk, just the same one in background flavor
- If the sandbox dies during outage, backgrounded processes die with it → same \`sandbox_lost\` dead-letter path

## Phase 3 gating (driven by your callout)

This PR also updates \`docs/design-docs/phase-2/design.md\` Recommended Planning Order to flag AC Track 3 as a **Phase 3 prerequisite**. Building Phase 3 features (batch APIs, webhooks, structured output, scaling) on top of Track 2's tool surface would lock in token-burning primitives that would then need to be rolled back. Sequence:

1. Phase 2 Tracks 1–4 ✅
2. AC Tracks 1–2 ✅
3. AC Track 3 (this proposal) — **before Phase 3**
4. Phase 2 Tracks 5 (Memory) and 6 (GitHub Integration) — can run in parallel with AC Track 3
5. Phase 3

## Files changed

- \`docs/design-docs/agent-capabilities/design.md\` — new \"Track 3 — Coding-Agent Primitives (proposed)\" section with motivation, tool specs, task sketch, crash-recovery implications, and template dependency (ripgrep pre-install)
- \`docs/design-docs/phase-2/design.md\` — Recommended Planning Order refreshed to reflect shipped AC Tracks 1+2 and slot Track 3 as a Phase 3 prerequisite
- \`STATUS.md\` — Track 3 row added as \"Proposed (design only)\"; initiative title extended to include \"coding primitives\"

## Test plan

No code changes, so no test suite runs required.

- [ ] Design doc sections render cleanly on GitHub
- [ ] STATUS.md row renders with the new Track 3 entry
- [ ] Phase 2 design doc's link to the Track 3 section resolves

## What this PR is NOT

- Not an exec plan — tasks listed in the design are a sketch, not agent_tasks/ specs
- Not shipping any tools — no executor changes, no \`sandbox_tools.py\` changes
- Not a commitment to Track 5/6 ordering — those can move relative to AC Track 3 as priorities shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)