### PR TITLE
Local-dev task tracking: compaction trace + WORKER_LOG_LEVEL + docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ If an external PR reference slips in, rewrite the commit / PR description before
 - When validating background `Makefile` targets (`make start`, `make status`, `make stop`), prefer an interactive shell / PTY.
 - **Python venv:** the worker venv at `services/worker-service/.venv/` has all deps pinned. Activate with `source services/worker-service/.venv/bin/activate` or call `services/worker-service/.venv/bin/python` directly.
 - **Test DB isolation:** `par-e2e-postgres` on port **55433** is the tests' DB; the dev DB on 55432 is off-limits for tests (it corrupts local state). `make worker-test` passes `E2E_DB_DSN`; `make e2e-test` passes `E2E_DB_*` vars.
+- **Tracking a running task:** two surfaces answer "what's this task doing?" — the worker log (`.tmp/worker-*.log`) for runtime decisions (lifecycle, compaction, memory routing, dead-letter, retries) and `GET /v1/tasks/<id>/conversation` for what the agent actually did (turns / tool calls / tool results). `make start` runs workers at `WORKER_LOG_LEVEL=DEBUG` by default so per-turn compaction traces are already there; quiet it with `WORKER_LOG_LEVEL=INFO make start-worker`. See [Tracking a running task](./docs/LOCAL_DEVELOPMENT.md#tracking-a-running-task) for the event catalogue and jq recipes.
 
 ## Testing (Mandatory)
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,14 @@ SERVER_PORT ?= 8080
 VITE_API_BASE_URL ?= http://localhost:8080
 APP_DEV_TASK_CONTROLS_ENABLED ?= false
 VITE_DEV_TASK_CONTROLS_ENABLED ?= $(APP_DEV_TASK_CONTROLS_ENABLED)
+
+# Local-dev default: emit the per-turn compaction.projection_built DEBUG trace
+# and other debug chatter so `make start` gives developers immediate visibility
+# into what the worker is doing (see docs/LOCAL_DEVELOPMENT.md § Tracking a
+# running task). The worker service itself defaults to INFO in code — this
+# override is Makefile-local. Override for a quieter log with:
+#   WORKER_LOG_LEVEL=INFO make start-worker
+WORKER_LOG_LEVEL ?= DEBUG
 # Langfuse is now configured per-agent via the Console Settings page.
 # These defaults are only used by test-langfuse-up / dev-langfuse-up.
 LANGFUSE_HOST ?= http://127.0.0.1:3300
@@ -409,7 +417,7 @@ start-worker:
 			skipped=$$((skipped + 1)); \
 		else \
 			rm -f $$pidfile; \
-			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$i.log 2>&1 & echo $$! > $$pidfile; \
+			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$i.log 2>&1 & echo $$! > $$pidfile; \
 			started=$$((started + 1)); \
 		fi; \
 		i=$$((i + 1)); \
@@ -467,7 +475,7 @@ scale-worker:
 				slot=$$((slot + 1)); continue; \
 			fi; \
 			rm -f $$pidfile; \
-			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$slot.log 2>&1 & echo $$! > $$pidfile; \
+			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$slot.log 2>&1 & echo $$! > $$pidfile; \
 			started=$$((started + 1)); slot=$$((slot + 1)); \
 		done; \
 		echo "$(GREEN)✅ Scaled to $$target worker(s)$(NC)"; \

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -52,6 +52,123 @@ The checked-in local stack initializes a local Langfuse organization, project, a
 
 On startup, `make start` runs `services/model-discovery/main.py` to auto-discover available LLM providers from configured API keys and populate the `provider_keys` and `models` tables in PostgreSQL. The API service validates task submissions against these tables, and the console model selector is populated from `GET /v1/models`. Set `ANTHROPIC_API_KEY` for Claude models, `OPENAI_API_KEY` for GPT models, or both.
 
+## Tracking a running task
+
+Three surfaces answer "what is this task doing?" — pick by the question you're asking:
+
+| Your question | Surface | How to get there |
+|---|---|---|
+| What did the **agent** do? (turns, tool calls, results) | Conversation API | `GET /v1/tasks/<id>/conversation` |
+| What is the **runtime** deciding? (lifecycle, pause/retry/dead-letter, compaction) | Worker log | `.tmp/worker-<N>.log` |
+| Per-LLM-call traces and token costs | Langfuse UI | See [Local Langfuse Observability](#local-langfuse-observability) above |
+
+**Prerequisites.** `make start` running; `jq` installed (`brew install jq`). The API defaults to `http://localhost:8080` — override with `API_PORT`.
+
+### Quick start — "I submitted a task, now what?"
+
+1. **Find the task ID.** The console prints it on submit; otherwise list the most recent:
+
+   ```bash
+   curl -s http://localhost:8080/v1/tasks | jq '.items[] | {id: .task_id, status, agent: .agent_display_name, created_at}'
+   ```
+
+2. **See what the agent did** — the conversational transcript (turns, tool calls, tool results, HITL resumes):
+
+   ```bash
+   curl -s http://localhost:8080/v1/tasks/<task-id>/conversation \
+     | jq '.entries[] | {seq: .sequence, kind, tool: .content.tool_name, size: .content_size}'
+   ```
+
+3. **See what the runtime decided** — tail the worker log. `<N>` is the worker number (`1..WORKER_COUNT`); `ls .tmp/worker-*.log` to see which exist. The `fromjson?` wrapper is required because the worker log mixes JSON event lines with stdlib text lines — without it `jq` would parse-error on the text lines:
+
+   ```bash
+   tail -f .tmp/worker-1.log | jq -Rc --arg id "<task-id>" 'fromjson? | select(.task_id==$id) | {t: .timestamp, event, level}'
+   ```
+
+4. **If something looks off**, check the task-level status and the structured event feed:
+
+   ```bash
+   curl -s http://localhost:8080/v1/tasks/<task-id> | jq '{status, retry_count, output}'
+   curl -s http://localhost:8080/v1/tasks/<task-id>/events | jq '.events[] | {t: .created_at, event_type, status_after, error_code}'
+   ```
+
+### Top events to know
+
+Watch these in the worker log — each maps to a concrete question you're likely to ask.
+
+| Event | Level | Read when |
+|---|---|---|
+| `TASK_CLAIMED` / `TASK_COMPLETED` | INFO | "Did my task start / finish?" |
+| `Task <id> paused: <reason> (...)` | INFO | "Why is it stuck?" Usual reasons: `hitl_approval`, `hitl_input_requested`, `budget_exceeded` |
+| `Task <id> hit retryable error. Requeued (try N).` | INFO | "It retried — was it transient?" |
+| `Task <id> dead-lettered: <reason> (msg: ...)` | ERROR | **Look here first for terminal failures.** The `reason` code plus the `msg` string is usually enough to triage. |
+| `compaction.tier3_fired` | INFO | "Did context get compacted?" Explains surprising "the agent forgot X" behaviour. |
+
+> **Glossary.** HITL = human-in-the-loop pause (task waiting on approval or user input). Tier‑3 = the aggressive context-compaction pass that summarises older history to stay inside the model's token budget. Hard floor = the token ceiling beyond which compaction refuses to run further.
+
+### Peeking inside compaction
+
+`make start` runs workers at `WORKER_LOG_LEVEL=DEBUG` by default, so the per-turn compaction trace is already in your log — no extra flags. Filter for the `compaction.projection_built` event, emitted once per LLM call:
+
+```bash
+jq -Rc 'fromjson? | select(.event=="compaction.projection_built" and .task_id=="<task-id>")
+                  | {t: .timestamp, est: .est_tokens, trigger: .trigger_tokens, outcome}' \
+   .tmp/worker-1.log
+```
+
+> **Seeing lots of `below_threshold`? That's healthy.** It means the hook is checking every turn and finding nothing to do — current tokens are comfortably under the trigger (0.85 × `model_context_window`).
+
+Outcomes you might see: `below_threshold`, `fired`, `flush_fired`, `skipped:cap_reached`, `skipped:empty_slice`, `skipped:fatal`, `skipped:empty_summary`, `fatal_short_circuit`. Any of them may be suffixed `:hard_floor` when the projection still exceeds the model window.
+
+**Quieting the log.** If DEBUG is too chatty, override for a specific run: `WORKER_LOG_LEVEL=INFO make start-worker`. Accepted values: `DEBUG` (Makefile default), `INFO` (code / production default), `WARNING`, `ERROR`, `CRITICAL` (case-insensitive; invalid values fall back to INFO). `WORKER_LOG_LEVEL` is worker-only; the API service has separate logging.
+
+### Full event reference
+
+The worker log mixes two formats:
+
+- **JSON event lines** (lines starting with `{`) — structured events via structlog. Grep with `jq`.
+- **Text lines** (lines starting with a timestamp like `2026-04-20 15:43:...`) — stdlib `logging` output. Grep with plain `grep`.
+
+To separate them:
+
+```bash
+jq -Rc 'fromjson? | select(.event != null)' .tmp/worker-1.log   # JSON events only
+grep -v '^{' .tmp/worker-1.log                                  # text lines only
+```
+
+Tip: `jq -R 'fromjson?'` reads each line as raw text, tries to parse it as JSON, and silently skips lines that aren't — handy for grepping the mixed log without parse errors.
+
+**Lifecycle (JSON, INFO):** `TASK_CLAIMED`, `TASK_COMPLETED`, `TASK_REQUEUED`, `TASK_DEAD_LETTERED`, `LEASE_REVOKED`, `HEARTBEAT_SENT`, `POLL_EMPTY`, `REAPER_LEASE_EXPIRED`, `REAPER_TASK_TIMEOUT`, `REAPER_DEAD_LETTERED`.
+
+**Compaction (JSON):**
+- `compaction.projection_built` — DEBUG, one per hook invocation (see [Peeking inside compaction](#peeking-inside-compaction-opt-in-debug)).
+- `compaction.tier3_fired` / `compaction.tier3_skipped` / `compaction.hard_floor` — INFO/WARN. Fields include `tokens_in`, `tokens_out`, `summarizer_model_id`.
+- `compaction.model_context_window_unknown` — WARN at task start when the model's context window is unresolved; worker falls back to 128,000 tokens. Usually means a model row is missing its `context_window` value.
+
+**Runtime text lines (stdlib, grep by substring):**
+- `memory.route_after_agent` — per-turn routing for memory-enabled agents (`decision=tools`/`end`).
+- `Task <id> paused: <reason> (cost: ...)` / `Task <id> paused: <reason> (timeout: ...)` — HITL or budget pause.
+- `Task <id> hit retryable error. Requeued (try N).` — retry loop.
+- `Task <id> dead-lettered: <reason> (msg: <detail>)` — terminal failure.
+- `Per-step cost recording failed` / `Execution metadata write failed` — DB write hiccups; the task keeps running.
+- `sandbox_timeout_refresh_failed` — sandbox heartbeat miss at DEBUG; benign unless it recurs.
+- `Langfuse endpoint ... not found` / `Langfuse flush failed` — per-task tracing degraded; task is unaffected.
+
+**Two handy cross-task recipes:**
+
+```bash
+# All lifecycle transitions across every worker
+jq -Rc 'fromjson? | select(.event | IN("TASK_CLAIMED","TASK_COMPLETED","TASK_REQUEUED","TASK_DEAD_LETTERED","LEASE_REVOKED"))' \
+   .tmp/worker-*.log
+
+# All text-format lines for one task
+grep '<task-id>' .tmp/worker-*.log | grep -v '^{'
+```
+
+### Don't ship DEBUG to production
+
+The worker service defaults to `INFO` in code (see `services/worker-service/core/logging.py`). DEBUG is enabled *only* by the Makefile's `WORKER_LOG_LEVEL ?= DEBUG`, which applies to `make start` / `make start-worker` / `make scale-worker`. Production deploys (Helm, CDK) must not set `WORKER_LOG_LEVEL` — at fleet scale DEBUG produces several MB of JSON per hour per worker.
+
 ## Dev-Only Task Controls
 
 The runtime includes dev-only endpoints and tools for testing failure and recovery flows locally:

--- a/services/worker-service/core/logging.py
+++ b/services/worker-service/core/logging.py
@@ -2,16 +2,49 @@
 
 Provides structured logging with mandatory labels (task_id, worker_id, node_name)
 and metric emission primitives. Uses structlog for structured JSON output.
+
+**Worker-only.** The API service has its own logging configuration and does
+not share this module. The ``WORKER_LOG_LEVEL`` env var read below controls
+the worker's structlog filter exclusively; if the API service later adopts a
+shared logger, the env var name will want a rename to match.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
+
+
+_WORKER_LOG_LEVEL_ENV = "WORKER_LOG_LEVEL"
+
+
+def _resolve_level() -> int:
+    """Resolve the structlog filter level from ``WORKER_LOG_LEVEL``.
+
+    Accepts ``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL`` (case-
+    insensitive). Falls back to ``logging.INFO`` on unset or invalid values,
+    logging a one-time stdlib warning so the misconfig is visible. The default
+    keeps production behaviour unchanged — DEBUG is strictly opt-in for local
+    dev (see ``docs/LOCAL_DEVELOPMENT.md`` § Tracking a running task).
+    """
+    raw = os.environ.get(_WORKER_LOG_LEVEL_ENV)
+    if raw is None or raw == "":
+        return logging.INFO
+    candidate = raw.strip().upper()
+    level = logging.getLevelName(candidate)
+    # ``getLevelName`` returns the numeric level for known names and the
+    # string ``"Level <n>"`` for unknown input. Guard on both.
+    if isinstance(level, int):
+        return level
+    logging.getLogger(__name__).warning(
+        "Unknown %s=%r; falling back to INFO", _WORKER_LOG_LEVEL_ENV, raw
+    )
+    return logging.INFO
 
 
 def configure_logging() -> None:
@@ -25,7 +58,7 @@ def configure_logging() -> None:
             structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(),
         ],
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(_resolve_level()),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),
         cache_logger_on_first_use=True,

--- a/services/worker-service/executor/compaction/pre_model_hook.py
+++ b/services/worker-service/executor/compaction/pre_model_hook.py
@@ -60,12 +60,25 @@ from langchain_core.messages import (
     ToolMessage,
 )
 
+from core.logging import get_logger as _get_structlog_logger
 from executor.compaction.defaults import (
     COMPACTION_TRIGGER_FRACTION,
     KEEP_TOOL_USES,
     TIER_3_MAX_FIRINGS_PER_TASK,
     get_platform_default_summarizer_model,
 )
+
+
+# The DEBUG-only per-invocation projection trace (``compaction.projection_built``)
+# is emitted inside ``_finalize`` via a freshly-resolved structlog logger rather
+# than a cached module-level proxy. Deliberate — a cached
+# ``BoundLoggerLazyProxy`` (with ``cache_logger_on_first_use=True``) captures
+# whatever structlog config existed at import time, which breaks
+# ``structlog.testing.capture_logs`` isolation in later-running tests once any
+# other test has called ``structlog.reset_defaults()``. The per-call lookup
+# cost is one dict access per LLM turn (negligible). INFO/WARN event emission
+# for concrete firings still lives in ``executor.graph._compaction_logger``;
+# this signal is gated by ``WORKER_LOG_LEVEL`` (see ``core/logging.py``).
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +711,59 @@ async def compaction_pre_model_hook(
     # model's context window.
     trigger_tokens = int(COMPACTION_TRIGGER_FRACTION * model_context_window)
 
+    # All return paths in this function MUST go through ``_finalize`` so the
+    # ``compaction.projection_built`` DEBUG trace fires exactly once per
+    # invocation. New return sites are easy to forget — a parametrised test
+    # in ``tests/test_pre_model_hook.py`` enforces the invariant.
+    def _finalize(
+        outcome: str,
+        *,
+        messages: list[BaseMessage],
+        state_updates: dict[str, Any],
+        events: list[CompactionEvent],
+        tier3_skipped: bool = False,
+        summary_for_trace: str | None = None,
+        middle_for_trace: list[BaseMessage] | None = None,
+        est_tokens_for_trace: int | None = None,
+    ) -> CompactionPassResult:
+        # Suffix ``:hard_floor`` when any HardFloorEvent was appended on this
+        # path so a single log line surfaces both decisions.
+        trace_outcome = outcome
+        if any(isinstance(ev, HardFloorEvent) for ev in events):
+            trace_outcome = f"{outcome}:hard_floor"
+        # Resolve a fresh logger each call (see module-level comment for why).
+        _get_structlog_logger(worker_id="compaction").debug(
+            "compaction.projection_built",
+            task_id=task_id,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            checkpoint_id=checkpoint_id,
+            outcome=trace_outcome,
+            est_tokens=(
+                est_tokens_for_trace if est_tokens_for_trace is not None else est_tokens
+            ),
+            trigger_tokens=trigger_tokens,
+            model_context_window=model_context_window,
+            summary_len=len(
+                summary_for_trace if summary_for_trace is not None else summary
+            ),
+            middle_len=len(
+                middle_for_trace if middle_for_trace is not None else middle
+            ),
+            keep_window_len=len(keep_window),
+            raw_messages_len=len(raw_messages),
+            summarized_through=summarized_through,
+            tier3_firings_count=state_updates.get(
+                "tier3_firings_count", tier3_firings_count
+            ),
+        )
+        return CompactionPassResult(
+            messages=messages,
+            state_updates=state_updates,
+            events=events,
+            tier3_skipped=tier3_skipped,
+        )
+
     if est_tokens < trigger_tokens:
         # Below threshold — emit the projection as-is.
         # Still run the hard-floor safety net in case of pathological inputs.
@@ -711,7 +777,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "below_threshold",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -734,7 +801,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "fatal_short_circuit",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -761,7 +829,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "skipped:cap_reached",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -809,11 +878,13 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "flush_fired",
             messages=flush_projection,
             state_updates=state_updates,
             events=events,
             tier3_skipped=False,
+            est_tokens_for_trace=est_tokens_with_flush,
         )
 
     # If middle is empty, there's nothing the summariser can reduce — skip.
@@ -836,7 +907,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "skipped:empty_slice",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -899,7 +971,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "skipped:fatal",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -931,7 +1004,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            f"skipped:{summarize_result.skipped_reason or 'unknown'}",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -963,7 +1037,8 @@ async def compaction_pre_model_hook(
                     agent_id=agent_id,
                 )
             )
-        return CompactionPassResult(
+        return _finalize(
+            "skipped:empty_summary",
             messages=projection,
             state_updates=state_updates,
             events=events,
@@ -1029,9 +1104,13 @@ async def compaction_pre_model_hook(
             )
         )
 
-    return CompactionPassResult(
+    return _finalize(
+        "fired",
         messages=post_projection,
         state_updates=state_updates,
         events=events,
         tier3_skipped=False,
+        summary_for_trace=new_summary,
+        middle_for_trace=[],
+        est_tokens_for_trace=post_est,
     )

--- a/services/worker-service/tests/conftest.py
+++ b/services/worker-service/tests/conftest.py
@@ -2,10 +2,33 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
+import structlog
 
 from core.config import WorkerConfig
-from core.logging import MetricsCollector
+from core.logging import MetricsCollector, configure_logging
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _worker_log_level_debug_for_tests() -> None:
+    """Force ``WORKER_LOG_LEVEL=DEBUG`` for the whole test session.
+
+    Production defaults to INFO via ``core.logging._resolve_level``, which
+    wraps the logger with ``make_filtering_bound_logger(INFO)`` — a wrapper
+    that drops DEBUG calls *before* any processor runs. ``capture_logs``
+    hooks the processor chain, so at INFO it captures nothing from DEBUG
+    emissions (notably ``compaction.projection_built``). Setting DEBUG at
+    session start lets tests inspect every log line the hook produces,
+    without changing production defaults. Must be set BEFORE any test
+    imports ``core.logging.configure_logging`` indirectly.
+    """
+    os.environ.setdefault("WORKER_LOG_LEVEL", "DEBUG")
+    # Reconfigure in case another import chain already called
+    # ``configure_logging()`` with the INFO default.
+    structlog.reset_defaults()
+    configure_logging()
 
 
 @pytest.fixture

--- a/services/worker-service/tests/test_logging.py
+++ b/services/worker-service/tests/test_logging.py
@@ -1,0 +1,87 @@
+"""Tests for ``core.logging`` structlog level plumbing.
+
+Covers the ``WORKER_LOG_LEVEL`` env var introduced for local-dev observability
+(``docs/LOCAL_DEVELOPMENT.md`` § Tracking a running task). Production stays at
+INFO; DEBUG is strictly opt-in.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+import pytest
+import structlog
+
+from core.logging import _resolve_level, configure_logging, get_logger
+
+
+@pytest.fixture(autouse=True)
+def _restore_structlog_config():
+    """Tests here reconfigure structlog (via ``reset_defaults`` +
+    ``configure_logging``) to verify the ``WORKER_LOG_LEVEL`` filter plumbing.
+    Restore the session-wide DEBUG setup at teardown so sibling test files
+    using ``capture_logs`` aren't left with an INFO-filtered logger that
+    silently drops DEBUG emissions (see ``conftest.py`` fixture).
+    """
+    yield
+    import os
+    os.environ["WORKER_LOG_LEVEL"] = "DEBUG"
+    structlog.reset_defaults()
+    configure_logging()
+
+
+def test_resolve_level_default_is_info(monkeypatch) -> None:
+    monkeypatch.delenv("WORKER_LOG_LEVEL", raising=False)
+    assert _resolve_level() == logging.INFO
+
+
+def test_resolve_level_debug(monkeypatch) -> None:
+    monkeypatch.setenv("WORKER_LOG_LEVEL", "DEBUG")
+    assert _resolve_level() == logging.DEBUG
+
+
+def test_resolve_level_case_insensitive(monkeypatch) -> None:
+    monkeypatch.setenv("WORKER_LOG_LEVEL", "warning")
+    assert _resolve_level() == logging.WARNING
+
+
+def test_resolve_level_invalid_falls_back_to_info(monkeypatch) -> None:
+    monkeypatch.setenv("WORKER_LOG_LEVEL", "BOGUS")
+    assert _resolve_level() == logging.INFO
+
+
+def test_resolve_level_empty_string_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv("WORKER_LOG_LEVEL", "")
+    assert _resolve_level() == logging.INFO
+
+
+def test_configure_logging_debug_enables_debug_output(monkeypatch) -> None:
+    """End-to-end: WORKER_LOG_LEVEL=DEBUG + configure_logging + emit DEBUG → visible."""
+    monkeypatch.setenv("WORKER_LOG_LEVEL", "DEBUG")
+    # Redirect structlog's PrintLoggerFactory output so we can inspect emitted JSON.
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    # Force structlog to re-resolve the level (bypass cache_logger_on_first_use).
+    structlog.reset_defaults()
+    configure_logging()
+    logger = get_logger(worker_id="test")
+    logger.debug("debug_event_visible", foo="bar")
+    output = buf.getvalue()
+    assert "debug_event_visible" in output, f"DEBUG line not captured: {output!r}"
+
+
+def test_configure_logging_default_suppresses_debug(monkeypatch) -> None:
+    """Default INFO filter drops DEBUG lines (production-equivalent behaviour)."""
+    monkeypatch.delenv("WORKER_LOG_LEVEL", raising=False)
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    structlog.reset_defaults()
+    configure_logging()
+    logger = get_logger(worker_id="test")
+    logger.debug("debug_event_should_not_appear")
+    logger.info("info_event_should_appear")
+    output = buf.getvalue()
+    assert "debug_event_should_not_appear" not in output
+    assert "info_event_should_appear" in output

--- a/services/worker-service/tests/test_pre_model_hook.py
+++ b/services/worker-service/tests/test_pre_model_hook.py
@@ -23,6 +23,7 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from structlog.testing import capture_logs
 
 from executor.compaction.pre_model_hook import (
     HardFloorEvent,
@@ -34,6 +35,14 @@ from executor.compaction.pre_model_hook import (
 )
 from executor.compaction.summarizer import SummarizeResult
 from tests.shape_validator import assert_valid_shape
+
+
+# NOTE: ``capture_logs`` rebinds the structlog logger and bypasses the level
+# filter set by ``core.logging.configure_logging``, so DEBUG assertions here
+# pass regardless of ``WORKER_LOG_LEVEL``. That is the intended behaviour —
+# tests assert emission, not filter-layer suppression. If you're reading this
+# and concluding "DEBUG is on by default," it isn't: production runs are still
+# gated by ``WORKER_LOG_LEVEL`` at the bind layer.
 
 
 # ---------------------------------------------------------------------------
@@ -409,21 +418,117 @@ async def test_no_summarizer_below_threshold():
     state = _fresh_state(msgs)
 
     summarizer = _make_summarizer()
-    result = await compaction_pre_model_hook(
-        raw_messages=msgs,
-        state=state,
-        agent_config=_agent_config(),
-        model_context_window=10_000,
-        task_context=_task_context(),
-        summarizer=summarizer,
-        estimate_tokens_fn=_fixed_estimator(8_499),
-    )
+    with capture_logs() as caps:
+        result = await compaction_pre_model_hook(
+            raw_messages=msgs,
+            state=state,
+            agent_config=_agent_config(),
+            model_context_window=10_000,
+            task_context=_task_context(),
+            summarizer=summarizer,
+            estimate_tokens_fn=_fixed_estimator(8_499),
+        )
     summarizer.assert_not_awaited()
     # No firing means no summary / watermark updates.
     assert "summary" not in result.state_updates
     assert "summarized_through_turn_index" not in result.state_updates
     # Firings count never advances without a firing.
     assert "tier3_firings_count" not in result.state_updates
+    # Exactly one projection trace with the expected outcome + shape.
+    traces = [e for e in caps if e.get("event") == "compaction.projection_built"]
+    assert len(traces) == 1, f"expected one projection trace, got {traces}"
+    (trace,) = traces
+    assert trace["outcome"] == "below_threshold"
+    assert trace["est_tokens"] == 8_499
+    assert trace["trigger_tokens"] == 8_500
+    assert trace["model_context_window"] == 10_000
+    assert trace["task_id"] == "task-1"
+    assert trace["tenant_id"] == "tenant-1"
+    assert trace["agent_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario",
+    ["below_threshold", "fired", "cap_reached", "fatal_short_circuit", "empty_summary"],
+)
+async def test_projection_trace_emitted_once_per_call(scenario: str) -> None:
+    """Every return path in ``compaction_pre_model_hook`` emits exactly one
+    ``compaction.projection_built`` DEBUG trace, carrying the correct outcome
+    tag. Guards the emit-once invariant across the 9 return sites funnelled
+    through ``_finalize``."""
+    msgs = _build_messages(n_pairs=5)
+    state = _fresh_state(msgs)
+    summarizer = _make_summarizer()
+
+    if scenario == "below_threshold":
+        est = 8_499  # < 0.85 * 10_000
+        expected_outcome = "below_threshold"
+    elif scenario == "fired":
+        est = 9_000  # ≥ trigger; summarizer returns a valid summary
+        expected_outcome = "fired"
+    elif scenario == "cap_reached":
+        est = 9_000
+        state["tier3_firings_count"] = 10  # hit TIER_3_MAX_FIRINGS_PER_TASK
+        expected_outcome = "skipped:cap_reached"
+    elif scenario == "fatal_short_circuit":
+        est = 9_000
+        state["tier3_fatal_short_circuited"] = True
+        expected_outcome = "fatal_short_circuit"
+    elif scenario == "empty_summary":
+        est = 9_000
+        summarizer = _make_summarizer(summary_text="   ")  # whitespace-only
+        expected_outcome = "skipped:empty_summary"
+    else:  # pragma: no cover
+        raise AssertionError(scenario)
+
+    with capture_logs() as caps:
+        await compaction_pre_model_hook(
+            raw_messages=msgs,
+            state=state,
+            agent_config=_agent_config(),
+            model_context_window=10_000,
+            task_context=_task_context(),
+            summarizer=summarizer,
+            estimate_tokens_fn=_fixed_estimator(est),
+        )
+
+    traces = [e for e in caps if e.get("event") == "compaction.projection_built"]
+    assert len(traces) == 1, (
+        f"scenario={scenario}: expected exactly one trace per hook call, got "
+        f"{len(traces)}: {traces}"
+    )
+    (trace,) = traces
+    assert trace["outcome"] == expected_outcome, (
+        f"scenario={scenario}: expected outcome={expected_outcome}, got {trace!r}"
+    )
+    assert trace["log_level"] == "debug"
+
+
+def test_all_returns_funnel_through_finalize() -> None:
+    """Lint-style guard: the only ``return CompactionPassResult(`` in
+    ``pre_model_hook.py`` must be inside ``_finalize`` itself — every caller
+    site must go through ``_finalize(...)`` so the DEBUG trace fires exactly
+    once. If this test fails, a new return site was added without routing it
+    through ``_finalize``.
+    """
+    src_path = (
+        pathlib.Path(__file__).parent.parent
+        / "executor"
+        / "compaction"
+        / "pre_model_hook.py"
+    )
+    src = src_path.read_text()
+    # Count non-``_finalize`` return sites by excluding the one inside the
+    # helper. We don't parse — the structural guard is "at most one raw
+    # return of CompactionPassResult exists in the file, and it lives inside
+    # _finalize". Exact count is 1.
+    raw_returns = src.count("return CompactionPassResult(")
+    assert raw_returns == 1, (
+        f"Expected exactly 1 'return CompactionPassResult(' (inside _finalize); "
+        f"found {raw_returns}. New return sites must call _finalize(...) so "
+        f"the compaction.projection_built DEBUG trace emits once per invocation."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New `compaction.projection_built` DEBUG event** (`pre_model_hook.py`) — one structured line per LLM turn capturing the hook's decision state: `est_tokens`, `trigger_tokens`, `model_context_window`, region sizes, `outcome` (`below_threshold` / `fired` / `flush_fired` / `skipped:<reason>` / `fatal_short_circuit`, optionally `:hard_floor`-suffixed). Funnels all 9 return sites through a `_finalize` closure so the trace fires exactly once per invocation; a lint test guards the invariant.
- **`WORKER_LOG_LEVEL` plumbing** (`core/logging.py`) — env-var-driven structlog filter level; defaults to `INFO` in code (production-safe). Accepts `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL` (case-insensitive; invalid values fall back to INFO with a one-time warning).
- **Makefile local-dev default** — `WORKER_LOG_LEVEL ?= DEBUG` exported to `start-worker` + `scale-worker` so `make start` gives developers per-turn tracing out of the box. Production deploys (Helm/CDK) don't set the env var, so they still default to INFO.
- **`docs/LOCAL_DEVELOPMENT.md` § Tracking a running task** — covers the three surfaces (worker log, Conversation API, task events) with a copy-paste quick-start, a top-5 event catalogue, a full event reference, and `jq` recipes (with `fromjson?` for the mixed JSON+stdlib log). One-line pointer added to `AGENTS.md` § Local Validation Notes.

## Why

Previously, a developer (or Claude Code acting as a dev agent) asking "what is this task doing?" had three options — dig in the DB, stand up Langfuse, or read stdlib `logger.info(...)` narration. None of them told you what the compaction hook was *evaluating* each turn, and "why didn't compaction fire?" was unanswerable without running a debugger. Now it's one `jq` filter.

The code default stays INFO so production volume is unchanged. DEBUG is Makefile-local; the `Don't ship DEBUG to production` doc section spells this out.

## Test plan

- [x] `pytest services/worker-service/tests/test_logging.py -q` — 7 new tests covering env-var resolution, default fallbacks, end-to-end DEBUG visibility
- [x] `pytest services/worker-service/tests/test_pre_model_hook.py -q` — original 30 tests still pass; 5 new parametrised outcome tests + 1 lint test for the emit-once invariant
- [x] Full worker suite: `954 passed, 2 skipped` — no regressions
- [x] Order-independence: both `test_logging.py, test_pre_model_hook.py` and reversed order pass identically (session-scoped conftest fixture forces `WORKER_LOG_LEVEL=DEBUG` so `capture_logs` sees DEBUG emissions)
- [x] Live end-to-end: `make stop-worker && make start-worker`, submit a task via `POST /v1/tasks`, observe one `compaction.projection_built` line per LLM turn with `outcome=below_threshold` for small tasks
- [x] Doc recipes dogfooded: every `curl` + `jq` snippet in the new section produces clean output against the live stack
- [x] Production safety: default code path at `WORKER_LOG_LEVEL` unset returns `logging.INFO`; structlog filter drops DEBUG at bind layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)