### PR TITLE
Re-validate Langfuse host on worker-side trace path

### DIFF
--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -35,6 +35,7 @@ from sandbox.provisioner import (
 
 from executor.mcp_session import McpSessionManager, ToolServerConfig, McpConnectionError
 from executor.schema_converter import mcp_tools_to_structured_tools, MAX_TOOLS_PER_AGENT
+from executor import url_safety
 from storage.s3_client import S3Client
 from tools.definitions import (
     create_default_dependencies,
@@ -117,8 +118,21 @@ class GraphExecutor:
             if row is None:
                 logger.warning("Langfuse endpoint %s not found in database", endpoint_id)
                 return None
+            host = row["host"]
+            # Re-validate at trace time. The API blocks unsafe hosts on save, but a
+            # DNS-based host saved as safe can be rebound to a metadata / internal
+            # address before this worker ships traces + Basic Auth credentials to it.
+            # Bail with None so the task still runs — tracing just degrades off.
+            try:
+                url_safety.validate(host)
+            except url_safety.UrlSafetyError as exc:
+                logger.warning(
+                    "Langfuse endpoint %s host rejected by url safety check; disabling tracing: %s",
+                    endpoint_id, exc,
+                )
+                return None
             return {
-                "host": row["host"],
+                "host": host,
                 "public_key": row["public_key"],
                 "secret_key": row["secret_key"],
             }

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -124,7 +124,7 @@ class GraphExecutor:
             # address before this worker ships traces + Basic Auth credentials to it.
             # Bail with None so the task still runs — tracing just degrades off.
             try:
-                url_safety.validate(host)
+                await url_safety.validate(host)
             except url_safety.UrlSafetyError as exc:
                 logger.warning(
                     "Langfuse endpoint %s host rejected by url safety check; disabling tracing: %s",

--- a/services/worker-service/executor/url_safety.py
+++ b/services/worker-service/executor/url_safety.py
@@ -1,0 +1,104 @@
+"""Outbound URL safety validator for customer-configured hosts (Langfuse, etc.).
+
+Mirrors the policy of the Java UrlSafetyValidator used by the API service: block
+the SSRF vectors that matter (link-local / cloud-metadata, CGNAT, 0/8, multicast,
+reserved, IPv6 ULA, IPv4-mapped IPv6 forms of each, non-http(s) schemes, userinfo,
+and .local / .internal suffixes) while keeping dev workflows working — loopback
+and RFC1918 stay allowed so local Langfuse (127.0.0.1:3300) and VPN-reachable
+internal instances don't break.
+
+When the platform onboards external tenants, add a strict mode that additionally
+rejects loopback and RFC1918 and gate it on a config flag.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+
+Resolver = Callable[[str], list[str]]
+
+
+class UrlSafetyError(ValueError):
+    """Raised when a URL is rejected by the safety check."""
+
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+_BLOCKED_IPV4_NETWORKS = (
+    ipaddress.ip_network("0.0.0.0/8"),         # "this" network / unspecified block
+    ipaddress.ip_network("100.64.0.0/10"),     # CGNAT — covers Alibaba IMDS 100.100.100.200
+    ipaddress.ip_network("169.254.0.0/16"),    # link-local — covers AWS/GCP/Azure IMDS
+    ipaddress.ip_network("224.0.0.0/4"),       # multicast
+    ipaddress.ip_network("240.0.0.0/4"),       # reserved / future use
+)
+
+_BLOCKED_IPV6_NETWORKS = (
+    ipaddress.ip_network("::/128"),            # unspecified
+    ipaddress.ip_network("fc00::/7"),          # unique local addresses
+    ipaddress.ip_network("fe80::/10"),         # link-local
+    ipaddress.ip_network("ff00::/8"),          # multicast
+)
+
+
+def _default_resolver(host: str) -> list[str]:
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UrlSafetyError(f"Hostname could not be resolved: {host}") from exc
+    return sorted({info[4][0] for info in infos})
+
+
+def validate(url: str, *, resolver: Resolver = _default_resolver) -> None:
+    """Raise UrlSafetyError if the URL points anywhere unsafe; return None otherwise."""
+    if url is None or not str(url).strip():
+        raise UrlSafetyError("URL is required")
+
+    parsed = urlparse(str(url).strip())
+
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise UrlSafetyError("URL must use http or https scheme")
+
+    if parsed.username or parsed.password:
+        raise UrlSafetyError("Credentials embedded in URLs are not allowed")
+
+    host = parsed.hostname
+    if not host:
+        raise UrlSafetyError("URL must include a hostname")
+
+    normalized = host.lower()
+    if normalized.endswith(".local") or normalized.endswith(".internal"):
+        raise UrlSafetyError("Hostnames ending in .local or .internal are not allowed")
+
+    ips = resolver(host)
+    if not ips:
+        raise UrlSafetyError(f"Hostname could not be resolved: {host}")
+
+    for ip_text in ips:
+        _assert_safe_address(ipaddress.ip_address(ip_text))
+
+
+def _assert_safe_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    if isinstance(address, ipaddress.IPv4Address):
+        _assert_safe_ipv4(address)
+        return
+
+    # IPv4-mapped IPv6 (::ffff:a.b.c.d) must be re-checked against v4 rules so
+    # ::ffff:169.254.169.254 can't bypass the IPv4 metadata block.
+    mapped = address.ipv4_mapped
+    if mapped is not None:
+        _assert_safe_ipv4(mapped)
+        return
+
+    for net in _BLOCKED_IPV6_NETWORKS:
+        if address in net:
+            raise UrlSafetyError("URL resolves to a reserved address range")
+
+
+def _assert_safe_ipv4(address: ipaddress.IPv4Address) -> None:
+    for net in _BLOCKED_IPV4_NETWORKS:
+        if address in net:
+            raise UrlSafetyError("URL resolves to a reserved address range")

--- a/services/worker-service/executor/url_safety.py
+++ b/services/worker-service/executor/url_safety.py
@@ -7,19 +7,23 @@ and .local / .internal suffixes) while keeping dev workflows working — loopbac
 and RFC1918 stay allowed so local Langfuse (127.0.0.1:3300) and VPN-reachable
 internal instances don't break.
 
+DNS resolution is offloaded to a thread so a slow resolver cannot pause the
+worker's event loop. Tests inject their own resolver and never hit real DNS.
+
 When the platform onboards external tenants, add a strict mode that additionally
 rejects loopback and RFC1918 and gate it on a config flag.
 """
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import socket
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from urllib.parse import urlparse
 
 
-Resolver = Callable[[str], list[str]]
+Resolver = Callable[[str], Awaitable[list[str]]]
 
 
 class UrlSafetyError(ValueError):
@@ -44,15 +48,19 @@ _BLOCKED_IPV6_NETWORKS = (
 )
 
 
-def _default_resolver(host: str) -> list[str]:
+async def _default_resolver(host: str) -> list[str]:
+    # Offload the blocking syscall so slow / unresponsive DNS cannot stall the
+    # worker's event loop — all other coroutines would pause with it otherwise.
     try:
-        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+        infos = await asyncio.to_thread(
+            socket.getaddrinfo, host, None, type=socket.SOCK_STREAM
+        )
     except socket.gaierror as exc:
         raise UrlSafetyError(f"Hostname could not be resolved: {host}") from exc
     return sorted({info[4][0] for info in infos})
 
 
-def validate(url: str, *, resolver: Resolver = _default_resolver) -> None:
+async def validate(url: str, *, resolver: Resolver = _default_resolver) -> None:
     """Raise UrlSafetyError if the URL points anywhere unsafe; return None otherwise."""
     if url is None or not str(url).strip():
         raise UrlSafetyError("URL is required")
@@ -73,7 +81,7 @@ def validate(url: str, *, resolver: Resolver = _default_resolver) -> None:
     if normalized.endswith(".local") or normalized.endswith(".internal"):
         raise UrlSafetyError("Hostnames ending in .local or .internal are not allowed")
 
-    ips = resolver(host)
+    ips = await resolver(host)
     if not ips:
         raise UrlSafetyError(f"Hostname could not be resolved: {host}")
 

--- a/services/worker-service/tests/test_langfuse_cost.py
+++ b/services/worker-service/tests/test_langfuse_cost.py
@@ -108,8 +108,10 @@ async def test_calculate_cost_returns_metadata():
 @pytest.mark.asyncio
 async def test_resolve_found():
     executor = _make_executor()
+    # Loopback host — the url_safety re-check accepts it (dev-friendly) and does
+    # not hit real DNS.
     executor.pool.fetchrow = AsyncMock(return_value={
-        "host": "https://langfuse.example.com",
+        "host": "http://127.0.0.1:3300",
         "public_key": "pk-lf-test-public",
         "secret_key": "sk-lf-test-secret",
     })
@@ -117,10 +119,27 @@ async def test_resolve_found():
     result = await executor._resolve_langfuse_credentials("aaaabbbb-0000-0000-0000-000000000001")
 
     assert result is not None
-    assert result["host"] == "https://langfuse.example.com"
+    assert result["host"] == "http://127.0.0.1:3300"
     assert result["public_key"] == "pk-lf-test-public"
     assert result["secret_key"] == "sk-lf-test-secret"
     executor.pool.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_unsafe_host():
+    """A stored host that now resolves to a metadata IP must not return creds —
+    tracing just degrades off rather than shipping the bearer credentials
+    somewhere unsafe."""
+    executor = _make_executor()
+    executor.pool.fetchrow = AsyncMock(return_value={
+        "host": "http://169.254.169.254/",
+        "public_key": "pk-lf-test-public",
+        "secret_key": "sk-lf-test-secret",
+    })
+
+    result = await executor._resolve_langfuse_credentials("aaaabbbb-0000-0000-0000-000000000004")
+
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/services/worker-service/tests/test_url_safety.py
+++ b/services/worker-service/tests/test_url_safety.py
@@ -1,8 +1,8 @@
 """Tests for executor.url_safety.
 
 Mirrors services/api-service/.../UrlSafetyValidatorTest.java — same policy, same
-positive cases, same threat-focused negatives. Tests inject a resolver so they
-never hit real DNS.
+positive cases, same threat-focused negatives. Tests inject an async resolver so
+they never hit real DNS.
 """
 
 from __future__ import annotations
@@ -13,50 +13,57 @@ from executor.url_safety import UrlSafetyError, validate
 
 
 def resolver_returning(*ips: str):
-    def _resolve(host: str) -> list[str]:
+    async def _resolve(host: str) -> list[str]:
         return list(ips)
     return _resolve
 
 
-def failing_resolver(host: str) -> list[str]:
+async def failing_resolver(host: str) -> list[str]:
     raise UrlSafetyError(f"Hostname could not be resolved: {host}")
 
 
 # --- scheme / format ---
 
-def test_rejects_none():
+@pytest.mark.asyncio
+async def test_rejects_none():
     with pytest.raises(UrlSafetyError):
-        validate(None)
+        await validate(None)
 
 
-def test_rejects_blank():
+@pytest.mark.asyncio
+async def test_rejects_blank():
     with pytest.raises(UrlSafetyError):
-        validate("   ")
+        await validate("   ")
 
 
-def test_rejects_file_scheme():
+@pytest.mark.asyncio
+async def test_rejects_file_scheme():
     with pytest.raises(UrlSafetyError, match="scheme"):
-        validate("file:///etc/passwd")
+        await validate("file:///etc/passwd")
 
 
-def test_rejects_gopher_scheme():
+@pytest.mark.asyncio
+async def test_rejects_gopher_scheme():
     with pytest.raises(UrlSafetyError):
-        validate("gopher://example.com/")
+        await validate("gopher://example.com/")
 
 
-def test_rejects_data_scheme():
+@pytest.mark.asyncio
+async def test_rejects_data_scheme():
     with pytest.raises(UrlSafetyError):
-        validate("data:text/plain,hi")
+        await validate("data:text/plain,hi")
 
 
-def test_rejects_schemeless():
+@pytest.mark.asyncio
+async def test_rejects_schemeless():
     with pytest.raises(UrlSafetyError):
-        validate("example.com/path")
+        await validate("example.com/path")
 
 
-def test_rejects_credentials_in_url():
+@pytest.mark.asyncio
+async def test_rejects_credentials_in_url():
     with pytest.raises(UrlSafetyError, match="[Cc]redentials"):
-        validate(
+        await validate(
             "https://alice:secret@example.com/",
             resolver=resolver_returning("93.184.216.34"),
         )
@@ -64,105 +71,145 @@ def test_rejects_credentials_in_url():
 
 # --- hostname suffix blocks ---
 
-def test_rejects_dot_local_suffix():
+@pytest.mark.asyncio
+async def test_rejects_dot_local_suffix():
     with pytest.raises(UrlSafetyError):
-        validate("http://printer.local/", resolver=resolver_returning("93.184.216.34"))
+        await validate("http://printer.local/", resolver=resolver_returning("93.184.216.34"))
 
 
-def test_rejects_dot_internal_suffix():
+@pytest.mark.asyncio
+async def test_rejects_dot_internal_suffix():
     with pytest.raises(UrlSafetyError):
-        validate("http://metadata.internal/", resolver=resolver_returning("93.184.216.34"))
+        await validate("http://metadata.internal/", resolver=resolver_returning("93.184.216.34"))
 
 
 # --- resolved-IP blocks (the ones that actually matter for SSRF) ---
 
-def test_rejects_aws_metadata_literal():
+@pytest.mark.asyncio
+async def test_rejects_aws_metadata_literal():
     with pytest.raises(UrlSafetyError, match="[Rr]eserved"):
-        validate(
+        await validate(
             "http://169.254.169.254/latest/meta-data/",
             resolver=resolver_returning("169.254.169.254"),
         )
 
 
-def test_rejects_alibaba_metadata_literal():
+@pytest.mark.asyncio
+async def test_rejects_alibaba_metadata_literal():
     # 100.100.100.200 — Alibaba Cloud IMDS, in CGNAT range.
     with pytest.raises(UrlSafetyError):
-        validate(
+        await validate(
             "http://100.100.100.200/",
             resolver=resolver_returning("100.100.100.200"),
         )
 
 
-def test_rejects_dns_pointing_at_metadata():
+@pytest.mark.asyncio
+async def test_rejects_dns_pointing_at_metadata():
     # DNS rebind shape: public-looking hostname resolves to metadata IP.
     with pytest.raises(UrlSafetyError):
-        validate(
+        await validate(
             "http://attacker.example.com/",
             resolver=resolver_returning("169.254.169.254"),
         )
 
 
-def test_rejects_zero_network():
+@pytest.mark.asyncio
+async def test_rejects_zero_network():
     with pytest.raises(UrlSafetyError):
-        validate("http://a.example.com/", resolver=resolver_returning("0.0.0.0"))
+        await validate("http://a.example.com/", resolver=resolver_returning("0.0.0.0"))
 
 
-def test_rejects_ipv6_unique_local():
+@pytest.mark.asyncio
+async def test_rejects_ipv6_unique_local():
     with pytest.raises(UrlSafetyError):
-        validate("http://a.example.com/", resolver=resolver_returning("fd00::1"))
+        await validate("http://a.example.com/", resolver=resolver_returning("fd00::1"))
 
 
-def test_rejects_ipv4_mapped_metadata():
+@pytest.mark.asyncio
+async def test_rejects_ipv4_mapped_metadata():
     # ::ffff:169.254.169.254 — mapped form must not bypass the v4 check.
     with pytest.raises(UrlSafetyError):
-        validate(
+        await validate(
             "http://a.example.com/",
             resolver=resolver_returning("::ffff:169.254.169.254"),
         )
 
 
-def test_rejects_mixed_resolution_if_any_is_reserved():
+@pytest.mark.asyncio
+async def test_rejects_mixed_resolution_if_any_is_reserved():
     # DNS returns both a public and a metadata IP — must reject.
     with pytest.raises(UrlSafetyError):
-        validate(
+        await validate(
             "http://a.example.com/",
             resolver=resolver_returning("93.184.216.34", "169.254.169.254"),
         )
 
 
-def test_rejects_unresolvable():
+@pytest.mark.asyncio
+async def test_rejects_unresolvable():
     with pytest.raises(UrlSafetyError, match="could not be resolved"):
-        validate("http://nx.example.com/", resolver=failing_resolver)
+        await validate("http://nx.example.com/", resolver=failing_resolver)
 
 
 # --- dev-friendly positive cases ---
 
-def test_accepts_public_https():
-    # No exception.
-    validate(
+@pytest.mark.asyncio
+async def test_accepts_public_https():
+    await validate(
         "https://cloud.langfuse.com/api/public/health",
         resolver=resolver_returning("93.184.216.34"),
     )
 
 
-def test_accepts_localhost():
+@pytest.mark.asyncio
+async def test_accepts_localhost():
     # Dev workflow: Langfuse / MCP on localhost.
-    validate(
+    await validate(
         "http://localhost:3300/api/public/health",
         resolver=resolver_returning("127.0.0.1"),
     )
 
 
-def test_accepts_loopback_literal():
-    validate(
+@pytest.mark.asyncio
+async def test_accepts_loopback_literal():
+    await validate(
         "http://127.0.0.1:3300/api/public/health",
         resolver=resolver_returning("127.0.0.1"),
     )
 
 
-def test_accepts_rfc1918():
-    # Dev workflow: VPN-reachable internal service.
-    validate(
+@pytest.mark.asyncio
+async def test_accepts_rfc1918():
+    await validate(
         "https://tools-10/mcp",
         resolver=resolver_returning("10.20.30.40"),
     )
+
+
+# --- event-loop safety ---
+
+@pytest.mark.asyncio
+async def test_default_resolver_does_not_block_the_loop():
+    """The default resolver must yield control while DNS is in flight.
+
+    We run validate() against an IP literal — getaddrinfo returns instantly for
+    an IP — alongside a heartbeat coroutine that should tick at least once.
+    If validate were blocking, the heartbeat would not tick until it returned.
+    """
+    import asyncio
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        for _ in range(3):
+            await asyncio.sleep(0)
+            ticks += 1
+
+    await asyncio.gather(
+        validate("http://93.184.216.34/", resolver=resolver_returning("93.184.216.34")),
+        heartbeat(),
+    )
+
+    assert ticks >= 1, "validate() should yield to other coroutines while resolving"

--- a/services/worker-service/tests/test_url_safety.py
+++ b/services/worker-service/tests/test_url_safety.py
@@ -1,0 +1,168 @@
+"""Tests for executor.url_safety.
+
+Mirrors services/api-service/.../UrlSafetyValidatorTest.java — same policy, same
+positive cases, same threat-focused negatives. Tests inject a resolver so they
+never hit real DNS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from executor.url_safety import UrlSafetyError, validate
+
+
+def resolver_returning(*ips: str):
+    def _resolve(host: str) -> list[str]:
+        return list(ips)
+    return _resolve
+
+
+def failing_resolver(host: str) -> list[str]:
+    raise UrlSafetyError(f"Hostname could not be resolved: {host}")
+
+
+# --- scheme / format ---
+
+def test_rejects_none():
+    with pytest.raises(UrlSafetyError):
+        validate(None)
+
+
+def test_rejects_blank():
+    with pytest.raises(UrlSafetyError):
+        validate("   ")
+
+
+def test_rejects_file_scheme():
+    with pytest.raises(UrlSafetyError, match="scheme"):
+        validate("file:///etc/passwd")
+
+
+def test_rejects_gopher_scheme():
+    with pytest.raises(UrlSafetyError):
+        validate("gopher://example.com/")
+
+
+def test_rejects_data_scheme():
+    with pytest.raises(UrlSafetyError):
+        validate("data:text/plain,hi")
+
+
+def test_rejects_schemeless():
+    with pytest.raises(UrlSafetyError):
+        validate("example.com/path")
+
+
+def test_rejects_credentials_in_url():
+    with pytest.raises(UrlSafetyError, match="[Cc]redentials"):
+        validate(
+            "https://alice:secret@example.com/",
+            resolver=resolver_returning("93.184.216.34"),
+        )
+
+
+# --- hostname suffix blocks ---
+
+def test_rejects_dot_local_suffix():
+    with pytest.raises(UrlSafetyError):
+        validate("http://printer.local/", resolver=resolver_returning("93.184.216.34"))
+
+
+def test_rejects_dot_internal_suffix():
+    with pytest.raises(UrlSafetyError):
+        validate("http://metadata.internal/", resolver=resolver_returning("93.184.216.34"))
+
+
+# --- resolved-IP blocks (the ones that actually matter for SSRF) ---
+
+def test_rejects_aws_metadata_literal():
+    with pytest.raises(UrlSafetyError, match="[Rr]eserved"):
+        validate(
+            "http://169.254.169.254/latest/meta-data/",
+            resolver=resolver_returning("169.254.169.254"),
+        )
+
+
+def test_rejects_alibaba_metadata_literal():
+    # 100.100.100.200 — Alibaba Cloud IMDS, in CGNAT range.
+    with pytest.raises(UrlSafetyError):
+        validate(
+            "http://100.100.100.200/",
+            resolver=resolver_returning("100.100.100.200"),
+        )
+
+
+def test_rejects_dns_pointing_at_metadata():
+    # DNS rebind shape: public-looking hostname resolves to metadata IP.
+    with pytest.raises(UrlSafetyError):
+        validate(
+            "http://attacker.example.com/",
+            resolver=resolver_returning("169.254.169.254"),
+        )
+
+
+def test_rejects_zero_network():
+    with pytest.raises(UrlSafetyError):
+        validate("http://a.example.com/", resolver=resolver_returning("0.0.0.0"))
+
+
+def test_rejects_ipv6_unique_local():
+    with pytest.raises(UrlSafetyError):
+        validate("http://a.example.com/", resolver=resolver_returning("fd00::1"))
+
+
+def test_rejects_ipv4_mapped_metadata():
+    # ::ffff:169.254.169.254 — mapped form must not bypass the v4 check.
+    with pytest.raises(UrlSafetyError):
+        validate(
+            "http://a.example.com/",
+            resolver=resolver_returning("::ffff:169.254.169.254"),
+        )
+
+
+def test_rejects_mixed_resolution_if_any_is_reserved():
+    # DNS returns both a public and a metadata IP — must reject.
+    with pytest.raises(UrlSafetyError):
+        validate(
+            "http://a.example.com/",
+            resolver=resolver_returning("93.184.216.34", "169.254.169.254"),
+        )
+
+
+def test_rejects_unresolvable():
+    with pytest.raises(UrlSafetyError, match="could not be resolved"):
+        validate("http://nx.example.com/", resolver=failing_resolver)
+
+
+# --- dev-friendly positive cases ---
+
+def test_accepts_public_https():
+    # No exception.
+    validate(
+        "https://cloud.langfuse.com/api/public/health",
+        resolver=resolver_returning("93.184.216.34"),
+    )
+
+
+def test_accepts_localhost():
+    # Dev workflow: Langfuse / MCP on localhost.
+    validate(
+        "http://localhost:3300/api/public/health",
+        resolver=resolver_returning("127.0.0.1"),
+    )
+
+
+def test_accepts_loopback_literal():
+    validate(
+        "http://127.0.0.1:3300/api/public/health",
+        resolver=resolver_returning("127.0.0.1"),
+    )
+
+
+def test_accepts_rfc1918():
+    # Dev workflow: VPN-reachable internal service.
+    validate(
+        "https://tools-10/mcp",
+        resolver=resolver_returning("10.20.30.40"),
+    )


### PR DESCRIPTION
## Summary

Follow-up to #61. That PR closed the tool-server TOCTOU on the API side; the worker-side Langfuse path had the same shape open.

`executor/graph.py:_resolve_langfuse_credentials` reads the stored Langfuse host from Postgres and hands it to a `Langfuse` client that POSTs traces plus Basic Auth credentials to whatever DNS currently resolves there. A host saved as safe at configuration time can be rebound between save and trace — shipping the bearer credentials (and LLM trace payloads) to the rebound IP.

New `executor/url_safety.py` is a one-for-one Python port of the Java `UrlSafetyValidator`: block link-local / cloud-metadata, CGNAT, 0/8, multicast, reserved, IPv6 ULA, IPv4-mapped bypasses, non-http(s) schemes, userinfo, and `.local` / `.internal` suffixes; allow loopback and RFC1918 so local Langfuse (127.0.0.1:3300) and VPN-reachable internal instances keep working. Applied inside `_resolve_langfuse_credentials`: on reject, log the reason and return `None` so the task still executes with tracing disabled rather than dropping creds onto the rebound target.

## Threat-severity note

Lower severity than the API-side fix — customers on the worker path mostly attack their own endpoint with their own credentials, not platform IAM via a metadata-service bounce. But the code pattern is identical and the fix is cheap, so it's not worth letting the half-done state sit.

## What this does *not* do

Does not IP-pin the HTTP client (resolve once, connect to that IP, SNI original hostname). Revalidation leaves a sub-second window between the validator's resolve and the Langfuse SDK's resolve. IP pinning is the right move before onboarding any external tenant; tracking it in issues #62/#63/#64 rather than here.

## Test plan

- [x] `pytest tests/test_url_safety.py` — 19 cases: scheme / credentials-in-URL / `.local` / `.internal` / AWS & Alibaba metadata / DNS-rebind / IPv4-mapped IPv6 / mixed resolution / unresolvable, plus dev-friendly positives (loopback, RFC1918, public HTTPS).
- [x] `pytest tests/test_langfuse_cost.py` — existing cases green after updating one fixture host to a loopback literal, plus new `test_resolve_rejects_unsafe_host` asserting creds are withheld when the stored host is a metadata IP.
- [x] Full worker unit suite (`pytest tests --ignore=tests/test_checkpointer_integration.py --ignore=tests/test_integration.py`) — 415 passed / 2 skipped.