### PR TITLE
Add phase 1 prompt nudge for issue 97

### DIFF
--- a/services/console/src/features/agents/CreateAgentDialog.test.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.test.tsx
@@ -139,6 +139,19 @@ describe('CreateAgentDialog', () => {
         expect(optionValues).not.toContain('gpt-4o-mini');
     });
 
+    it('auto-selects the first available model so the display matches form state (no stale hardcoded default)', async () => {
+        render(<CreateAgentDialog open onOpenChange={() => {}} />, { wrapper: createWrapper() });
+
+        fireEvent.change(screen.getByLabelText(/agent name/i), { target: { value: 'Default Model Agent' } });
+        fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+        await waitFor(() => expect(createMock).toHaveBeenCalled());
+
+        const payload = createMock.mock.calls[0][0];
+        expect(payload.agent_config.provider).toBe('anthropic');
+        expect(payload.agent_config.model).toBe('claude-3-5-sonnet-latest');
+    });
+
     it('includes memory config in the create payload when memory is enabled', async () => {
         render(<CreateAgentDialog open onOpenChange={() => {}} />, { wrapper: createWrapper() });
 

--- a/services/console/src/features/agents/CreateAgentDialog.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.tsx
@@ -82,8 +82,8 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
         defaultValues: {
             display_name: '',
             system_prompt: 'You are a helpful assistant. Provide concise and accurate answers.',
-            provider: 'anthropic',
-            model: 'claude-3-5-sonnet-latest',
+            provider: '',
+            model: '',
             temperature: 0.7,
             tool_servers: [],
             max_concurrent_tasks: 5,
@@ -104,6 +104,15 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
     const sandboxEnabled = form.watch('sandbox_enabled');
     const memoryEnabled = form.watch('memory_enabled');
     const selectedProvider = form.watch('provider');
+    const selectedModel = form.watch('model');
+
+    useEffect(() => {
+        if (models.length === 0) return;
+        if (selectedModel) return;
+        const first = models[0];
+        form.setValue('provider', first.provider);
+        form.setValue('model', first.model_id);
+    }, [models, selectedModel, form]);
     const providerFilteredModels = useMemo(
         () => models.filter((m) => m.provider === selectedProvider),
         [models, selectedProvider],

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -158,6 +158,14 @@ logger = logging.getLogger(__name__)
 from core.logging import get_logger as _get_structlog_logger
 _compaction_logger = _get_structlog_logger(worker_id="graph")
 
+_FUTURE_WORK_PROMISE_RE = re.compile(
+    r"\b(?:i(?:'| wi)ll|let me|next i(?:'| wi)ll|now i(?:'| wi)ll)\s+"
+    r"(?:review|look(?:\s+up)?|search|check|inspect|open|read|analy[sz]e|"
+    r"dig|investigate|reconstruct|gather|pull|fetch|use|call|start|"
+    r"continue|compare|trace|verify)\b",
+    re.IGNORECASE,
+)
+
 
 def _finalize_output_content(messages: list) -> Any:
     """Flatten the final message's content for persistence as ``output.result``.
@@ -191,6 +199,33 @@ def _finalize_output_content(messages: list) -> Any:
     if isinstance(raw, list):
         return _extract_message_text(raw, separator="\n\n")
     return raw
+
+
+def _message_content_to_text(message: BaseMessage) -> str:
+    """Flatten provider-shaped message content to plain text for heuristics."""
+    raw = getattr(message, "content", "")
+    if isinstance(raw, list):
+        return _extract_message_text(raw, separator="\n\n")
+    return raw if isinstance(raw, str) else str(raw)
+
+
+def _looks_like_future_work_promise(message: BaseMessage) -> bool:
+    """Best-effort detector for terminal AI turns that promise more work.
+
+    Phase 1 is intentionally non-invasive: we use this only for telemetry so
+    operators can measure residual cases after the prompt nudge lands. The
+    heuristic therefore prefers a narrow allowlist of future-tense
+    "I'm about to investigate/search/review" verbs over broader intent
+    detection that could fire on legitimate final answers.
+    """
+    if not isinstance(message, AIMessage):
+        return False
+    if getattr(message, "tool_calls", None):
+        return False
+    text = _message_content_to_text(message).strip()
+    if not text:
+        return False
+    return bool(_FUTURE_WORK_PROMISE_RE.search(text))
 
 
 class _ContextExceededIrrecoverableError(Exception):
@@ -2256,6 +2291,13 @@ class GraphExecutor:
                 "You can read web pages using the `read_url` tool to fetch content from URLs."
             )
 
+        if allowed_tools:
+            sections.append(
+                "If you intend to use a tool, emit the tool call in the same response. "
+                "Do not narrate future tool calls in prose ('I'll look up...', 'Next I'll...'). "
+                "Either call the tool now, or produce the final answer."
+            )
+
         if injected_files:
             file_list = "\n".join(f"  - /home/user/{f}" for f in injected_files)
             sections.append(
@@ -2995,6 +3037,18 @@ class GraphExecutor:
                 # Checkpoint persistence is unchanged — this normalizes only
                 # the terminal output.result artifact.
                 output_content = _finalize_output_content(messages)
+                last_message = messages[-1] if messages else None
+                if last_message is not None and _looks_like_future_work_promise(last_message):
+                    logger.warning(
+                        "agent.terminated_with_promise",
+                        extra={
+                            "task_id": task_id,
+                            "tenant_id": tenant_id,
+                            "agent_id": agent_id,
+                            "model": agent_config.get("model"),
+                            "message_preview": output_content[:200],
+                        },
+                    )
 
                 # Per-checkpoint cost tracking replaces end-of-task aggregation.
                 # Costs are now written incrementally in the streaming loop above.

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -8,6 +8,7 @@ from core.config import WorkerConfig
 from executor.graph import GraphExecutor, _handle_tool_error
 from executor.mcp_session import McpConnectionError, McpToolCallError
 from executor.schema_converter import MAX_TOOLS_PER_AGENT
+from langchain_core.messages import AIMessage
 from langchain_core.tools import StructuredTool
 from langgraph.errors import GraphRecursionError
 from checkpointer.postgres import LeaseRevokedException
@@ -1449,6 +1450,81 @@ class TestInputFileInjection:
         # would collapse ``agent_decides`` into ``always`` mode.
         assert "opt-in" in msg.lower()
         assert "MUST" not in msg  # no policy-level enforcement on save_memory
+
+    def test_platform_system_message_warns_against_narrating_future_tool_calls(self):
+        """Phase 1 guardrail: the platform prompt tells models to call tools now or answer finally."""
+        executor = _build_test_executor()
+        msg = executor._build_platform_system_message(["web_search", "read_url"])
+        assert "If you intend to use a tool, emit the tool call in the same response." in msg
+        assert "Do not narrate future tool calls in prose" in msg
+        assert "Either call the tool now, or produce the final answer." in msg
+
+
+def test_detects_future_work_promise_in_terminal_ai_message():
+    """Regression guard for prose promises that should have been tool calls."""
+    from executor.graph import _looks_like_future_work_promise
+
+    assert _looks_like_future_work_promise(
+        AIMessage(
+            content=(
+                "Absolutely - I can do a deeper dive. "
+                "To do this properly, I'll review the underlying articles directly."
+            )
+        )
+    ) is True
+
+
+def test_does_not_flag_normal_final_answer_as_future_work_promise():
+    """Plain terminal answers should not emit the promise telemetry event."""
+    from executor.graph import _looks_like_future_work_promise
+
+    assert _looks_like_future_work_promise(
+        AIMessage(content="The timeline is now reconstructed and summarized above.")
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_execute_task_logs_terminated_with_promise_event(mock_worker, task_data):
+    """Completion path emits telemetry when the final AI turn promises future work."""
+    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
+
+    with patch.object(executor, "_build_graph") as mock_build:
+        mock_graph = MagicMock()
+        mock_compiled = AsyncMock()
+        mock_graph.compile.return_value = mock_compiled
+        mock_build.return_value = mock_graph
+
+        with patch("executor.graph.PostgresDurableCheckpointer") as MockCheckpointer:
+            mock_ckpt = AsyncMock()
+            mock_ckpt.aget_tuple.return_value = None
+            MockCheckpointer.return_value = mock_ckpt
+
+            async def mock_astream(*args, **kwargs):
+                yield {"mock": "event"}
+
+            mock_compiled.astream = mock_astream
+
+            terminal_message = AIMessage(
+                content=(
+                    "Absolutely - I can do a deeper dive. "
+                    "To do this properly, I'll review the underlying articles directly."
+                )
+            )
+            mock_state = MagicMock()
+            mock_state.values = {"messages": [terminal_message]}
+            mock_compiled.aget_state.return_value = mock_state
+
+            with patch("executor.graph.logger") as mock_logger:
+                await executor.execute_task(
+                    task_data,
+                    mock_worker.heartbeat.start_heartbeat.return_value.cancel_event,
+                )
+
+    matching_calls = [
+        c for c in mock_logger.warning.call_args_list
+        if c.args and c.args[0] == "agent.terminated_with_promise"
+    ]
+    assert len(matching_calls) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR now includes two related fixes:

1. Phase 1 of issue #97 in the worker runtime
2. a Console fix for Create Agent default model selection

The worker change adds a platform-system-message nudge telling the model to emit tool calls in the same response instead of narrating future tool use in prose, and it logs `agent.terminated_with_promise` when a task still terminates on a final assistant message that looks like a promise of future work.

The Console change removes the stale hardcoded default model in the Create Agent dialog and auto-selects the first available model from the fetched model list so the visible selection matches the submitted payload.

## Why

Today `route_after_agent` follows the standard ReAct contract: if the final `AIMessage` has no `tool_calls`, the graph terminates. Reasoning models sometimes reply with prose like "I'll review the articles directly" without actually emitting a tool call, which causes the task to complete prematurely.

Separately, the Create Agent dialog could show a stale default model choice that was no longer aligned with the actual available models list, so the rendered selection and submitted form state could drift.

## What Changed

- add a platform prompt rule in the worker system message: call the tool now or produce the final answer
- add a narrow terminal-message heuristic for future-work promises
- emit `agent.terminated_with_promise` as a structured warning event when the heuristic matches
- add executor tests covering the prompt text, the promise detector, and the completion-path telemetry event
- initialize the Create Agent dialog's provider/model from the first fetched model instead of a hardcoded default
- add a Console test covering the auto-selected default model payload

## Impact

The worker change does not add any automatic continuation or retry behavior.

If the model still ends with prose and no tool call, the task still completes as before; the worker now logs the event so we can see how often the prompt nudge was insufficient.

The Console change keeps the visible model selection and submitted payload in sync with the live model list.

## Validation

- `services/worker-service/.venv/bin/pytest services/worker-service/tests/test_executor.py -q`
- `cd services/console && npm exec vitest run src/features/agents/CreateAgentDialog.test.tsx`

Refs #97
