### PR TITLE
Phase 2 track structure: relocate coding primitives; register Tracks 9 & 10

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,8 @@ Bird's-eye view of where the project stands. For navigation and structure, see [
 | Track 6 | GitHub Integration | Not started | — | — |
 | Track 7 | Context Window Management | Stub ([track-7-context-window-management.md](docs/design-docs/phase-2/track-7-context-window-management.md)); brainstorm pending | — | — |
 | Track 8 | Coding-Agent Primitives | Design proposed ([track-8-coding-primitives.md](docs/design-docs/phase-2/track-8-coding-primitives.md)); relocated from AC Track 3; plan not started | — | — |
+| Track 9 | Planning Primitive | Stub ([track-9-planning-primitive.md](docs/design-docs/phase-2/track-9-planning-primitive.md)); brainstorm pending | — | — |
+| Track 10 | Deep Research Mode | Not started (brainstorm after Track 9) | — | — |
 
 
 ### Cross-Cutting

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@ Bird's-eye view of where the project stands. For navigation and structure, see [
 | Track 5 | Memory | Design drafted ([track-5-memory.md](docs/design-docs/phase-2/track-5-memory.md)); plan not started | — | — |
 | Track 6 | GitHub Integration | Not started | — | — |
 | Track 7 | Context Window Management | Stub ([track-7-context-window-management.md](docs/design-docs/phase-2/track-7-context-window-management.md)); brainstorm pending | — | — |
+| Track 8 | Coding-Agent Primitives | Design proposed ([track-8-coding-primitives.md](docs/design-docs/phase-2/track-8-coding-primitives.md)); relocated from AC Track 3; plan not started | — | — |
 
 
 ### Cross-Cutting
@@ -33,4 +34,4 @@ Bird's-eye view of where the project stands. For navigation and structure, see [
 |-------|------|--------|------|----------|
 | Track 1 | Output Artifact Storage | Complete | [plan](docs/exec-plans/completed/agent-capabilities/track-1/plan.md) | [progress](docs/exec-plans/completed/agent-capabilities/track-1/progress.md) |
 | Track 2 | E2B Sandbox & File Input | Complete | [plan](docs/exec-plans/completed/agent-capabilities/track-2/plan.md) | [progress](docs/exec-plans/completed/agent-capabilities/track-2/progress.md) |
-| Track 3 | Coding-Agent Primitives | Proposed (design only) | — | — |
+| Track 3 | Coding-Agent Primitives | Relocated to [Phase 2 Track 8](docs/design-docs/phase-2/track-8-coding-primitives.md) on 2026-04-18 | — | — |

--- a/docs/design-docs/agent-capabilities/design.md
+++ b/docs/design-docs/agent-capabilities/design.md
@@ -325,7 +325,7 @@ The API service (Java/Spring Boot) needs these changes:
 
 ## Implementation Tracks
 
-Tracks 1 and 2 are complete and delivered the sandbox + artifact foundation. Track 3 (proposed) extends the sandbox tool surface with coding-agent primitives and depends on Track 2.
+Tracks 1 and 2 are complete and delivered the sandbox + artifact foundation. Coding-agent primitives (previously Track 3) have been **relocated to [Phase 2 Track 8](../phase-2/track-8-coding-primitives.md)** — coding primitives are platform surface area, not a cross-cutting capability add-on.
 
 ### Track 1 — Output Artifact Storage
 
@@ -362,82 +362,9 @@ Delivers sandbox code execution and file input. Agents can receive files, execut
 
 **Exec plan:** `docs/exec-plans/completed/agent-capabilities/track-2/`
 
-### Track 3 — Coding-Agent Primitives (proposed)
+### Track 3 — Coding-Agent Primitives (relocated)
 
-Extends the sandbox tool surface so agents doing real iterative coding (edit → run test → read stack trace → edit again) can work without blowing through the context window on every turn. The Track 2 tools are sufficient to "run a script"; Track 3 is what makes "iterate on a codebase" practical. Depends on Track 2.
-
-**Scope boundary:** This track is strictly in-sandbox tooling. Phase 2 Track 6 (GitHub Integration) owns the repo ingress/egress story — `git clone` at task start, branch push, PR creation. Track 3 does not duplicate any of that; agents can still `sandbox_exec("git clone ...")` in the meantime.
-
-#### Motivation
-
-Observed gaps with the Track 2 tool set, each exercised many times per coding turn:
-
-1. **No surgical edit.** Every file change requires `sandbox_write_file` with the full new contents. For a 2k-line file, that's ~8k tokens per change, and long edit sessions drift — the LLM silently mutates unrelated code.
-2. **No partial file read.** `sandbox_read_file` returns the whole file. Reading a 10k-line file to locate one stack frame costs ~40k tokens.
-3. **No first-class search.** Agents fall back to `sandbox_exec("rg ...")`, which wraps the search in shell scaffolding, loses structured output, and has no cap on how much ripgrep can dump into the context.
-4. **No background processes.** `sandbox_exec` is blocking. Agents can't start a dev server and then run tests against it, tail logs while work continues, or run a long-running suite without holding the tool slot.
-5. **No output truncation.** A failing webpack build emits 50 MB of stderr. One bad run can evict the entire recent context.
-
-Each of these is individually cheap to close; the impact is multiplicative because coding agents hit every one of them within a single turn.
-
-#### New tools
-
-| Tool | Description |
-|------|-------------|
-| `sandbox_edit` | Exact-string replacement in a file. Inputs: `path`, `old_string`, `new_string`, optional `replace_all` (default false). Fails when `old_string` is non-unique and `replace_all` is false, when `old_string` is absent, or when `path` doesn't exist. Mirrors Claude Code's Edit. |
-| `sandbox_grep` | Ripgrep-backed content search. Inputs: `pattern`, optional `path`, `glob`, `output_mode` (one of `files_with_matches` \| `content` \| `count`; default `files_with_matches`), `head_limit` (default ~250). Output always capped by `head_limit`. |
-| `sandbox_glob` | Glob-style file path match, sorted by mtime (most recent first). Inputs: `pattern`, optional `path`, `head_limit`. |
-| `sandbox_process_read` | Read accumulated stdout/stderr from a backgrounded process by `process_id`. Returns new output since the last read and the process's current running/exited state. Output is truncated to a per-call byte cap. |
-| `sandbox_process_kill` | Terminate a backgrounded process by `process_id`. |
-
-#### Modified tools
-
-| Tool | Change |
-|------|--------|
-| `sandbox_exec` | Add optional `run_in_background` (default false). When true, returns `{process_id, started_at}` immediately instead of blocking; agent retrieves output via `sandbox_process_read`. Add `max_output_bytes` with head/tail/mixed truncation so one noisy command can't destroy the context. |
-| `sandbox_read_file` | Add optional `offset` (1-based line number, default 1) and `limit` (lines, default whole file but capped at a configurable maximum). Response includes total line count so the agent knows when more remains. |
-
-#### Explicitly out of scope
-
-- **`git clone` at task start / GitHub PR tool** — owned by Phase 2 Track 6.
-- **`apply_patch` (multi-file diff apply)** — redundant once `sandbox_edit` ships. Revisit only if agents show need for multi-file atomic edits.
-- **Todo/plan tracking tool** — potentially useful, but not sandbox-coupled; belongs to a separate cross-cutting design.
-- **HTTP/fetch tool with POST/PUT/DELETE** — `sandbox_exec("curl ...")` is adequate. Upgrade only if logs show it's a hot path.
-- **Interactive stdin / TTY / debugger attach** — E2B's process API doesn't cleanly support interactive sessions. Out of scope; revisit if needed.
-
-#### Task sketch
-
-| # | Task | Service | Description |
-|---|------|---------|-------------|
-| 1 | `sandbox_edit` tool | Worker | String-replace with uniqueness check, via `sbx.files.read` / `sbx.files.write` |
-| 2 | `sandbox_read_file` offset/limit | Worker | Extend Track 2 tool with line-range params |
-| 3 | `sandbox_grep` tool | Worker | Wrap `rg` in the sandbox with structured output and `head_limit` truncation |
-| 4 | `sandbox_glob` tool | Worker | Wrap glob + stat, sort by mtime |
-| 5 | `sandbox_exec` output truncation | Worker | Add `max_output_bytes` with head/tail/mixed modes |
-| 6 | `sandbox_exec` background mode | Worker | Add `run_in_background`; return `process_id`; integrate with E2B process API |
-| 7 | `sandbox_process_read` + `sandbox_process_kill` | Worker | Tools that reattach to backgrounded processes by `process_id` |
-| 8 | Sandbox template: install `ripgrep` | Infrastructure | Add `rg` to the platform's E2B template so `sandbox_grep` can rely on it |
-| 9 | Crash-recovery test for backgrounded processes | Cross-service | Verify that on worker crash + reconnect, an agent can still read output from a process launched before the crash (E2B keeps it alive) |
-| 10 | Integration tests | Cross-service | End-to-end coding loop: clone (via exec), edit, grep, run tests, read output |
-
-#### Crash-recovery implications
-
-Background processes introduce per-sandbox state **not** captured in Postgres checkpoints:
-
-- The E2B sandbox persists across worker crashes, and processes inside it keep running. On reconnect, the worker re-attaches to the sandbox by `sandbox_id` (already implemented in Track 2) and to individual processes by their E2B-assigned `process_id`.
-- If the sandbox itself was destroyed (TTL expired during outage), the backgrounded processes die with it — same failure mode as Track 2's sandbox loss; the task dead-letters with `sandbox_lost`.
-- **Idempotency:** if a checkpoint is re-executed after a crash (Phase 1 allows re-running an interrupted in-flight node), an agent's `sandbox_exec(..., run_in_background=True)` call could double-launch the same process. This is the same non-idempotent-tool concern Phase 1 already flags; `sandbox_exec` is already non-idempotent, and background mode does not make it worse. A follow-up in Phase 3 non-idempotent-tool guards would address it alongside the existing foreground case.
-
-#### Template dependency
-
-Ripgrep is not in every E2B template. Options:
-
-- **(A) Pre-install `rg` in the platform's custom E2B template.** Simple, matches the Claude-Code-cloud pattern of pre-baked templates. Preferred.
-- **(B) Auto-fallback to `grep -r` when `rg` is absent.** Keeps the tool usable on third-party templates at the cost of worse output quality and performance.
-
-Track 3 adopts (A) as the default; (B) is a considered fallback if customers pin arbitrary templates.
-
-**Exec plan:** TBD — created after design approval.
+Relocated to **Phase 2 Track 8** — see [../phase-2/track-8-coding-primitives.md](../phase-2/track-8-coding-primitives.md) for the full design. Coding primitives are platform surface area (alongside Memory, GitHub Integration, Context Window Management), not a cross-cutting capability add-on. The track content itself is unchanged by the move.
 
 ### Track sequencing
 
@@ -445,7 +372,7 @@ Track 1 is self-contained — when complete, agents can produce output artifacts
 
 Track 2 adds sandbox and file input. It uses Track 1's S3 client for `sandbox_download` and artifact storage for input file injection. The `sandbox_id` column, `dead_letter_reason` extension, sandbox agent config, multipart submission, and file attachment UI all live in Track 2.
 
-Track 3 (proposed) extends the sandbox tool surface. It depends on Track 2's sandbox provisioner, `sandbox_id` persistence, and the existing sandbox tool registration pattern. It is independent of Track 1 (no artifact changes) and independent of Phase 2 Track 6 (GitHub work is strictly repo ingress/egress).
+Coding primitives (formerly Track 3, now Phase 2 Track 8) depend on Track 2's sandbox provisioner, `sandbox_id` persistence, and the existing sandbox tool registration pattern. They are independent of Track 1 (no artifact changes) and independent of Phase 2 Track 6 (GitHub work is strictly repo ingress/egress).
 
 ## Dependencies
 

--- a/docs/design-docs/phase-2/design.md
+++ b/docs/design-docs/phase-2/design.md
@@ -114,6 +114,21 @@ Enable code agents to access customer repositories and deliver results as pull r
 Primary design coverage:
 - Detailed design TBD (will be developed as a dedicated design doc when this track is planned)
 
+### Track 8 — Coding-Agent Primitives
+
+Extend the sandbox tool surface so agents doing real iterative coding (edit → run test → read stack trace → edit again) can work without blowing through the context window on every turn. The Agent Capabilities Track 2 tools are sufficient to "run a script"; Track 8 is what makes "iterate on a codebase" practical.
+
+- `sandbox_edit` (surgical string-replace, not full-file rewrite)
+- `sandbox_read_file` with `offset` + `limit` (partial reads)
+- `sandbox_grep` + `sandbox_glob` (first-class ripgrep/glob surfaces, not shell-wrapped)
+- `sandbox_exec` output truncation + background mode with `sandbox_process_read` / `sandbox_process_kill`
+
+**Depends on:** Agent Capabilities Track 2 (E2B Sandbox & File Input) — already complete.
+
+**Relocated from Agent Capabilities Track 3** on 2026-04-18 — coding primitives are platform surface area, not a cross-cutting capability add-on.
+
+**Status:** Design proposed — see [track-8-coding-primitives.md](./track-8-coding-primitives.md). Implementation plan TBD.
+
 ### Track 7 — Context Window Management
 
 Keep long-running tasks viable by bounding the in-task message-history growth that otherwise pushes tasks into context-limit or cost-limit failure.
@@ -140,16 +155,16 @@ For implementation planning, the safest order is:
 5. **Agent Capabilities (cross-cutting)** — see [agent-capabilities/design.md](../agent-capabilities/design.md):
    - AC Track 1 — Output Artifact Storage ✅
    - AC Track 2 — E2B Sandbox & File Input ✅
-   - **AC Track 3 — Coding-Agent Primitives (proposed; must land before Phase 3)**
-6. Track 7 — Context Window Management (recommended ahead of Track 5: long tasks must be able to finish before cross-task memory is useful)
-7. Track 5 — Memory
-8. Track 6 — GitHub Integration
+6. **Track 8 — Coding-Agent Primitives (proposed; must land before Phase 3)** — relocated from AC Track 3
+7. Track 7 — Context Window Management (recommended ahead of Track 5: long tasks must be able to finish before cross-task memory is useful)
+8. Track 5 — Memory
+9. Track 6 — GitHub Integration
 
 Phase 2 Tracks 1–4 and Agent Capabilities Tracks 1 & 2 are complete — the platform can now run coding and document-processing workloads end-to-end with sandbox execution and artifact storage.
 
-**AC Track 3 is gating for Phase 3.** The Track 2 sandbox tool surface is sufficient to run a script but not to iterate on a codebase — every edit re-sends the full file, every search goes through `sandbox_exec` with no output cap, long-running processes block the tool slot. Phase 3 work (batch APIs, webhooks, structured output, scaling) should be built on top of a mature coding-agent tool surface rather than ship on top of token-burning primitives that would then need to be rolled back later. See [agent-capabilities/design.md#track-3-coding-agent-primitives-proposed](../agent-capabilities/design.md) for the detailed proposal.
+**Track 8 is gating for Phase 3.** The Agent Capabilities Track 2 sandbox tool surface is sufficient to run a script but not to iterate on a codebase — every edit re-sends the full file, every search goes through `sandbox_exec` with no output cap, long-running processes block the tool slot. Phase 3 work (batch APIs, webhooks, structured output, scaling) should be built on top of a mature coding-agent tool surface rather than ship on top of token-burning primitives that would then need to be rolled back later. See [track-8-coding-primitives.md](./track-8-coding-primitives.md) for the detailed proposal.
 
-Tracks 5 (Memory), 6 (GitHub Integration), and 7 (Context Window Management) can be sequenced alongside AC Track 3 as independent initiatives — they have no blocking dependency in either direction. Track 7 is recommended ahead of Track 5 on the grounds that cross-task memory is less useful if long-running tasks cannot complete.
+Tracks 5 (Memory), 6 (GitHub Integration), 7 (Context Window Management), and 8 (Coding-Agent Primitives) can be sequenced as independent initiatives — they have no blocking dependency in either direction. Track 7 is recommended ahead of Track 5 on the grounds that cross-task memory is less useful if long-running tasks cannot complete.
 
 ---
 

--- a/docs/design-docs/phase-2/design.md
+++ b/docs/design-docs/phase-2/design.md
@@ -129,6 +129,33 @@ Extend the sandbox tool surface so agents doing real iterative coding (edit → 
 
 **Status:** Design proposed — see [track-8-coding-primitives.md](./track-8-coding-primitives.md). Implementation plan TBD.
 
+### Track 9 — Planning Primitive
+
+Add a durable, first-class plan/todo surface that survives compaction, checkpoint restart, and follow-up — the managed-runtime equivalent of Claude Code's `TodoWrite`, but as typed state rather than a message-history convention.
+
+- Typed `plan: list[PlanItem]` field on graph state; checkpointed by LangGraph
+- `plan_write` tool (full-list replace semantics) the agent calls when it decides to plan or replan
+- Auto-injection of current plan state into every LLM call, post-compaction
+- Opt-in per agent via `agent_config.planning.enabled` (default `false`), matching Track 5's shape
+- ReAct topology unchanged — the primitive is data, not graph control flow
+
+**Depends on:** Nothing hard-blocking. Composes with Track 7 (injection runs post-compaction) and Track 10 (deep-research mode may use this as its plan data surface).
+
+**Status:** Stub — see [track-9-planning-primitive.md](./track-9-planning-primitive.md). Direction sketched during 2026-04-17 brainstorm; full design and open questions pending.
+
+### Track 10 — Deep Research Mode (proposed)
+
+Add a first-class "deep research" agent mode selected at agent creation (`agent_config.mode = 'deep_research'`), with a distinct graph topology (orchestrator + parallel subagents + synthesiser) rather than a bolt-on tool. Inspired by Anthropic and OpenAI deep-research products.
+
+- New graph topology, separate from the default ReAct mode
+- Parallel subagent fan-out; subagent costs roll up into the parent task's budget (single budget envelope)
+- Builds on Track 9's planning primitive for its plan/tree representation
+- Coding capabilities (Track 8) remain orthogonal — any mode can be configured with coding tools
+
+**Depends on:** Track 9 (planning primitive) for the plan data surface.
+
+**Status:** Not started — brainstorm pending. Registered here to block accidental coupling with Track 9.
+
 ### Track 7 — Context Window Management
 
 Keep long-running tasks viable by bounding the in-task message-history growth that otherwise pushes tasks into context-limit or cost-limit failure.

--- a/docs/design-docs/phase-2/track-8-coding-primitives.md
+++ b/docs/design-docs/phase-2/track-8-coding-primitives.md
@@ -1,0 +1,80 @@
+# Track 8 Design — Coding-Agent Primitives
+
+**Status: Proposed — design complete, implementation plan TBD.**
+
+Relocated from Agent Capabilities Track 3 on 2026-04-18. Coding primitives are platform surface area, not a cross-cutting capability add-on, and belong alongside the other Phase 2 runtime tracks.
+
+## Context
+
+Extends the sandbox tool surface so agents doing real iterative coding (edit → run test → read stack trace → edit again) can work without blowing through the context window on every turn. Agent Capabilities Track 2 shipped tools sufficient to "run a script"; Track 8 is what makes "iterate on a codebase" practical. Depends on Agent Capabilities Track 2 (E2B Sandbox & File Input).
+
+**Scope boundary:** Strictly in-sandbox tooling. Phase 2 Track 6 (GitHub Integration) owns the repo ingress/egress story — `git clone` at task start, branch push, PR creation. Track 8 does not duplicate any of that; agents can still `sandbox_exec("git clone ...")` in the meantime.
+
+## Motivation
+
+Observed gaps with the Track 2 tool set, each exercised many times per coding turn:
+
+1. **No surgical edit.** Every file change requires `sandbox_write_file` with the full new contents. For a 2k-line file, that's ~8k tokens per change, and long edit sessions drift — the LLM silently mutates unrelated code.
+2. **No partial file read.** `sandbox_read_file` returns the whole file. Reading a 10k-line file to locate one stack frame costs ~40k tokens.
+3. **No first-class search.** Agents fall back to `sandbox_exec("rg ...")`, which wraps the search in shell scaffolding, loses structured output, and has no cap on how much ripgrep can dump into the context.
+4. **No background processes.** `sandbox_exec` is blocking. Agents can't start a dev server and then run tests against it, tail logs while work continues, or run a long-running suite without holding the tool slot.
+5. **No output truncation.** A failing webpack build emits 50 MB of stderr. One bad run can evict the entire recent context.
+
+Each of these is individually cheap to close; the impact is multiplicative because coding agents hit every one of them within a single turn.
+
+## New tools
+
+| Tool | Description |
+|------|-------------|
+| `sandbox_edit` | Exact-string replacement in a file. Inputs: `path`, `old_string`, `new_string`, optional `replace_all` (default false). Fails when `old_string` is non-unique and `replace_all` is false, when `old_string` is absent, or when `path` doesn't exist. Mirrors Claude Code's Edit. |
+| `sandbox_grep` | Ripgrep-backed content search. Inputs: `pattern`, optional `path`, `glob`, `output_mode` (one of `files_with_matches` \| `content` \| `count`; default `files_with_matches`), `head_limit` (default ~250). Output always capped by `head_limit`. |
+| `sandbox_glob` | Glob-style file path match, sorted by mtime (most recent first). Inputs: `pattern`, optional `path`, `head_limit`. |
+| `sandbox_process_read` | Read accumulated stdout/stderr from a backgrounded process by `process_id`. Returns new output since the last read and the process's current running/exited state. Output is truncated to a per-call byte cap. |
+| `sandbox_process_kill` | Terminate a backgrounded process by `process_id`. |
+
+## Modified tools
+
+| Tool | Change |
+|------|--------|
+| `sandbox_exec` | Add optional `run_in_background` (default false). When true, returns `{process_id, started_at}` immediately instead of blocking; agent retrieves output via `sandbox_process_read`. Add `max_output_bytes` with head/tail/mixed truncation so one noisy command can't destroy the context. |
+| `sandbox_read_file` | Add optional `offset` (1-based line number, default 1) and `limit` (lines, default whole file but capped at a configurable maximum). Response includes total line count so the agent knows when more remains. |
+
+## Explicitly out of scope
+
+- **`git clone` at task start / GitHub PR tool** — owned by Phase 2 Track 6.
+- **`apply_patch` (multi-file diff apply)** — redundant once `sandbox_edit` ships. Revisit only if agents show need for multi-file atomic edits.
+- **Todo/plan tracking tool** — handled separately by **Phase 2 Track 9 (Planning Primitive)**, which is a cross-cutting primitive not coupled to the sandbox.
+- **HTTP/fetch tool with POST/PUT/DELETE** — `sandbox_exec("curl ...")` is adequate. Upgrade only if logs show it's a hot path.
+- **Interactive stdin / TTY / debugger attach** — E2B's process API doesn't cleanly support interactive sessions. Out of scope; revisit if needed.
+
+## Task sketch
+
+| # | Task | Service | Description |
+|---|------|---------|-------------|
+| 1 | `sandbox_edit` tool | Worker | String-replace with uniqueness check, via `sbx.files.read` / `sbx.files.write` |
+| 2 | `sandbox_read_file` offset/limit | Worker | Extend Track 2 tool with line-range params |
+| 3 | `sandbox_grep` tool | Worker | Wrap `rg` in the sandbox with structured output and `head_limit` truncation |
+| 4 | `sandbox_glob` tool | Worker | Wrap glob + stat, sort by mtime |
+| 5 | `sandbox_exec` output truncation | Worker | Add `max_output_bytes` with head/tail/mixed modes |
+| 6 | `sandbox_exec` background mode | Worker | Add `run_in_background`; return `process_id`; integrate with E2B process API |
+| 7 | `sandbox_process_read` + `sandbox_process_kill` | Worker | Tools that reattach to backgrounded processes by `process_id` |
+| 8 | Sandbox template: install `ripgrep` | Infrastructure | Add `rg` to the platform's E2B template so `sandbox_grep` can rely on it |
+| 9 | Crash-recovery test for backgrounded processes | Cross-service | Verify that on worker crash + reconnect, an agent can still read output from a process launched before the crash (E2B keeps it alive) |
+| 10 | Integration tests | Cross-service | End-to-end coding loop: clone (via exec), edit, grep, run tests, read output |
+
+## Crash-recovery implications
+
+Background processes introduce per-sandbox state **not** captured in Postgres checkpoints:
+
+- The E2B sandbox persists across worker crashes, and processes inside it keep running. On reconnect, the worker re-attaches to the sandbox by `sandbox_id` (already implemented in Agent Capabilities Track 2) and to individual processes by their E2B-assigned `process_id`.
+- If the sandbox itself was destroyed (TTL expired during outage), the backgrounded processes die with it — same failure mode as the Track 2 sandbox-loss path; the task dead-letters with `sandbox_lost`.
+- **Idempotency:** if a checkpoint is re-executed after a crash (Phase 1 allows re-running an interrupted in-flight node), an agent's `sandbox_exec(..., run_in_background=True)` call could double-launch the same process. This is the same non-idempotent-tool concern Phase 1 already flags; `sandbox_exec` is already non-idempotent, and background mode does not make it worse. A follow-up in Phase 3 non-idempotent-tool guards would address it alongside the existing foreground case.
+
+## Template dependency
+
+Ripgrep is not in every E2B template. Options:
+
+- **(A) Pre-install `rg` in the platform's custom E2B template.** Simple, matches the Claude-Code-cloud pattern of pre-baked templates. Preferred.
+- **(B) Auto-fallback to `grep -r` when `rg` is absent.** Keeps the tool usable on third-party templates at the cost of worse output quality and performance.
+
+Track 8 adopts (A) as the default; (B) is a considered fallback if customers pin arbitrary templates.

--- a/docs/design-docs/phase-2/track-9-planning-primitive.md
+++ b/docs/design-docs/phase-2/track-9-planning-primitive.md
@@ -1,0 +1,46 @@
+# Track 9 Design — Planning Primitive
+
+**Status: Stub — direction sketched, full design pending its own brainstorm and design pass.**
+
+## Why this track exists
+
+Long-running agent tasks — coding loops especially, but also any task with more than a handful of steps — lose coherence when there is no durable surface for "what the agent is trying to accomplish and how far along it is". The LLM drifts, Track 7's compaction eventually removes planning detail from message history, worker restarts and follow-ups lose in-conversation scratch notes.
+
+Claude Code's `TodoWrite` tool is the widely-copied answer to this gap. It works for a desktop CLI because the list lives in message history and Claude Code's context is small enough that the list stays visible. In a managed multi-tenant runtime with aggressive compaction and Console/API visibility requirements, the equivalent has to be **first-class durable state**, not a message-history convention.
+
+Track 9 adds that primitive: a typed `plan` field on the task's graph state, written by the agent via a `plan_write` tool, auto-injected into the LLM's context on every call, and exposed to the Console and API.
+
+## Relationship to other tracks
+
+- **Track 5 (Memory):** Memory is *cross-task* ("what did I learn before?"). Plans are *within-task* ("what am I doing right now?"). Different scope, different storage, no shared schema. A task's plan is thrown away at task end; memory is curated and persisted.
+- **Track 7 (Context Window Management):** The plan survives Track 7 compaction because it is injected *after* Track 7's transform runs, on every LLM call. Track 7 is free to drop old `plan_write` tool returns from history; the injection replaces that view.
+- **Track 10 (Deep Research Mode, proposed):** Track 10 may choose a plan-execute graph topology (planner → executor → replanner) for research orchestration. If it does, it builds on Track 9's `plan` state field rather than inventing its own. **Track 9 is the data primitive; Track 10 picks the topology.**
+- **Track 8 (Coding-Agent Primitives):** Coding agents are the motivating use case for the planning primitive. Track 8's out-of-scope list already flags "Todo/plan tracking tool — handled separately by Track 9".
+
+## Shape of the proposed work
+
+Direction established in brainstorm (2026-04-17):
+
+1. **First-class durable state, not message-history convention.** Plan lives as a typed field on graph state (`plan: list[PlanItem]`), checkpointed by LangGraph, serves API reads, renders in Console.
+2. **Per-task scope.** Fresh plan per task. No cross-task continuity at this primitive's layer — cross-task continuity is Track 5's job. Follow-up and redrive (Track 4) preserve the plan because they reuse the same `task_id`.
+3. **ReAct, not plan-execute.** Graph topology is unchanged from today's single-agent-node ReAct loop. The agent decides when to plan and when to replan by calling `plan_write` with an updated list. No planner/executor/replanner nodes are introduced by Track 9. Track 10 may choose a different topology for its own mode; Track 9 does not force it.
+4. **Auto-injection every LLM call, post-compaction.** Before each LLM call, if the plan is non-empty, a short rendered block (`"## Current plan\n☐ …\n✓ …"`) is prepended to the message list *after* Track 7's compaction transform runs. Guarantees the LLM always sees current plan state. Empty plan → no injection (no cost).
+5. **Opt-in per agent via `agent_config.planning.enabled` (default `false`).** When `false`: no tool, no injection, no preamble. Matches Track 5's opt-in shape (`memory.enabled`).
+6. **Platform-provided system-prompt preamble when enabled.** Prepended to the customer's `system_prompt` when `planning.enabled = true`. Tells the agent *when* to plan (non-trivial tasks) and *when not to* (1–2 step tasks). Directly addresses the "From Plan to Action" finding that forced bad plans hurt more than no plan.
+7. **Item schema (Claude Code shape + id + result).** Each item is `{ id, content, activeForm, status, result }` where `status ∈ { pending, in_progress, completed, skipped }`. `id` is stable across plan rewrites so the Console can render progress diffs without heuristic matching. `result` is the agent-written outcome when an item moves to `completed` or `skipped` — audit trail for customer trust and compliance.
+
+## Open design questions (to be answered during the brainstorm)
+
+- **Write semantics.** Full-list replace (like Claude Code's `TodoWrite`) or patch-style (add/update/remove ops)? Full-replace is simpler but costs more tokens in the tool call; patch is cheaper but introduces the complexity of conflict resolution across turns.
+- **Ownership.** Agent-only writes (simplest), customer-prescribed initial plan at submission (prescribes work like a job spec), or HITL-human edits during pauses (biggest surface, conflict resolution needed).
+- **HITL integration.** Does transitioning an item to `in_progress` or `completed` trigger a HITL pause point? Or is the plan silent with respect to HITL and only the existing `wait_for_input` / `wait_for_approval` tools create pauses?
+- **API surface.** Read-only (`GET /v1/tasks/{id}/plan`) or mutable (HITL plan edits via `PATCH`)? Tied to the ownership question.
+- **Console rendering.** List view only? Timeline of status changes? Diff view across turns? How does it compose with the existing Unified Timeline from Track 2?
+- **Plan size limits.** Platform cap on total items per plan, per-item content length, total tokens the injection can consume.
+- **Rendering format for injection.** Markdown checkbox block? JSON? Rendered for max LLM parse-ability vs token economy.
+- **Pre-compaction flush analogue.** Track 7 is expected to insert a memory flush hook before aggressive compaction. Does it also give the agent a chance to *update the plan* before aggressive compaction runs? The answer is probably "no — the plan is already durable and injected post-compaction", but worth confirming during design.
+- **Exactly-one-`in_progress` rule.** Claude Code's `TodoWrite` prompt enforces "exactly one in_progress at a time". Do we enforce this at the tool layer (reject the call if more than one), at the prompt layer (discourage in the preamble), or leave it to the agent's discretion? Tool-layer enforcement is the safest but rejects legitimate cases where a coding agent might run tests in the background while editing.
+
+## Next step
+
+Run a dedicated brainstorm for this track (superpowers:brainstorming) before writing any implementation plan. The direction above is approved; the details in "Open design questions" are the ones that require decisions during the brainstorm.


### PR DESCRIPTION
## Summary

- **Relocate coding-agent primitives** from Agent Capabilities Track 3 → **Phase 2 Track 8**. Coding primitives are platform surface area, not a cross-cutting capability add-on — they belong alongside Memory, GitHub Integration, and Context Window Management.
- **Register Track 9 — Planning Primitive (stub).** Captures the direction from a 2026-04-17 brainstorm: a durable, first-class plan/todo surface that survives compaction and checkpoint restart. Claude Code's `TodoWrite` shape, promoted to typed state rather than message-history convention. Full design and open questions are enumerated inline; the brainstorm is deferred to its own pass.
- **Register Track 10 — Deep Research Mode (placeholder line).** Not started, but registered in the index to prevent accidental coupling with Track 9. Track 9 is the data primitive (plan as typed state); Track 10 may choose a planner/executor/replanner graph topology and will build on Track 9's plan field rather than reinventing one.

## Key design decisions already settled

**Track 9 (planning primitive) direction** — captured in the stub as "Shape of the proposed work":

- First-class durable state (`plan: list[PlanItem]` on graph state), not message-history convention — survives compaction, serves API reads, renders in Console.
- Per-task scope. No cross-task continuity at this layer — that's Track 5's (Memory) job.
- ReAct topology unchanged. The primitive is data, not graph control flow; it composes with plan-execute if Track 10 wants that topology later.
- Auto-injection every LLM call, post-compaction. Guarantees the LLM always sees current plan state regardless of Track 7's transforms.
- Opt-in per agent via `agent_config.planning.enabled` (default `false`) — matches Track 5's `memory.enabled` shape. When `false`: no tool, no injection, no preamble.
- Platform-provided system-prompt preamble when enabled, telling the agent when to plan and when not to — directly addresses the "From Plan to Action" finding that forced bad plans hurt more than no plan.
- Item schema `{ id, content, activeForm, status, result }` with `status ∈ { pending, in_progress, completed, skipped }`.

## Files

- New: `docs/design-docs/phase-2/track-8-coding-primitives.md`
- New: `docs/design-docs/phase-2/track-9-planning-primitive.md`
- Modified: `docs/design-docs/agent-capabilities/design.md` — Track 3 section shrunk to a relocation pointer
- Modified: `docs/design-docs/phase-2/design.md` — Track 8/9/10 sections added; Recommended Planning Order updated
- Modified: `STATUS.md` — Tracks 8/9/10 rows added; AC Track 3 marked relocated

Docs-only. No code or schema changes.

## Test plan

- [ ] Confirm the Track 8 content in the new file matches what was in AC Track 3 (content move, not rewrite).
- [ ] Confirm `docs/design-docs/phase-2/design.md` Recommended Planning Order names Track 8 as gating for Phase 3 (previously "AC Track 3").
- [ ] Confirm `STATUS.md` shows Track 8 as "Design proposed", Track 9 as "Stub", Track 10 as "Not started".
- [ ] Confirm AC `design.md` Track 3 section is a relocation pointer, not full content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)