### PR TITLE
Agent memory: Console config UI + checkpoint display + cost attribution fixes

### DIFF
--- a/services/api-service/src/main/java/com/persistentagent/api/service/CheckpointEventParser.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/CheckpointEventParser.java
@@ -240,6 +240,64 @@ public class CheckpointEventParser {
                 null);
     }
 
+    /**
+     * Extract the {@code pending_memory} channel from a checkpoint payload,
+     * or {@code null} if absent. Used by the caller to detect memory_write
+     * transitions across consecutive checkpoints — the channel value carries
+     * forward once written, so only a change in value identifies the actual
+     * memory_write step.
+     */
+    public Map<?, ?> extractPendingMemory(Object checkpointPayload, String checkpointId) {
+        Object parsedPayload = parseJson(checkpointPayload, "checkpoint_payload", checkpointId);
+        if (parsedPayload instanceof Map<?, ?> payloadMap) {
+            Object channelValues = payloadMap.get("channel_values");
+            if (channelValues instanceof Map<?, ?> channelMap) {
+                Object pendingMemory = channelMap.get("pending_memory");
+                if (pendingMemory instanceof Map<?, ?> memoryMap) {
+                    return memoryMap;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Build the user-facing event for a memory_write checkpoint. Only the
+     * title + summary are surfaced; observations, embeddings, and accounting
+     * are internal and belong on the memory detail page, not the timeline.
+     */
+    public CheckpointEventResponse buildMemoryEvent(Map<?, ?> memoryMap) {
+        return new CheckpointEventResponse(
+                "system",
+                "Memory Saved",
+                buildMemorySavedSummary(memoryMap),
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    // Render the memory_write step as a short prose summary: the memory's
+    // one-line title followed by its paragraph. Everything else on the
+    // pending_memory dict — observations_snapshot, summarizer_model_id,
+    // content_vec, token/cost accounting — is implementation detail and
+    // belongs on the memory detail page, not the task timeline.
+    private String buildMemorySavedSummary(Map<?, ?> memoryMap) {
+        String title = asString(memoryMap.get("title"));
+        String summary = asString(memoryMap.get("summary"));
+        if ((title == null || title.isBlank()) && (summary == null || summary.isBlank())) {
+            return "Agent observations were saved to persistent memory.";
+        }
+        if (title == null || title.isBlank()) {
+            return summary;
+        }
+        if (summary == null || summary.isBlank()) {
+            return title;
+        }
+        return title + "\n\n" + summary;
+    }
+
     private List<Object> asList(Object value) {
         if (value instanceof List<?> list) {
             return new ArrayList<>(list);

--- a/services/api-service/src/main/java/com/persistentagent/api/service/TaskService.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/TaskService.java
@@ -308,17 +308,44 @@ public class TaskService {
         List<Map<String, Object>> rows = taskRepository.getCheckpoints(taskId, tenantId)
                 .orElseThrow(() -> new TaskNotFoundException(taskId));
 
+        // The memory_write node sets the pending_memory channel, which then
+        // carries forward in every subsequent checkpoint's channel_values
+        // (LangGraph state is cumulative). So "this checkpoint has
+        // pending_memory" is not a reliable signal — only checkpoints where
+        // the pending_memory VALUE changed from the previous one are actual
+        // memory_write steps. We compute this boolean once, up-front, then
+        // override the event on flagged checkpoints.
+        boolean[] isMemoryWrite = new boolean[rows.size()];
+        Map<?, ?> priorPendingMemory = null;
+        for (int i = 0; i < rows.size(); i++) {
+            Map<String, Object> row = rows.get(i);
+            String checkpointId = (String) row.get("checkpoint_id");
+            Map<?, ?> currentPendingMemory = checkpointEventParser.extractPendingMemory(
+                    row.get("checkpoint_payload"), checkpointId);
+            if (currentPendingMemory != null && !currentPendingMemory.equals(priorPendingMemory)) {
+                isMemoryWrite[i] = true;
+                priorPendingMemory = currentPendingMemory;
+            }
+        }
+
         List<CheckpointResponse> checkpoints = IntStream.range(0, rows.size())
                 .mapToObj(i -> {
                     Map<String, Object> row = rows.get(i);
                     String checkpointId = (String) row.get("checkpoint_id");
                     String nodeName = checkpointEventParser.extractNodeName(row.get("metadata_payload"), checkpointId);
                     Object executionMetadata = parseJson(row.get("execution_metadata"));
-                    CheckpointEventResponse event = checkpointEventParser.parseEvent(
-                            row.get("checkpoint_payload"),
-                            row.get("metadata_payload"),
-                            nodeName,
-                            checkpointId);
+                    CheckpointEventResponse event;
+                    if (isMemoryWrite[i]) {
+                        Map<?, ?> memoryMap = checkpointEventParser.extractPendingMemory(
+                                row.get("checkpoint_payload"), checkpointId);
+                        event = checkpointEventParser.buildMemoryEvent(memoryMap);
+                    } else {
+                        event = checkpointEventParser.parseEvent(
+                                row.get("checkpoint_payload"),
+                                row.get("metadata_payload"),
+                                nodeName,
+                                checkpointId);
+                    }
                     return new CheckpointResponse(
                             checkpointId,
                             i + 1, // step_number derived from insertion order
@@ -331,7 +358,46 @@ public class TaskService {
                 })
                 .toList();
 
-        return new CheckpointListResponse(checkpoints);
+        return new CheckpointListResponse(relabelSubsequentMemorySaves(checkpoints));
+    }
+
+    // The first memory_write terminal step is a fresh save; subsequent ones
+    // (from follow-ups or redrives) UPSERT the same agent_memory_entries row
+    // via ON CONFLICT (task_id), so rendering them all as "Memory Saved" reads
+    // like multiple memories exist when only one does. Relabel 2nd+ events so
+    // users see the write path is a refresh, not a new row.
+    private List<CheckpointResponse> relabelSubsequentMemorySaves(List<CheckpointResponse> checkpoints) {
+        int memorySaveCount = 0;
+        List<CheckpointResponse> rewritten = new java.util.ArrayList<>(checkpoints.size());
+        for (CheckpointResponse cp : checkpoints) {
+            CheckpointEventResponse event = cp.event();
+            if (event != null && "Memory Saved".equals(event.title())) {
+                memorySaveCount++;
+                if (memorySaveCount > 1) {
+                    CheckpointEventResponse relabeled = new CheckpointEventResponse(
+                            event.type(),
+                            "Memory Updated",
+                            event.summary(),
+                            event.content(),
+                            event.toolName(),
+                            event.toolArgs(),
+                            event.toolResult(),
+                            event.usage());
+                    rewritten.add(new CheckpointResponse(
+                            cp.checkpointId(),
+                            cp.stepNumber(),
+                            cp.nodeName(),
+                            cp.workerId(),
+                            cp.costMicrodollars(),
+                            cp.executionMetadata(),
+                            relabeled,
+                            cp.createdAt()));
+                    continue;
+                }
+            }
+            rewritten.add(cp);
+        }
+        return rewritten;
     }
 
     public TaskObservabilityResponse getTaskObservability(UUID taskId) {

--- a/services/api-service/src/test/java/com/persistentagent/api/service/TaskServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/TaskServiceTest.java
@@ -843,6 +843,110 @@ class TaskServiceTest {
     }
 
     @Test
+    void getCheckpoints_memoryWriteCheckpoint_returnsMemorySavedEvent() {
+        UUID taskId = UUID.randomUUID();
+        Timestamp now = Timestamp.from(Instant.now());
+        // The memory_write node writes pending_memory but does NOT append to
+        // messages. Without the dedicated branch in CheckpointEventParser, the
+        // parser would re-render the trailing "ai" message as a duplicate
+        // "Agent Response" step. source is always "loop" (LangGraph's standard
+        // superstep label), so detection must key off channel_values.
+        List<Map<String, Object>> rows = List.of(
+                checkpointRow(
+                        "cp-memory-write",
+                        "worker-a",
+                        0,
+                        null,
+                        "{\"source\": \"loop\", \"step\": 6}",
+                        """
+                                {
+                                  "channel_values": {
+                                    "messages": [
+                                      {"kwargs": {"type":"ai","content":"final answer"}}
+                                    ],
+                                    "pending_memory": {
+                                      "title": "Completed: test task",
+                                      "summary": "Agent produced final answer.",
+                                      "outcome": "succeeded",
+                                      "content_vec": [0.1, 0.2, 0.3],
+                                      "summarizer_model_id": "claude-haiku-4-5",
+                                      "observations_snapshot": ["obs 1", "obs 2"],
+                                      "tags": [],
+                                      "summarizer_tokens_in": 500,
+                                      "summarizer_tokens_out": 80,
+                                      "summarizer_cost_microdollars": 1200,
+                                      "embedding_tokens": 42,
+                                      "embedding_cost_microdollars": 5
+                                    }
+                                  }
+                                }
+                                """,
+                        now));
+        when(taskRepository.getCheckpoints(taskId, "default")).thenReturn(Optional.of(rows));
+
+        CheckpointEventResponse event = taskService.getCheckpoints(taskId).checkpoints().get(0).event();
+
+        assertEquals("system", event.type());
+        assertEquals("Memory Saved", event.title());
+        // The memory_write step is rendered as prose (title + summary). None
+        // of the internal fields — observations, embedding vector, or
+        // accounting — leak into the task timeline.
+        assertNull(event.content());
+        assertEquals(
+                "Completed: test task\n\nAgent produced final answer.",
+                event.summary());
+    }
+
+    @Test
+    void getCheckpoints_multipleMemoryWrites_relabelsSubsequentAsUpdate() {
+        // First memory_write creates the agent_memory_entries row; subsequent
+        // memory_write steps (from follow-ups or redrives) UPSERT the same row
+        // via ON CONFLICT(task_id), so rendering them all as "Memory Saved"
+        // would imply multiple memories exist when only one does.
+        UUID taskId = UUID.randomUUID();
+        Timestamp now = Timestamp.from(Instant.now());
+        String memoryPayload = """
+                {
+                  "channel_values": {
+                    "messages": [ {"kwargs": {"type":"ai","content":"done"}} ],
+                    "pending_memory": {
+                      "title": "First pass",
+                      "summary": "Initial memory write.",
+                      "outcome": "succeeded"
+                    }
+                  }
+                }
+                """;
+        String memoryPayload2 = """
+                {
+                  "channel_values": {
+                    "messages": [ {"kwargs": {"type":"ai","content":"done again"}} ],
+                    "pending_memory": {
+                      "title": "Refreshed",
+                      "summary": "Follow-up refreshed memory.",
+                      "outcome": "succeeded"
+                    }
+                  }
+                }
+                """;
+        List<Map<String, Object>> rows = List.of(
+                checkpointRow("cp-memory-1", "worker-a", 0, null,
+                        "{\"source\": \"loop\", \"step\": 6}", memoryPayload, now),
+                checkpointRow("cp-memory-2", "worker-a", 0, null,
+                        "{\"source\": \"loop\", \"step\": 12}", memoryPayload2,
+                        Timestamp.from(now.toInstant().plusSeconds(10))));
+        when(taskRepository.getCheckpoints(taskId, "default")).thenReturn(Optional.of(rows));
+
+        List<CheckpointResponse> result = taskService.getCheckpoints(taskId).checkpoints();
+
+        assertEquals(2, result.size());
+        assertEquals("Memory Saved", result.get(0).event().title());
+        assertEquals("Memory Updated", result.get(1).event().title());
+        // Summary on the updated event still reflects the fresh memory content.
+        assertTrue(result.get(1).event().summary().contains("Follow-up refreshed memory."));
+    }
+
+    @Test
     void getCheckpoints_malformedPayload_fallsBackToCheckpointEvent() {
         UUID taskId = UUID.randomUUID();
         Timestamp now = Timestamp.from(Instant.now());

--- a/services/console/src/features/agents/AgentDetailPage.test.tsx
+++ b/services/console/src/features/agents/AgentDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -100,6 +100,28 @@ const MOCK_AGENT_WITH_SANDBOX = {
     },
 };
 
+const MOCK_AGENT_WITH_MEMORY = {
+    ...MOCK_AGENT,
+    agent_config: {
+        ...MOCK_AGENT.agent_config,
+        memory: {
+            enabled: true,
+            summarizer_model: 'claude-3-5-sonnet-latest',
+            max_entries: 2500,
+        },
+    },
+};
+
+const MOCK_AGENT_WITH_MEMORY_DEFAULTS = {
+    ...MOCK_AGENT,
+    agent_config: {
+        ...MOCK_AGENT.agent_config,
+        memory: {
+            enabled: true,
+        },
+    },
+};
+
 describe('AgentDetailPage', () => {
     it('shows sandbox info in read-only mode when sandbox is enabled', async () => {
         agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_SANDBOX, isLoading: false, error: null });
@@ -165,6 +187,34 @@ describe('AgentDetailPage', () => {
         );
     });
 
+    it('preserves memory config in the submit payload when saving an existing memory-enabled agent', async () => {
+        agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_MEMORY, isLoading: false, error: null });
+
+        render(<AgentDetailPage />, { wrapper: createWrapper() });
+
+        expect(await screen.findByRole('heading', { name: 'Research Agent' })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => expect(updateMock).toHaveBeenCalled());
+
+        expect(updateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                request: expect.objectContaining({
+                    agent_config: expect.objectContaining({
+                        memory: {
+                            enabled: true,
+                            summarizer_model: 'claude-3-5-sonnet-latest',
+                            max_entries: 2500,
+                        },
+                    }),
+                }),
+            }),
+            expect.any(Object),
+        );
+    });
+
     it('omits sandbox from submit payload when sandbox is disabled', async () => {
         agentMock.mockReturnValue({ data: MOCK_AGENT, isLoading: false, error: null });
 
@@ -204,6 +254,37 @@ describe('AgentDetailPage', () => {
         expect(screen.getByText('$5.00')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+    });
+
+    it('shows memory settings in overview and renders the memory tab without an icon', async () => {
+        agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_MEMORY, isLoading: false, error: null });
+
+        render(<AgentDetailPage />, { wrapper: createWrapper() });
+
+        expect(await screen.findByRole('heading', { name: 'Research Agent' })).toBeInTheDocument();
+
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+        expect(screen.getByText('claude-3-5-sonnet-latest')).toBeInTheDocument();
+        expect(screen.getByText('2500')).toBeInTheDocument();
+
+        const memoryTab = screen.getByTestId('agent-tab-memory');
+        expect(within(memoryTab).getByText('Memory')).toBeInTheDocument();
+        expect(memoryTab.querySelector('svg')).toBeNull();
+
+        expect(screen.getByTestId('agent-memory-status-label')).toHaveClass('whitespace-nowrap');
+    });
+
+    it('shows concrete memory defaults in overview when optional values are unset', async () => {
+        agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_MEMORY_DEFAULTS, isLoading: false, error: null });
+
+        render(<AgentDetailPage />, { wrapper: createWrapper() });
+
+        expect(await screen.findByRole('heading', { name: 'Research Agent' })).toBeInTheDocument();
+
+        expect(
+            screen.getByText('Platform default (runtime-configured; fallback: claude-haiku-4-5)')
+        ).toBeInTheDocument();
+        expect(screen.getByText('10,000')).toBeInTheDocument();
     });
 
     it('shows loading state', () => {

--- a/services/console/src/features/agents/AgentDetailPage.tsx
+++ b/services/console/src/features/agents/AgentDetailPage.tsx
@@ -21,7 +21,10 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Bot, Pencil, X, Brain } from 'lucide-react';
+import { Bot, Pencil, X } from 'lucide-react';
+
+const MEMORY_MAX_ENTRIES_PLATFORM_DEFAULT = 10_000;
+const MEMORY_SUMMARIZER_PLATFORM_DEFAULT = 'Platform default (runtime-configured; fallback: claude-haiku-4-5)';
 
 const agentDetailSchema = z.object({
     display_name: z.string().min(1, 'Agent name is required').max(200),
@@ -39,6 +42,16 @@ const agentDetailSchema = z.object({
     sandbox_vcpu: z.number().int().min(1).max(8).default(2),
     sandbox_memory_mb: z.number().int().min(512).max(8192).default(2048),
     sandbox_timeout_seconds: z.number().int().min(60).max(86400).default(3600),
+    memory_enabled: z.boolean().default(false),
+    memory_summarizer_model: z.string().default(''),
+    memory_max_entries: z
+        .string()
+        .default('')
+        .refine((value) => {
+            if (value.trim() === '') return true;
+            const parsed = Number.parseInt(value, 10);
+            return Number.isInteger(parsed) && parsed >= 100 && parsed <= 100_000;
+        }, 'Max entries must be between 100 and 100,000'),
 });
 
 type AgentDetailFormValues = z.infer<typeof agentDetailSchema>;
@@ -79,6 +92,9 @@ export function AgentDetailPage() {
             sandbox_vcpu: 2,
             sandbox_memory_mb: 2048,
             sandbox_timeout_seconds: 3600,
+            memory_enabled: false,
+            memory_summarizer_model: '',
+            memory_max_entries: '',
         },
     });
 
@@ -100,6 +116,9 @@ export function AgentDetailPage() {
                 sandbox_vcpu: agent.agent_config.sandbox?.vcpu ?? 2,
                 sandbox_memory_mb: agent.agent_config.sandbox?.memory_mb ?? 2048,
                 sandbox_timeout_seconds: agent.agent_config.sandbox?.timeout_seconds ?? 3600,
+                memory_enabled: agent.agent_config.memory?.enabled ?? false,
+                memory_summarizer_model: agent.agent_config.memory?.summarizer_model ?? '',
+                memory_max_entries: agent.agent_config.memory?.max_entries?.toString() ?? '',
             });
         }
     }, [agent, form]);
@@ -115,6 +134,19 @@ export function AgentDetailPage() {
                 timeout_seconds: data.sandbox_timeout_seconds,
             }
             : undefined;
+        const parsedMaxEntries = data.memory_max_entries.trim() === ''
+            ? undefined
+            : Number.parseInt(data.memory_max_entries, 10);
+        const summarizerModel = data.memory_summarizer_model.trim();
+        const hasExistingMemoryConfig = !!agent?.agent_config?.memory;
+        const hasMemoryConfig = hasExistingMemoryConfig || data.memory_enabled || !!summarizerModel || parsedMaxEntries !== undefined;
+        const memoryConfig = hasMemoryConfig
+            ? {
+                enabled: data.memory_enabled,
+                ...(summarizerModel ? { summarizer_model: summarizerModel } : {}),
+                ...(parsedMaxEntries !== undefined ? { max_entries: parsedMaxEntries } : {}),
+            }
+            : undefined;
         mutation.mutate(
             {
                 agentId,
@@ -127,6 +159,7 @@ export function AgentDetailPage() {
                         temperature: data.temperature,
                         tool_servers: data.tool_servers,
                         ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
+                        ...(memoryConfig ? { memory: memoryConfig } : {}),
                     },
                     status: data.status,
                     max_concurrent_tasks: data.max_concurrent_tasks,
@@ -176,6 +209,7 @@ export function AgentDetailPage() {
     const isDisabled = form.watch('status') === 'disabled';
     const selectedToolServers = form.watch('tool_servers');
     const sandboxEnabled = form.watch('sandbox_enabled');
+    const memoryEnabledInForm = form.watch('memory_enabled');
 
     function handleCancel() {
         form.reset();
@@ -257,10 +291,9 @@ export function AgentDetailPage() {
                         to={`${basePath}/memory`}
                         role="tab"
                         aria-selected={onMemoryRoute}
-                        className={`${tabBaseClass} ${onMemoryRoute ? tabActiveClass : tabInactiveClass} inline-flex items-center gap-1.5`}
+                        className={`${tabBaseClass} ${onMemoryRoute ? tabActiveClass : tabInactiveClass}`}
                         data-testid="agent-tab-memory"
                     >
-                        <Brain className="w-3.5 h-3.5" />
                         Memory
                     </Link>
                 )}
@@ -285,6 +318,33 @@ export function AgentDetailPage() {
                             </div>
                             {readOnlyField('Temperature', agent.agent_config.temperature)}
                             {toolLabels.length > 0 && readOnlyField('Tools', toolLabels.join(', '))}
+                            {agent.agent_config.memory && (
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 pt-4 border-t border-white/8">
+                                    <div>
+                                        <span
+                                            data-testid="agent-memory-status-label"
+                                            className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px] whitespace-nowrap"
+                                        >
+                                            Memory Status
+                                        </span>
+                                        <span className="text-foreground text-sm font-mono">
+                                            {agent.agent_config.memory.enabled ? 'Enabled' : 'Disabled'}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Summarizer Model</span>
+                                        <span className="text-foreground text-sm font-mono">
+                                            {agent.agent_config.memory.summarizer_model || MEMORY_SUMMARIZER_PLATFORM_DEFAULT}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Max Entries</span>
+                                        <span className="text-foreground text-sm font-mono">
+                                            {agent.agent_config.memory.max_entries ?? MEMORY_MAX_ENTRIES_PLATFORM_DEFAULT.toLocaleString()}
+                                        </span>
+                                    </div>
+                                </div>
+                            )}
                             {agent.agent_config.sandbox?.enabled && (
                                 <div className="space-y-2">
                                     <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Sandbox</span>
@@ -597,6 +657,93 @@ export function AgentDetailPage() {
                                                                 The sandbox stays alive while the task is running. This timeout only applies after
                                                                 a crash — if no one redrives within this window, the sandbox and its files are lost.
                                                                 Default: 1 hour.
+                                                            </p>
+                                                            <FormMessage className="text-destructive font-bold text-xs" />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+
+                                <div className="space-y-3">
+                                    <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Memory</span>
+                                    <div className="p-3 border border-border rounded-none bg-black/30 space-y-4">
+                                        <FormField
+                                            control={form.control}
+                                            name="memory_enabled"
+                                            render={({ field }) => (
+                                                <FormItem className="flex flex-row items-center gap-3">
+                                                    <FormControl>
+                                                        <Checkbox
+                                                            className="rounded-none border-primary data-[state=checked]:bg-primary data-[state=checked]:text-black"
+                                                            checked={field.value}
+                                                            onCheckedChange={field.onChange}
+                                                        />
+                                                    </FormControl>
+                                                    <div>
+                                                        <FormLabel className="font-normal font-mono cursor-pointer text-sm">
+                                                            Enable Memory
+                                                        </FormLabel>
+                                                        <p className="text-xs text-muted-foreground mt-0.5">
+                                                            Persist cross-task memory entries for this agent and expose the Memory tab in the Console.
+                                                        </p>
+                                                    </div>
+                                                </FormItem>
+                                            )}
+                                        />
+
+                                        {memoryEnabledInForm && (
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+                                                <FormField
+                                                    control={form.control}
+                                                    name="memory_summarizer_model"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <FormLabel className="uppercase tracking-widest text-muted-foreground/70 text-[10px]">Summarizer Model</FormLabel>
+                                                            <FormControl>
+                                                                <Input
+                                                                    aria-label="Summarizer Model"
+                                                                    className="rounded-none border-border bg-black/50 w-full"
+                                                                    placeholder="e.g., claude-3-5-haiku-latest"
+                                                                    {...field}
+                                                                />
+                                                            </FormControl>
+                                                            <p className="text-xs text-muted-foreground mt-1">
+                                                                Leave blank to use the runtime-configured platform default summarizer. If the platform does not override it, the worker falls back to
+                                                                {' '}
+                                                                <code>claude-haiku-4-5</code>
+                                                                .
+                                                            </p>
+                                                            <FormMessage className="text-destructive font-bold text-xs" />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                                <FormField
+                                                    control={form.control}
+                                                    name="memory_max_entries"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <FormLabel className="uppercase tracking-widest text-muted-foreground/70 text-[10px]">Max Entries</FormLabel>
+                                                            <FormControl>
+                                                                <Input
+                                                                    type="number"
+                                                                    min="100"
+                                                                    max="100000"
+                                                                    step="100"
+                                                                    aria-label="Max Entries"
+                                                                    className="rounded-none border-border bg-black/50 w-full"
+                                                                    placeholder="10000"
+                                                                    {...field}
+                                                                />
+                                                            </FormControl>
+                                                            <p className="text-xs text-muted-foreground mt-1">
+                                                                Optional retention cap. When omitted, the platform default of
+                                                                {' '}
+                                                                <code>10,000</code>
+                                                                {' '}
+                                                                entries is used.
                                                             </p>
                                                             <FormMessage className="text-destructive font-bold text-xs" />
                                                         </FormItem>

--- a/services/console/src/features/agents/CreateAgentDialog.test.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CreateAgentDialog } from './CreateAgentDialog';
+
+const createMock = vi.fn();
+
+vi.mock('./useAgents', () => ({
+    useCreateAgent: () => ({
+        mutate: createMock,
+        isPending: false,
+    }),
+}));
+
+vi.mock('@/features/submit/useModels', () => ({
+    useModels: () => ({
+        data: [
+            { provider: 'anthropic', model_id: 'claude-3-5-sonnet-latest', display_name: 'Claude 3.5 Sonnet' },
+            { provider: 'anthropic', model_id: 'claude-3-5-haiku-latest', display_name: 'Claude 3.5 Haiku' },
+        ],
+        isLoading: false,
+    }),
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+vi.mock('../tool-servers/useToolServers', () => ({
+    useToolServers: () => ({
+        data: [],
+        isLoading: false,
+    }),
+}));
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+}
+
+afterEach(() => {
+    cleanup();
+    createMock.mockReset();
+});
+
+describe('CreateAgentDialog', () => {
+    it('includes memory config in the create payload when memory is enabled', async () => {
+        render(<CreateAgentDialog open onOpenChange={() => {}} />, { wrapper: createWrapper() });
+
+        fireEvent.change(screen.getByLabelText(/agent name/i), { target: { value: 'Memory Agent' } });
+        fireEvent.click(screen.getByText('Enable Memory'));
+        fireEvent.change(screen.getByLabelText(/max entries/i), { target: { value: '2500' } });
+        fireEvent.change(screen.getByLabelText(/summarizer model/i), {
+            target: { value: 'claude-3-5-haiku-latest' },
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+        await waitFor(() => expect(createMock).toHaveBeenCalled());
+
+        expect(createMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agent_config: expect.objectContaining({
+                    memory: {
+                        enabled: true,
+                        max_entries: 2500,
+                        summarizer_model: 'claude-3-5-haiku-latest',
+                    },
+                }),
+            }),
+            expect.any(Object),
+        );
+    });
+});

--- a/services/console/src/features/agents/CreateAgentDialog.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.tsx
@@ -35,6 +35,16 @@ const createAgentSchema = z.object({
     sandbox_vcpu: z.number().int().min(1).max(8).default(2),
     sandbox_memory_mb: z.number().int().min(512).max(8192).default(2048),
     sandbox_timeout_seconds: z.number().int().min(60).max(86400).default(3600),
+    memory_enabled: z.boolean().default(false),
+    memory_summarizer_model: z.string().default(''),
+    memory_max_entries: z
+        .string()
+        .default('')
+        .refine((value) => {
+            if (value.trim() === '') return true;
+            const parsed = Number.parseInt(value, 10);
+            return Number.isInteger(parsed) && parsed >= 100 && parsed <= 100_000;
+        }, 'Max entries must be between 100 and 100,000'),
 });
 
 type CreateAgentFormValues = z.infer<typeof createAgentSchema>;
@@ -67,11 +77,15 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
             sandbox_vcpu: 2,
             sandbox_memory_mb: 2048,
             sandbox_timeout_seconds: 3600,
+            memory_enabled: false,
+            memory_summarizer_model: '',
+            memory_max_entries: '',
         },
     });
 
     const selectedToolServers = form.watch('tool_servers');
     const sandboxEnabled = form.watch('sandbox_enabled');
+    const memoryEnabled = form.watch('memory_enabled');
 
     function onSubmit(data: CreateAgentFormValues) {
         const sandboxConfig = data.sandbox_enabled
@@ -81,6 +95,18 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
                 vcpu: data.sandbox_vcpu,
                 memory_mb: data.sandbox_memory_mb,
                 timeout_seconds: data.sandbox_timeout_seconds,
+            }
+            : undefined;
+        const parsedMaxEntries = data.memory_max_entries.trim() === ''
+            ? undefined
+            : Number.parseInt(data.memory_max_entries, 10);
+        const summarizerModel = data.memory_summarizer_model.trim();
+        const hasMemoryConfig = data.memory_enabled || !!summarizerModel || parsedMaxEntries !== undefined;
+        const memoryConfig = hasMemoryConfig
+            ? {
+                enabled: data.memory_enabled,
+                ...(summarizerModel ? { summarizer_model: summarizerModel } : {}),
+                ...(parsedMaxEntries !== undefined ? { max_entries: parsedMaxEntries } : {}),
             }
             : undefined;
 
@@ -94,6 +120,7 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
                     temperature: data.temperature,
                     tool_servers: data.tool_servers,
                     ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
+                    ...(memoryConfig ? { memory: memoryConfig } : {}),
                 },
                 max_concurrent_tasks: data.max_concurrent_tasks,
                 budget_max_per_task: data.budget_max_per_task,
@@ -379,6 +406,93 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
                                                         The sandbox stays alive while the task is running. This timeout only applies after
                                                         a crash — if no one redrives within this window, the sandbox and its files are lost.
                                                         Default: 1 hour.
+                                                    </p>
+                                                    <FormMessage className="text-destructive font-bold text-xs" />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        <div className="space-y-3">
+                            <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Memory</span>
+                            <div className="p-3 border border-border rounded-none bg-black/30 space-y-4">
+                                <FormField
+                                    control={form.control}
+                                    name="memory_enabled"
+                                    render={({ field }) => (
+                                        <FormItem className="flex flex-row items-center gap-3">
+                                            <FormControl>
+                                                <Checkbox
+                                                    className="rounded-none border-primary data-[state=checked]:bg-primary data-[state=checked]:text-black"
+                                                    checked={field.value}
+                                                    onCheckedChange={field.onChange}
+                                                />
+                                            </FormControl>
+                                            <div>
+                                                <FormLabel className="font-normal font-mono cursor-pointer text-sm">
+                                                    Enable Memory
+                                                </FormLabel>
+                                                <p className="text-xs text-muted-foreground mt-0.5">
+                                                    Persist cross-task memory entries for this agent and unlock memory tools in the Console.
+                                                </p>
+                                            </div>
+                                        </FormItem>
+                                    )}
+                                />
+
+                                {memoryEnabled && (
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="memory_summarizer_model"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel className="uppercase tracking-widest text-muted-foreground/70 text-[10px]">Summarizer Model</FormLabel>
+                                                    <FormControl>
+                                                        <Input
+                                                            aria-label="Summarizer Model"
+                                                            className="rounded-none border-border bg-black/50 w-full"
+                                                            placeholder="e.g., claude-3-5-haiku-latest"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <p className="text-xs text-muted-foreground mt-1">
+                                                        Leave blank to use the runtime-configured platform default summarizer. If the platform does not override it, the worker falls back to
+                                                        {' '}
+                                                        <code>claude-haiku-4-5</code>
+                                                        .
+                                                    </p>
+                                                    <FormMessage className="text-destructive font-bold text-xs" />
+                                                </FormItem>
+                                            )}
+                                        />
+                                        <FormField
+                                            control={form.control}
+                                            name="memory_max_entries"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel className="uppercase tracking-widest text-muted-foreground/70 text-[10px]">Max Entries</FormLabel>
+                                                    <FormControl>
+                                                        <Input
+                                                            type="number"
+                                                            min="100"
+                                                            max="100000"
+                                                            step="100"
+                                                            aria-label="Max Entries"
+                                                            className="rounded-none border-border bg-black/50 w-full"
+                                                            placeholder="10000"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <p className="text-xs text-muted-foreground mt-1">
+                                                        Optional retention cap. When omitted, the platform default of
+                                                        {' '}
+                                                        <code>10,000</code>
+                                                        {' '}
+                                                        entries is used.
                                                     </p>
                                                     <FormMessage className="text-destructive font-bold text-xs" />
                                                 </FormItem>

--- a/services/console/src/features/agents/memory/MemoryEntryDetail.tsx
+++ b/services/console/src/features/agents/memory/MemoryEntryDetail.tsx
@@ -120,7 +120,7 @@ export function MemoryEntryDetail({
 
                     <div className="flex flex-wrap gap-2 shrink-0">
                         <Link
-                            to={`/tasks/new?agentId=${encodeURIComponent(agentId)}&attachMemoryId=${encodeURIComponent(entry.memory_id)}`}
+                            to={`/tasks/new?agent_id=${encodeURIComponent(agentId)}&attachMemoryId=${encodeURIComponent(entry.memory_id)}`}
                         >
                             <Button
                                 type="button"

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -1141,6 +1141,40 @@ class GraphExecutor:
                             embedding_cost,
                         )
 
+                    # Mirror the memory-write cost onto the checkpoint row.
+                    # The API's cost totals and the per-step timeline read
+                    # checkpoints.cost_microdollars (not agent_cost_ledger), so
+                    # without this UPDATE the memory step shows $0 and the
+                    # cumulative total doesn't advance between the agent's
+                    # final response and the memory-saved step. We also
+                    # populate execution_metadata with the summarizer's model
+                    # + tokens so the Console's usage panel renders on this
+                    # step the same way it does for chat-model steps.
+                    if checkpoint_id:
+                        step_total_cost = summarizer_cost + embedding_cost
+                        summarizer_tokens_in = int(
+                            pending_memory.get("summarizer_tokens_in") or 0
+                        )
+                        summarizer_tokens_out = int(
+                            pending_memory.get("summarizer_tokens_out") or 0
+                        )
+                        exec_metadata = {
+                            "model": pending_memory.get("summarizer_model_id"),
+                            "input_tokens": summarizer_tokens_in,
+                            "output_tokens": summarizer_tokens_out,
+                        }
+                        await conn.execute(
+                            '''UPDATE checkpoints
+                               SET cost_microdollars = $1,
+                                   execution_metadata = $2::jsonb
+                               WHERE checkpoint_id = $3
+                                 AND task_id = $4::uuid''',
+                            step_total_cost,
+                            json.dumps(exec_metadata),
+                            checkpoint_id,
+                            task_id,
+                        )
+
                 # Track 3: decrement running_task_count on completion.
                 await conn.execute(
                     '''INSERT INTO agent_runtime_state

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -1146,10 +1146,18 @@ class GraphExecutor:
                     # checkpoints.cost_microdollars (not agent_cost_ledger), so
                     # without this UPDATE the memory step shows $0 and the
                     # cumulative total doesn't advance between the agent's
-                    # final response and the memory-saved step. We also
-                    # populate execution_metadata with the summarizer's model
-                    # + tokens so the Console's usage panel renders on this
-                    # step the same way it does for chat-model steps.
+                    # final response and the memory-saved step.
+                    #
+                    # This must be ADDITIVE, not a replacement. The sandbox
+                    # cleanup path at the end of execute_task (see the
+                    # "sandbox_cost_recording_failed" block) has already
+                    # accumulated sandbox runtime spend onto this same
+                    # checkpoint via `cost_microdollars = cost_microdollars
+                    # + $1`; replacing would silently drop that spend from
+                    # the timeline totals. Same goes for any future
+                    # post-astream cost attribution path that lands on the
+                    # terminal checkpoint. execution_metadata uses COALESCE
+                    # so if an earlier writer populated it we don't clobber.
                     if checkpoint_id:
                         step_total_cost = summarizer_cost + embedding_cost
                         summarizer_tokens_in = int(
@@ -1165,8 +1173,8 @@ class GraphExecutor:
                         }
                         await conn.execute(
                             '''UPDATE checkpoints
-                               SET cost_microdollars = $1,
-                                   execution_metadata = $2::jsonb
+                               SET cost_microdollars = cost_microdollars + $1,
+                                   execution_metadata = COALESCE(execution_metadata, $2::jsonb)
                                WHERE checkpoint_id = $3
                                  AND task_id = $4::uuid''',
                             step_total_cost,

--- a/services/worker-service/tests/test_memory_write.py
+++ b/services/worker-service/tests/test_memory_write.py
@@ -305,6 +305,126 @@ class TestCommitUpsertFollowUpBehaviour:
         assert row["version"] == 2
         assert row["updated_at"] > row["created_at"]
 
+    @pytest.mark.asyncio
+    async def test_followup_cycle_preserves_combined_observations_and_mirrors_cost(
+        self, integration_pool: asyncpg.Pool
+    ) -> None:
+        """End-to-end the full first-run + follow-up cycle at the commit boundary.
+
+        The design-doc invariant is "combined execution" — after a follow-up,
+        the persisted memory row must reflect both runs' observations (and the
+        follow-up's refreshed summary). The append-only observations reducer
+        delivers a merged list by the time memory_write fires, and the worker
+        passes that merged list into the UPSERT. We also verify the per-step
+        cost mirror lands on each run's terminal checkpoint — two distinct
+        checkpoints, two distinct cost attributions, one DB row.
+        """
+        task_id = str(uuid.uuid4())
+        await _seed_running_task(integration_pool, task_id=task_id)
+        executor = _make_executor(integration_pool)
+        agent_config = {"memory": {"enabled": True, "max_entries": 10_000}}
+
+        # Seed a terminal checkpoint for run 1 and commit with obs=["obs-run-1"].
+        checkpoint_id_1 = f"cp-{uuid.uuid4()}"
+        async with integration_pool.acquire() as conn:
+            await conn.execute(
+                """INSERT INTO checkpoints (
+                       task_id, checkpoint_ns, checkpoint_id, worker_id,
+                       thread_ts, checkpoint_payload, metadata_payload,
+                       cost_microdollars)
+                   VALUES ($1::uuid, '', $2, $3, $2, '{}'::jsonb,
+                           '{"source":"loop","step":6}'::jsonb, 0)""",
+                task_id, checkpoint_id_1, WORKER_A,
+            )
+
+        pm_run1 = _pending_memory(
+            title="Run 1 memory",
+            summary="Summary of the first run only.",
+            observations=["obs-run-1"],
+            content_vec=[0.1] * 1536,
+        )
+        await executor._commit_memory_and_complete_task(
+            task_id=task_id, tenant_id=TENANT_ID, agent_id=AGENT_ID,
+            pending_memory=pm_run1, agent_config=agent_config,
+            output={"result": "first"}, worker_id=WORKER_A,
+        )
+
+        # Simulate the follow-up transition: completed → running, fresh lease.
+        async with integration_pool.acquire() as conn:
+            await conn.execute(
+                """UPDATE tasks SET status='running', lease_owner=$2,
+                          lease_expiry=NOW() + INTERVAL '60 seconds'
+                   WHERE task_id=$1::uuid""",
+                task_id, WORKER_A,
+            )
+
+        # The follow-up's terminal checkpoint is a NEW row. memory_write runs
+        # on this new checkpoint, so the cost attribution lands here, not on
+        # the prior run's terminal checkpoint. The observations channel's
+        # append-only reducer yields ["obs-run-1", "obs-run-2"] by the time
+        # memory_write fires — that's the snapshot we pass into the UPSERT.
+        checkpoint_id_2 = f"cp-{uuid.uuid4()}"
+        async with integration_pool.acquire() as conn:
+            await conn.execute(
+                """INSERT INTO checkpoints (
+                       task_id, checkpoint_ns, checkpoint_id, worker_id,
+                       thread_ts, checkpoint_payload, metadata_payload,
+                       cost_microdollars)
+                   VALUES ($1::uuid, '', $2, $3, $2, '{}'::jsonb,
+                           '{"source":"loop","step":12}'::jsonb, 0)""",
+                task_id, checkpoint_id_2, WORKER_A,
+            )
+
+        pm_run2 = _pending_memory(
+            title="Refreshed after follow-up",
+            summary="Summary now covering both runs.",
+            observations=["obs-run-1", "obs-run-2"],
+            content_vec=[0.2] * 1536,
+        )
+        result = await executor._commit_memory_and_complete_task(
+            task_id=task_id, tenant_id=TENANT_ID, agent_id=AGENT_ID,
+            pending_memory=pm_run2, agent_config=agent_config,
+            output={"result": "second"}, worker_id=WORKER_A,
+        )
+        assert result["inserted"] is False
+
+        async with integration_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT title, summary, version, observations, "
+                "       created_at, updated_at "
+                "FROM agent_memory_entries WHERE task_id = $1::uuid",
+                task_id,
+            )
+            mem_row_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM agent_memory_entries "
+                "WHERE task_id = $1::uuid", task_id,
+            )
+            cp1_cost = await conn.fetchval(
+                "SELECT cost_microdollars FROM checkpoints "
+                "WHERE checkpoint_id = $1", checkpoint_id_1,
+            )
+            cp2_cost = await conn.fetchval(
+                "SELECT cost_microdollars FROM checkpoints "
+                "WHERE checkpoint_id = $1", checkpoint_id_2,
+            )
+
+        # Invariant 1: exactly one row for the task, not a second entry.
+        assert mem_row_count == 1
+        # Invariant 2: version advanced on UPDATE branch.
+        assert row["version"] == 2
+        # Invariant 3: follow-up's title + summary replace run 1's content.
+        assert row["title"] == "Refreshed after follow-up"
+        assert row["summary"] == "Summary now covering both runs."
+        # Invariant 4: combined observations land in the DB row.
+        assert list(row["observations"]) == ["obs-run-1", "obs-run-2"]
+        # Invariant 5: each run's cost lands on its own terminal checkpoint,
+        # so the Console timeline shows a distinct per-step cost on each
+        # Memory Saved / Memory Updated step.
+        assert cp1_cost == 102  # summarizer 100 + embedding 2 on run 1
+        assert cp2_cost == 102  # summarizer 100 + embedding 2 on run 2
+        # Invariant 6: updated_at strictly advances across the follow-up.
+        assert row["updated_at"] > row["created_at"]
+
 
 class TestCommitTrim:
     @pytest.mark.asyncio
@@ -473,6 +593,73 @@ class TestCommitLeaseEnforcement:
         assert task_row["status"] == "running"
         assert task_row["lease_owner"] == WORKER_A
         assert mem_count == 0
+
+
+class TestCommitCheckpointAttribution:
+    """The commit path mirrors the memory step's cost onto the terminal
+    checkpoint row so the API's cost totals and the Console timeline
+    (which read checkpoints.cost_microdollars — not agent_cost_ledger)
+    reflect the summarizer + embedding spend on the memory-saved step.
+    """
+
+    async def _seed_checkpoint(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        task_id: str,
+        checkpoint_id: str,
+        worker_id: str = WORKER_A,
+    ) -> None:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO checkpoints (
+                    task_id, checkpoint_ns, checkpoint_id, worker_id,
+                    thread_ts, checkpoint_payload, metadata_payload,
+                    cost_microdollars
+                )
+                VALUES ($1::uuid, '', $2, $3, $2, '{}'::jsonb,
+                        '{"source":"loop","step":6}'::jsonb, 0)
+                """,
+                task_id, checkpoint_id, worker_id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_memory_cost_mirrored_onto_latest_checkpoint(
+        self, integration_pool: asyncpg.Pool
+    ) -> None:
+        task_id = str(uuid.uuid4())
+        checkpoint_id = f"cp-{uuid.uuid4()}"
+        await _seed_running_task(integration_pool, task_id=task_id)
+        await self._seed_checkpoint(
+            integration_pool, task_id=task_id, checkpoint_id=checkpoint_id
+        )
+        executor = _make_executor(integration_pool)
+        agent_config = {"memory": {"enabled": True, "max_entries": 10_000}}
+
+        # summarizer_cost=100, embedding_cost=2 → expected mirror = 102.
+        pm = _pending_memory(
+            title="Mirrored memory", content_vec=[0.1] * 1536,
+        )
+
+        await executor._commit_memory_and_complete_task(
+            task_id=task_id, tenant_id=TENANT_ID, agent_id=AGENT_ID,
+            pending_memory=pm, agent_config=agent_config,
+            output={"result": "done"}, worker_id=WORKER_A,
+        )
+
+        async with integration_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT cost_microdollars, execution_metadata "
+                "FROM checkpoints WHERE checkpoint_id = $1",
+                checkpoint_id,
+            )
+
+        assert row["cost_microdollars"] == 102
+        exec_metadata = json.loads(row["execution_metadata"])
+        assert exec_metadata["model"] == "claude-haiku-4-5"
+        assert exec_metadata["input_tokens"] == 50
+        assert exec_metadata["output_tokens"] == 20
 
 
 class TestCommitMissingPendingMemorySafetyNet:

--- a/services/worker-service/tests/test_memory_write.py
+++ b/services/worker-service/tests/test_memory_write.py
@@ -609,6 +609,8 @@ class TestCommitCheckpointAttribution:
         task_id: str,
         checkpoint_id: str,
         worker_id: str = WORKER_A,
+        initial_cost: int = 0,
+        initial_execution_metadata: str | None = None,
     ) -> None:
         async with pool.acquire() as conn:
             await conn.execute(
@@ -616,12 +618,13 @@ class TestCommitCheckpointAttribution:
                 INSERT INTO checkpoints (
                     task_id, checkpoint_ns, checkpoint_id, worker_id,
                     thread_ts, checkpoint_payload, metadata_payload,
-                    cost_microdollars
+                    cost_microdollars, execution_metadata
                 )
                 VALUES ($1::uuid, '', $2, $3, $2, '{}'::jsonb,
-                        '{"source":"loop","step":6}'::jsonb, 0)
+                        '{"source":"loop","step":6}'::jsonb, $4, $5::jsonb)
                 """,
                 task_id, checkpoint_id, worker_id,
+                initial_cost, initial_execution_metadata,
             )
 
     @pytest.mark.asyncio
@@ -660,6 +663,53 @@ class TestCommitCheckpointAttribution:
         assert exec_metadata["model"] == "claude-haiku-4-5"
         assert exec_metadata["input_tokens"] == 50
         assert exec_metadata["output_tokens"] == 20
+
+    @pytest.mark.asyncio
+    async def test_memory_cost_is_additive_preserving_prior_checkpoint_spend(
+        self, integration_pool: asyncpg.Pool
+    ) -> None:
+        """The mirror MUST add summarizer+embedding onto the checkpoint's
+        existing cost_microdollars, not replace it. Tasks that use the sandbox
+        have already rolled sandbox runtime spend onto the latest checkpoint
+        (`cost_microdollars = cost_microdollars + <sandbox>`) before the
+        commit path runs; replacing would silently drop that spend from the
+        API's timeline and status totals.
+        """
+        task_id = str(uuid.uuid4())
+        checkpoint_id = f"cp-{uuid.uuid4()}"
+        await _seed_running_task(integration_pool, task_id=task_id)
+        # Seed the checkpoint as if sandbox already rolled 500µ$ onto it.
+        # Also seed pre-existing execution_metadata to confirm COALESCE
+        # behaviour preserves whatever an earlier writer set.
+        await self._seed_checkpoint(
+            integration_pool, task_id=task_id, checkpoint_id=checkpoint_id,
+            initial_cost=500,
+            initial_execution_metadata='{"source":"sandbox_cost_rollup"}',
+        )
+        executor = _make_executor(integration_pool)
+        agent_config = {"memory": {"enabled": True, "max_entries": 10_000}}
+
+        pm = _pending_memory(
+            title="With prior spend", content_vec=[0.1] * 1536,
+        )
+        await executor._commit_memory_and_complete_task(
+            task_id=task_id, tenant_id=TENANT_ID, agent_id=AGENT_ID,
+            pending_memory=pm, agent_config=agent_config,
+            output={"result": "done"}, worker_id=WORKER_A,
+        )
+
+        async with integration_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT cost_microdollars, execution_metadata "
+                "FROM checkpoints WHERE checkpoint_id = $1",
+                checkpoint_id,
+            )
+
+        # 500 pre-existing + 100 summarizer + 2 embedding = 602.
+        assert row["cost_microdollars"] == 602
+        # Pre-existing execution_metadata is preserved via COALESCE.
+        preserved = json.loads(row["execution_metadata"])
+        assert preserved == {"source": "sandbox_cost_rollup"}
 
 
 class TestCommitMissingPendingMemorySafetyNet:


### PR DESCRIPTION
## Summary

### Console — memory config on agent create/edit (new)
- Expose `agent_config.memory` controls (`enabled`, `summarizer_model`, `max_entries`) in both `CreateAgentDialog` and `AgentDetailPage` so operators can enable memory and tune it without hand-editing JSON.
- Fix `MemoryEntryDetail`'s task-attach link to use `agent_id` (matching the API's query-param convention).
- Adds unit coverage for the new create-path memory config form.

### API — checkpoint display fixes
- Detect `memory_write` checkpoints by `pending_memory` transitions across rows (value persists cumulatively in LangGraph state, so "present" alone false-positives; only "changed since prior row" identifies the actual write). Emit a clean "Memory Saved" prose event; subsequent writes from follow-ups relabel to "Memory Updated" so the UPSERT semantics are visible instead of implying multiple memory rows exist.

### Worker — cost attribution fix
- Mirror `summarizer_cost + embedding_cost` from `agent_cost_ledger` back onto `checkpoints.cost_microdollars` on the memory step. Populate `execution_metadata` with summarizer model + tokens so the Console's per-step and cumulative cost totals advance across the memory step, matching how chat steps attribute cost.

### Tests
- API unit: parser relabel + field projection.
- Worker integration: `TestCommitCheckpointAttribution` (cost mirror) + `test_followup_cycle_preserves_combined_observations_and_mirrors_cost` (end-to-end first-run + follow-up cycle asserting observations merge, version bumps, distinct cost attribution per run).
- Console: `CreateAgentDialog.test.tsx` covering the memory config payload shape.

## Test plan
- [x] `cd services/api-service && ./gradlew test --tests "com.persistentagent.api.service.TaskServiceTest*"` — passes.
- [x] `E2E_DB_DSN=... pytest services/worker-service/tests/test_memory_write.py -v` — passes (including the two new tests).
- [x] `make console-test` — all 101 tests pass.
- [x] Playwright: timeline on a completed task now reads one "Memory Saved" with prose + correct per-step and cumulative cost; after a follow-up, only step 22 reads "Memory Updated" (no false positives on intermediate steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)