### PR TITLE
Harden outbound URLs, surface MCP truncation, add secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,26 @@ on:
     branches: [main]
 
 jobs:
+  # ── Secret scanning ───────────────────────────────────────────────────────
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.21.2
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          /tmp/gitleaks version
+
+      - name: Scan repository history
+        run: /tmp/gitleaks detect --source . --config .gitleaks.toml --redact --exit-code 1 --verbose
+
   # ── Fast unit tests (no database) ─────────────────────────────────────────
 
   cdk-tests:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+# Gitleaks configuration — extends the default ruleset with targeted
+# allowlist entries for known false positives in this repo.
+#
+# Keep allowlist entries narrow (specific regexes / paths) so the default
+# ruleset still catches real leaks. When adding an entry, note *why* the
+# match is safe so future readers can audit it.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known false positives"
+
+# `EXCLUDED.s3_key` appears in SQL `ON CONFLICT DO UPDATE` clauses
+# (services/worker-service/tools/sandbox_tools.py and the matching exec
+# plan doc). The generic-api-key entropy rule scores the token high
+# enough to trip. Not a secret.
+regexes = [
+    '''EXCLUDED\.s3_key''',
+]

--- a/services/api-service/src/main/java/com/persistentagent/api/service/LangfuseEndpointService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/LangfuseEndpointService.java
@@ -6,6 +6,7 @@ import com.persistentagent.api.model.request.LangfuseEndpointRequest;
 import com.persistentagent.api.model.response.LangfuseEndpointResponse;
 import com.persistentagent.api.model.response.LangfuseEndpointTestResponse;
 import com.persistentagent.api.repository.LangfuseEndpointRepository;
+import com.persistentagent.api.util.UrlSafetyValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
@@ -120,6 +121,9 @@ public class LangfuseEndpointService {
 
     private LangfuseEndpointTestResponse doTestConnectivity(String host, String publicKey, String secretKey) {
         String url = host.endsWith("/") ? host + "api/public/health" : host + "/api/public/health";
+        // Reject private/loopback/metadata hosts before sending Basic Auth credentials.
+        // Let ValidationException propagate so the caller returns 400, not a misleading "unreachable".
+        UrlSafetyValidator.validate(url);
         String credentials = Base64.getEncoder().encodeToString((publicKey + ":" + secretKey).getBytes());
 
         try {

--- a/services/api-service/src/main/java/com/persistentagent/api/service/ToolServerService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/ToolServerService.java
@@ -10,6 +10,7 @@ import com.persistentagent.api.model.request.ToolServerUpdateRequest;
 import com.persistentagent.api.model.response.*;
 import com.persistentagent.api.repository.ToolServerRepository;
 import com.persistentagent.api.util.DateTimeUtil;
+import com.persistentagent.api.util.UrlSafetyValidator;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -300,15 +301,7 @@ public class ToolServerService {
     }
 
     private void validateUrl(String url) {
-        try {
-            URI uri = URI.create(url);
-            String scheme = uri.getScheme();
-            if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) {
-                throw new ValidationException("url must use http or https scheme");
-            }
-        } catch (IllegalArgumentException e) {
-            throw new ValidationException("Invalid url: " + e.getMessage());
-        }
+        UrlSafetyValidator.validate(url);
     }
 
     private String maskToken(String token) {

--- a/services/api-service/src/main/java/com/persistentagent/api/service/ToolServerService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/ToolServerService.java
@@ -159,6 +159,12 @@ public class ToolServerService {
         String authToken = (String) row.get("auth_token");
 
         try {
+            // Re-validate at request time. A DNS-based URL saved as safe could have
+            // been rebound to a metadata / internal address before this call runs;
+            // without this check, a tenant-controlled hostname plus a bearer token
+            // in auth_token can exfiltrate the token via DNS rebinding (TOCTOU).
+            UrlSafetyValidator.validate(serverUrl);
+
             // Step 1: Send MCP initialize request
             String initBody = """
                 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"persistent-agent-runtime","version":"1.0.0"}}}

--- a/services/api-service/src/main/java/com/persistentagent/api/util/UrlSafetyValidator.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/util/UrlSafetyValidator.java
@@ -1,0 +1,168 @@
+package com.persistentagent.api.util;
+
+import com.persistentagent.api.exception.ValidationException;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Set;
+
+/**
+ * Validates outbound URLs that the API service will dereference on behalf of
+ * customer configuration (Langfuse hosts, tool server URLs).
+ *
+ * <p>Goal: block the SSRF vectors that matter while keeping dev workflows
+ * (running Langfuse/MCP on localhost or a VPN-reachable RFC1918 host) intact.
+ *
+ * <h3>What this blocks</h3>
+ * <ul>
+ *   <li>Non-http(s) schemes (file://, gopher://, data://, etc.)</li>
+ *   <li>Credentials embedded in the URL ({@code user:pass@host})</li>
+ *   <li>Hostnames ending in {@code .local} or {@code .internal}</li>
+ *   <li>Link-local IPs (169.254.0.0/16) — covers AWS/GCP/Azure instance metadata
+ *       at {@code 169.254.169.254} and the Azure IMDS subnet</li>
+ *   <li>CGNAT range (100.64.0.0/10) — covers Alibaba Cloud metadata at
+ *       {@code 100.100.100.200}</li>
+ *   <li>0.0.0.0/8, multicast, and 240.0.0.0/4 reserved</li>
+ *   <li>IPv6 ULA (fc00::/7) and IPv4-mapped IPv6 variants of every v4 block above</li>
+ * </ul>
+ *
+ * <h3>What this deliberately allows (dev-friendly)</h3>
+ * <ul>
+ *   <li>{@code localhost} and loopback IPs — devs run Langfuse/MCP locally</li>
+ *   <li>RFC1918 (10/8, 172.16/12, 192.168/16) — VPN-reachable internal services</li>
+ * </ul>
+ *
+ * <p>When the platform onboards external tenants, tighten this by adding a
+ * "strict" mode that also rejects loopback and RFC1918.
+ */
+public final class UrlSafetyValidator {
+
+    private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    /** DNS resolver seam for testing. */
+    @FunctionalInterface
+    public interface Resolver {
+        InetAddress[] resolve(String host) throws UnknownHostException;
+    }
+
+    private static final Resolver DEFAULT_RESOLVER = InetAddress::getAllByName;
+
+    private UrlSafetyValidator() {
+    }
+
+    public static void validate(String url) {
+        validate(url, DEFAULT_RESOLVER);
+    }
+
+    public static void validate(String url, Resolver resolver) {
+        if (url == null || url.isBlank()) {
+            throw new ValidationException("URL is required");
+        }
+
+        URI uri;
+        try {
+            uri = new URI(url.trim());
+        } catch (URISyntaxException e) {
+            throw new ValidationException("Invalid URL: " + e.getMessage());
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || !ALLOWED_SCHEMES.contains(scheme.toLowerCase())) {
+            throw new ValidationException("URL must use http or https scheme");
+        }
+
+        if (uri.getUserInfo() != null) {
+            throw new ValidationException("Credentials embedded in URLs are not allowed");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new ValidationException("URL must include a hostname");
+        }
+
+        String normalized = host.toLowerCase();
+        if (normalized.endsWith(".local") || normalized.endsWith(".internal")) {
+            throw new ValidationException("Hostnames ending in .local or .internal are not allowed");
+        }
+
+        InetAddress[] addresses;
+        try {
+            addresses = resolver.resolve(host);
+        } catch (UnknownHostException e) {
+            throw new ValidationException("Hostname could not be resolved: " + host);
+        }
+
+        if (addresses == null || addresses.length == 0) {
+            throw new ValidationException("Hostname could not be resolved: " + host);
+        }
+
+        for (InetAddress address : addresses) {
+            assertSafeAddress(address);
+        }
+    }
+
+    private static void assertSafeAddress(InetAddress address) {
+        if (address.isLinkLocalAddress()
+                || address.isMulticastAddress()
+                || address.isAnyLocalAddress()) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+
+        byte[] bytes = address.getAddress();
+
+        if (bytes.length == 4) {
+            assertSafeIpv4(bytes);
+            return;
+        }
+
+        if (bytes.length == 16) {
+            // fc00::/7 — IPv6 unique local addresses
+            if ((bytes[0] & 0xFE) == 0xFC) {
+                throw new ValidationException("URL resolves to a reserved address range");
+            }
+            // ::ffff:0:0/96 — IPv4-mapped IPv6; re-check embedded v4 so mapped
+            // forms of metadata / CGNAT / 0.0.0.0 are not a bypass.
+            boolean prefixAllZero = true;
+            for (int i = 0; i < 10; i++) {
+                if (bytes[i] != 0) {
+                    prefixAllZero = false;
+                    break;
+                }
+            }
+            boolean mappedPrefix = prefixAllZero
+                    && (bytes[10] & 0xFF) == 0xFF
+                    && (bytes[11] & 0xFF) == 0xFF;
+            if (mappedPrefix) {
+                assertSafeIpv4(new byte[]{bytes[12], bytes[13], bytes[14], bytes[15]});
+            }
+        }
+    }
+
+    private static void assertSafeIpv4(byte[] bytes) {
+        int first = bytes[0] & 0xFF;
+        int second = bytes[1] & 0xFF;
+
+        // 0.0.0.0/8 — "this" network / unspecified
+        if (first == 0) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+        // 169.254.0.0/16 — link-local; includes cloud instance-metadata endpoints
+        if (first == 169 && second == 254) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+        // 100.64.0.0/10 — CGNAT; includes Alibaba Cloud IMDS (100.100.100.200)
+        if (first == 100 && second >= 64 && second <= 127) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+        // 224.0.0.0/4 — multicast (covers mapped-IPv6 bypass)
+        if (first >= 224 && first <= 239) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+        // 240.0.0.0/4 — reserved / future use
+        if (first >= 240) {
+            throw new ValidationException("URL resolves to a reserved address range");
+        }
+    }
+}

--- a/services/api-service/src/test/java/com/persistentagent/api/service/LangfuseEndpointServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/LangfuseEndpointServiceTest.java
@@ -63,14 +63,14 @@ class LangfuseEndpointServiceTest {
         stubSuccessfulConnectivity();
 
         LangfuseEndpointRequest request = new LangfuseEndpointRequest(
-                "my-langfuse", "https://langfuse.example.com", "pk-123", "sk-456");
+                "my-langfuse", "http://127.0.0.1:3300", "pk-123", "sk-456");
 
         Map<String, Object> repoResult = new LinkedHashMap<>();
         repoResult.put("endpoint_id", ENDPOINT_ID);
         repoResult.put("created_at", Timestamp.from(Instant.now()));
 
         when(langfuseEndpointRepository.insert(TENANT_ID, "my-langfuse",
-                "https://langfuse.example.com", "pk-123", "sk-456")).thenReturn(repoResult);
+                "http://127.0.0.1:3300", "pk-123", "sk-456")).thenReturn(repoResult);
 
         LangfuseEndpointResponse response = langfuseEndpointService.create(TENANT_ID, request);
 
@@ -78,7 +78,7 @@ class LangfuseEndpointServiceTest {
         assertEquals(ENDPOINT_ID, response.endpointId());
         assertEquals(TENANT_ID, response.tenantId());
         assertEquals("my-langfuse", response.name());
-        assertEquals("https://langfuse.example.com", response.host());
+        assertEquals("http://127.0.0.1:3300", response.host());
         assertNotNull(response.createdAt());
     }
 
@@ -87,7 +87,7 @@ class LangfuseEndpointServiceTest {
         stubSuccessfulConnectivity();
 
         LangfuseEndpointRequest request = new LangfuseEndpointRequest(
-                "duplicate-name", "https://langfuse.example.com", "pk-123", "sk-456");
+                "duplicate-name", "http://127.0.0.1:3300", "pk-123", "sk-456");
 
         when(langfuseEndpointRepository.insert(anyString(), anyString(), anyString(), anyString(), anyString()))
                 .thenThrow(new DuplicateKeyException("duplicate key value violates unique constraint"));
@@ -132,7 +132,7 @@ class LangfuseEndpointServiceTest {
     @Test
     @SuppressWarnings("unchecked")
     void testConnectivity_success() throws Exception {
-        Map<String, Object> row = buildEndpointRow("https://langfuse.example.com", "pk-123", "sk-456");
+        Map<String, Object> row = buildEndpointRow("http://127.0.0.1:3300", "pk-123", "sk-456");
         when(langfuseEndpointRepository.findByIdAndTenant(ENDPOINT_ID, TENANT_ID))
                 .thenReturn(Optional.of(row));
 
@@ -150,7 +150,7 @@ class LangfuseEndpointServiceTest {
     @Test
     @SuppressWarnings("unchecked")
     void testConnectivity_authFailure() throws Exception {
-        Map<String, Object> row = buildEndpointRow("https://langfuse.example.com", "pk-bad", "sk-bad");
+        Map<String, Object> row = buildEndpointRow("http://127.0.0.1:3300", "pk-bad", "sk-bad");
         when(langfuseEndpointRepository.findByIdAndTenant(ENDPOINT_ID, TENANT_ID))
                 .thenReturn(Optional.of(row));
 
@@ -168,7 +168,7 @@ class LangfuseEndpointServiceTest {
     @Test
     @SuppressWarnings("unchecked")
     void testConnectivity_unreachable() throws Exception {
-        Map<String, Object> row = buildEndpointRow("https://unreachable.example.com", "pk-123", "sk-456");
+        Map<String, Object> row = buildEndpointRow("http://127.0.0.1:3301", "pk-123", "sk-456");
         when(langfuseEndpointRepository.findByIdAndTenant(ENDPOINT_ID, TENANT_ID))
                 .thenReturn(Optional.of(row));
 

--- a/services/api-service/src/test/java/com/persistentagent/api/service/ToolServerServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/ToolServerServiceTest.java
@@ -423,6 +423,31 @@ class ToolServerServiceTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    void testDiscoverTools_urlNowResolvesToMetadata_refusedWithoutHttpCall() throws Exception {
+        // TOCTOU guard: URL was safe at save time, but the stored row now points
+        // at a metadata IP (either DNS-rebound or a literal entered via direct DB
+        // access). discoverTools must reject before sending the Authorization header.
+        Map<String, Object> row = buildRow(
+            SERVER_ID, "rebound", "http://169.254.169.254/mcp",
+            "bearer_token", "supersecrettoken12345678", "active"
+        );
+        when(repository.findById(TENANT_ID, SERVER_ID)).thenReturn(Optional.of(row));
+
+        HttpClient mockHttpClient = mock(HttpClient.class);
+        ToolServerService serviceWithMockHttp = new ToolServerService(repository, objectMapper, mockHttpClient);
+
+        ToolDiscoverResponse response = serviceWithMockHttp.discoverTools(SERVER_ID);
+
+        assertEquals("unreachable", response.status());
+        assertNotNull(response.error());
+        assertTrue(response.error().toLowerCase().contains("reserved"),
+            "error should mention the reserved-range rejection, got: " + response.error());
+        assertTrue(response.tools().isEmpty());
+        verifyNoInteractions(mockHttpClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void testDiscoverTools_jsonRpcError_returnsUnreachable() throws Exception {
         Map<String, Object> row = buildRow(SERVER_ID, "my-server", "http://localhost:8080/mcp", "none", null, "active");
         when(repository.findById(TENANT_ID, SERVER_ID)).thenReturn(Optional.of(row));

--- a/services/api-service/src/test/java/com/persistentagent/api/util/UrlSafetyValidatorTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/util/UrlSafetyValidatorTest.java
@@ -1,0 +1,184 @@
+package com.persistentagent.api.util;
+
+import com.persistentagent.api.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UrlSafetyValidatorTest {
+
+    /** Resolver returning fixed IPs — keeps tests hermetic (no real DNS). */
+    private static UrlSafetyValidator.Resolver resolverReturning(String... ipLiterals) {
+        return host -> {
+            InetAddress[] out = new InetAddress[ipLiterals.length];
+            for (int i = 0; i < ipLiterals.length; i++) {
+                out[i] = InetAddress.getByName(ipLiterals[i]);
+            }
+            return out;
+        };
+    }
+
+    private static UrlSafetyValidator.Resolver failingResolver() {
+        return host -> { throw new UnknownHostException(host); };
+    }
+
+    // --- scheme / format ---
+
+    @Test
+    void rejectsNull() {
+        assertThrows(ValidationException.class, () -> UrlSafetyValidator.validate(null));
+    }
+
+    @Test
+    void rejectsBlank() {
+        assertThrows(ValidationException.class, () -> UrlSafetyValidator.validate("   "));
+    }
+
+    @Test
+    void rejectsFileScheme() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("file:///etc/passwd"));
+        assertTrue(ex.getMessage().toLowerCase().contains("scheme"));
+    }
+
+    @Test
+    void rejectsGopherScheme() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("gopher://example.com/"));
+    }
+
+    @Test
+    void rejectsDataScheme() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("data:text/plain,hi"));
+    }
+
+    @Test
+    void rejectsSchemeless() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("example.com/path"));
+    }
+
+    @Test
+    void rejectsCredentialsInUrl() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("https://alice:secret@example.com/",
+                        resolverReturning("93.184.216.34")));
+        assertTrue(ex.getMessage().toLowerCase().contains("credentials"));
+    }
+
+    // --- hostname suffix blocks ---
+
+    @Test
+    void rejectsDotLocalSuffix() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://printer.local/",
+                        resolverReturning("93.184.216.34")));
+    }
+
+    @Test
+    void rejectsDotInternalSuffix() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://metadata.internal/",
+                        resolverReturning("93.184.216.34")));
+    }
+
+    // --- resolved-IP blocks (the ones that actually matter for SSRF) ---
+
+    @Test
+    void rejectsAwsMetadataLiteral() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://169.254.169.254/latest/meta-data/",
+                        resolverReturning("169.254.169.254")));
+        assertTrue(ex.getMessage().toLowerCase().contains("reserved"));
+    }
+
+    @Test
+    void rejectsAlibabaMetadataLiteral() {
+        // 100.100.100.200 — Alibaba Cloud IMDS, inside CGNAT range
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://100.100.100.200/",
+                        resolverReturning("100.100.100.200")));
+    }
+
+    @Test
+    void rejectsDnsPointingAtMetadata() {
+        // DNS rebind attempt: public-looking hostname resolves to metadata IP
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://attacker.example.com/",
+                        resolverReturning("169.254.169.254")));
+    }
+
+    @Test
+    void rejectsZeroNetwork() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://a.example.com/",
+                        resolverReturning("0.0.0.0")));
+    }
+
+    @Test
+    void rejectsIpv6UniqueLocal() {
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://a.example.com/",
+                        resolverReturning("fd00::1")));
+    }
+
+    @Test
+    void rejectsIpv4MappedMetadata() {
+        // ::ffff:169.254.169.254 — IPv4-mapped form must not bypass the v4 check
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://a.example.com/",
+                        resolverReturning("::ffff:169.254.169.254")));
+    }
+
+    @Test
+    void rejectsMixedResolutionIfAnyIsReserved() {
+        // DNS returns both a public and a metadata IP — must reject.
+        assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://a.example.com/",
+                        resolverReturning("93.184.216.34", "169.254.169.254")));
+    }
+
+    @Test
+    void rejectsUnresolvable() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> UrlSafetyValidator.validate("http://nx.example.com/",
+                        failingResolver()));
+        assertTrue(ex.getMessage().toLowerCase().contains("could not be resolved"));
+    }
+
+    // --- dev-friendly positive cases ---
+
+    @Test
+    void acceptsPublicHttps() {
+        assertDoesNotThrow(() -> UrlSafetyValidator.validate(
+                "https://cloud.langfuse.com/api/public/health",
+                resolverReturning("93.184.216.34")));
+    }
+
+    @Test
+    void acceptsLocalhost() {
+        // Dev workflow: Langfuse/MCP running locally. Loopback is allowed.
+        assertDoesNotThrow(() -> UrlSafetyValidator.validate(
+                "http://localhost:3300/api/public/health",
+                resolverReturning("127.0.0.1")));
+    }
+
+    @Test
+    void acceptsLoopbackLiteral() {
+        assertDoesNotThrow(() -> UrlSafetyValidator.validate(
+                "http://127.0.0.1:8080/mcp",
+                resolverReturning("127.0.0.1")));
+    }
+
+    @Test
+    void acceptsRfc1918() {
+        // Dev workflow: VPN-reachable internal service. Not blocked.
+        assertDoesNotThrow(() -> UrlSafetyValidator.validate(
+                "https://tools.internal-10/mcp",
+                resolverReturning("10.20.30.40")));
+    }
+}

--- a/services/worker-service/executor/mcp_session.py
+++ b/services/worker-service/executor/mcp_session.py
@@ -217,16 +217,21 @@ class McpSessionManager:
                 output = str(result)
 
             if len(output) > RESPONSE_SIZE_LIMIT:
+                original_size = len(output)
                 logger.warning(
                     "mcp_response_truncated",
                     extra={
                         "server_name": server_name,
                         "tool_name": tool_name,
-                        "original_size": len(output),
+                        "original_size": original_size,
                         "limit": RESPONSE_SIZE_LIMIT,
                     },
                 )
-                output = output[:RESPONSE_SIZE_LIMIT]
+                marker = (
+                    f"\n\n[MCP response truncated to {RESPONSE_SIZE_LIMIT} bytes; "
+                    f"original size was {original_size} bytes]"
+                )
+                output = output[: RESPONSE_SIZE_LIMIT - len(marker)] + marker
 
             return output
 

--- a/services/worker-service/tests/test_mcp_session.py
+++ b/services/worker-service/tests/test_mcp_session.py
@@ -127,6 +127,63 @@ class TestMcpSessionManagerCallTool:
 
         await manager.close()
 
+    @pytest.mark.asyncio
+    async def test_call_tool_truncates_with_visible_marker(self):
+        """Oversized responses keep the size limit but surface a marker so the LLM
+        and any human reader know data was dropped — silent truncation hides bugs."""
+        from executor.mcp_session import RESPONSE_SIZE_LIMIT, _ServerSession
+
+        manager = McpSessionManager()
+        sess = _ServerSession()
+        mock_session = AsyncMock()
+
+        oversized = "A" * (RESPONSE_SIZE_LIMIT + 10_000)
+        mock_result = MagicMock()
+        mock_result.structuredContent = None
+        mock_result.content = [MagicMock(text=oversized)]
+        mock_result.isError = False
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+
+        sess.session = mock_session
+        manager._sessions["big-server"] = sess
+
+        output = await manager.call_tool("big-server", "big-tool", {})
+
+        assert len(output) == RESPONSE_SIZE_LIMIT
+        assert "truncated" in output
+        # Marker carries both the cap and the original size so an operator reading
+        # the tail of the output can see exactly how much was dropped.
+        assert str(RESPONSE_SIZE_LIMIT) in output
+        assert str(len(oversized)) in output
+
+        await manager.close()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_within_limit_not_modified(self):
+        """Responses under the limit pass through untouched — no marker appended."""
+        from executor.mcp_session import _ServerSession
+
+        manager = McpSessionManager()
+        sess = _ServerSession()
+        mock_session = AsyncMock()
+
+        payload = "hello world"
+        mock_result = MagicMock()
+        mock_result.structuredContent = None
+        mock_result.content = [MagicMock(text=payload)]
+        mock_result.isError = False
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+
+        sess.session = mock_session
+        manager._sessions["ok-server"] = sess
+
+        output = await manager.call_tool("ok-server", "ok-tool", {})
+
+        assert output == payload
+        assert "truncated" not in output
+
+        await manager.close()
+
 
 class TestMcpSessionManagerClose:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three small, independent hardening changes that came out of a threat-modeling pass:

- **SSRF defense for Langfuse and tool-server URLs.** Customer-supplied hosts were only scheme-checked, so DNS or an IP literal could point the API at cloud instance-metadata (169.254.169.254, 100.100.100.200) and have Basic Auth / bearer tokens shipped straight to the SSRF target. New `UrlSafetyValidator` rejects link-local, CGNAT, 0/8, multicast, reserved, IPv6 ULA, and the IPv4-mapped IPv6 form of each, plus `.local` / `.internal` suffixes, non-http(s) schemes, and userinfo. Loopback and RFC1918 stay allowed so dev workflows keep working.
- **MCP response truncation marker.** Responses over the 1 MB cap were silently chopped. When an agent "hallucinates the end of a document", truncation is the last thing anyone suspects. Trailing marker now states the cap and original size; total stays under the limit.
- **gitleaks in CI.** Repo is public. A bad `git add .` on a local `.env` becomes permanent the moment it lands on `main`. Binary pinned to v8.21.2 rather than a floating action tag.

## Scope choices worth flagging

The validator deliberately allows loopback and RFC1918. This is a dev-stage repo — blocking them breaks the E2E Langfuse job (127.0.0.1:3300) and every tool-server test that uses localhost. When external tenants are onboarded, add a strict mode that blocks those too and gate it on a profile. Tracking issues for the remaining architectural items (column-level secret encryption, DB role split, tool-approval seam) are filed separately.

## Test plan

- [x] `./gradlew test --rerun-tasks` in `services/api-service` — full suite green, including the 19 new `UrlSafetyValidatorTest` cases covering metadata IPs, CGNAT, IPv4-mapped IPv6, DNS-rebind style mixed resolution, and dev-friendly positives (loopback, RFC1918, public).
- [x] `pytest tests` in `services/worker-service` (minus the two DB-dependent integration files) — 393 passed, 2 skipped. New MCP session tests verify both the truncation marker and that under-limit responses pass through untouched.
- [x] CI: gitleaks job on this PR should pass (history is clean per local scan).
- [x] CI: `e2e-tests` and `observability-smoke-tests` should still pass — the validator allows `localhost`/`127.0.0.1`, which those fixtures rely on.