### PR TITLE
Fix read_url fetch handling for blocked and oversized pages

### DIFF
--- a/services/worker-service/tests/test_read_url_tool.py
+++ b/services/worker-service/tests/test_read_url_tool.py
@@ -42,6 +42,39 @@ def _build_client(handler) -> httpx.AsyncClient:
 
 class TestReadUrlFetcher:
     @pytest.mark.asyncio
+    async def test_uses_browser_like_headers_for_public_pages(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers.get("user-agent", "").startswith("Mozilla/5.0") and request.headers.get(
+                "accept-language"
+            ) == "en-US,en;q=0.9":
+                return httpx.Response(
+                    200,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
+                    content="""
+                        <html>
+                            <head><title>Readable Article</title></head>
+                            <body><main><p>Accessible content.</p></main></body>
+                        </html>
+                    """,
+                )
+
+            return httpx.Response(
+                403,
+                headers={"Content-Type": "text/html; charset=utf-8"},
+                content="<html><body>Please enable JS and disable any ad blocker</body></html>",
+            )
+
+        fetcher = ReadUrlFetcher(
+            client=_build_client(handler),
+            resolver=_public_resolver,
+        )
+
+        result = await fetcher.fetch("https://example.com/protected", 5000)
+
+        assert result.title == "Readable Article"
+        assert "Accessible content." in result.content
+
+    @pytest.mark.asyncio
     async def test_fetches_and_truncates_html_content(self) -> None:
         async def handler(request: httpx.Request) -> httpx.Response:
             del request
@@ -86,6 +119,39 @@ class TestReadUrlFetcher:
         assert result["title"] == "Example Page"
         assert result["content"].startswith("# Example Page")
         assert "[truncated]" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_accepts_large_html_pages_within_updated_body_limit(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            repeated_paragraph = "Live updates from a major news event. "
+            html = """
+                <html>
+                    <head><title>Large Page</title></head>
+                    <body>
+                        <main>
+                            <h1>Large Page</h1>
+                            <p>{paragraph}</p>
+                        </main>
+                    </body>
+                </html>
+            """.format(paragraph=repeated_paragraph * 35_000)
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/html; charset=utf-8"},
+                content=html,
+            )
+
+        fetcher = ReadUrlFetcher(
+            client=_build_client(handler),
+            resolver=_public_resolver,
+        )
+
+        result = await fetcher.fetch("https://example.com/live", 800)
+
+        assert result.title == "Large Page"
+        assert result.content.startswith("# Large Page")
+        assert "[truncated]" in result.content
 
     @pytest.mark.asyncio
     async def test_rejects_private_targets(self) -> None:

--- a/services/worker-service/tools/read_url.py
+++ b/services/worker-service/tools/read_url.py
@@ -22,6 +22,23 @@ MAX_BODY_BYTES: Final[int] = 1_000_000
 MAX_REDIRECTS: Final[int] = 3
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 10.0
 DISALLOWED_HOST_SUFFIXES: Final[tuple[str, ...]] = (".localhost", ".local", ".internal")
+DEFAULT_REQUEST_HEADERS: Final[dict[str, str]] = {
+    # Some news sites and CDNs block obvious bot headers but allow the same public
+    # pages to be fetched with standard browser request metadata.
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/135.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Upgrade-Insecure-Requests": "1",
+}
 STRIP_TAGS: Final[tuple[str, ...]] = (
     "script",
     "style",
@@ -51,6 +68,7 @@ class _FetchedResponse:
     status_code: int
     headers: dict[str, str]
     body: bytes
+    body_truncated: bool = False
 
 
 class ReadUrlFetcher:
@@ -109,6 +127,9 @@ class ReadUrlFetcher:
             if not truncated:
                 raise ToolExecutionError(f"No readable content was extracted from {current_url}.")
 
+            if response.body_truncated and len(content) <= max_chars:
+                truncated = _append_fetch_truncation_notice(truncated, max_chars)
+
             return ReadUrlResultData(
                 final_url=response.url,
                 title=title,
@@ -145,16 +166,11 @@ class ReadUrlFetcher:
             _assert_public_ip(ipaddress.ip_address(ip_text))
 
     async def _request_once(self, url: str) -> _FetchedResponse:
-        headers = {
-            "User-Agent": "persistent-agent-runtime/phase1-read-url",
-            "Accept": "text/html,text/plain,application/xhtml+xml",
-        }
-
         if self._client is not None:
             return await _stream_response(
                 self._client,
                 url,
-                headers,
+                DEFAULT_REQUEST_HEADERS,
                 self._timeout_seconds,
                 self._max_body_bytes,
             )
@@ -163,7 +179,7 @@ class ReadUrlFetcher:
             return await _stream_response(
                 client,
                 url,
-                headers,
+                DEFAULT_REQUEST_HEADERS,
                 self._timeout_seconds,
                 self._max_body_bytes,
             )
@@ -185,17 +201,23 @@ async def _stream_response(
             timeout=timeout_seconds,
         ) as response:
             body = bytearray()
+            body_truncated = False
             async for chunk in response.aiter_bytes():
+                remaining = max_body_bytes - len(body)
+                if remaining <= 0:
+                    body_truncated = True
+                    break
+                if len(chunk) > remaining:
+                    body.extend(chunk[:remaining])
+                    body_truncated = True
+                    break
                 body.extend(chunk)
-                if len(body) > max_body_bytes:
-                    raise ToolExecutionError(
-                        f"Response body exceeded the {max_body_bytes} byte limit."
-                    )
             return _FetchedResponse(
                 url=str(response.url),
                 status_code=response.status_code,
                 headers={key.lower(): value for key, value in response.headers.items()},
                 body=bytes(body),
+                body_truncated=body_truncated,
             )
     except httpx.TimeoutException as exc:
         raise ToolTransportError(f"URL fetch timed out for {url}.") from exc
@@ -291,3 +313,10 @@ def _truncate_text(text: str, max_chars: int) -> str:
     if max_chars <= len(marker):
         return text[:max_chars]
     return text[: max_chars - len(marker)].rstrip() + marker
+
+
+def _append_fetch_truncation_notice(text: str, max_chars: int) -> str:
+    marker = "\n\n[source HTML truncated during fetch]"
+    if len(text) + len(marker) <= max_chars:
+        return text + marker
+    return _truncate_text(text + marker, max_chars)


### PR DESCRIPTION
## Summary

This PR improves `read_url` handling for public pages that either reject bot-like fetches or exceed the existing raw HTML fetch cap.

## What changed

- switched `read_url` to send browser-like request headers for public page fetches
- kept the existing 1 MB fetch cap, but stopped treating oversized HTML as a hard failure
- when the fetched HTML hits the cap, parse the partial HTML we already have instead of erroring out
- annotate the returned content when the source HTML was truncated during fetch
- added regressions for:
  - header-sensitive pages that return `403` to bot-like requests
  - large HTML pages that should still return bounded readable content

## Why

A real `read_url` failure against a New York Times live page showed two issues in sequence:

1. the site returned `403` to the existing bot-like request headers
2. once browser-like headers were used, the page fetched successfully but exceeded the raw body limit and failed before extraction

The fix keeps the tool deterministic while making it more resilient for large public pages. It also avoids the worse tradeoff of simply raising the raw fetch limit and buffering much more HTML than the agent needs.

## Validation

- `services/worker-service/.venv/bin/pytest services/worker-service/tests/test_read_url_tool.py -q`
- `make test`
- manual verification against `https://www.nytimes.com/live/2026/04/16/us/trump-news` through the updated fetcher returned bounded readable content instead of the prior `403` failure

## Impact

Tasks using `read_url` should now succeed more often on modern news/live pages without pushing large raw page payloads into the main agent context.
