### PR TITLE
Prompt caching correctness + cross-provider summarizer selection

### DIFF
--- a/.env.localdev.example
+++ b/.env.localdev.example
@@ -8,7 +8,11 @@ E2B_API_KEY=e2b_...
 
 DB_DSN=postgresql://postgres:postgres@localhost:55432/persistent_agent_runtime
 VITE_API_BASE_URL=http://localhost:8080
-APP_DEV_TASK_CONTROLS_ENABLED=false
+# APP_DEV_TASK_CONTROLS_ENABLED defaults to `true` under ``make start``
+# (see docs/LOCAL_DEVELOPMENT.md § Dev-Only Task Controls). Set to ``false``
+# here if you want a local stack that mirrors production's in-code default
+# (which is ``false`` for all three services when the env var is unset).
+# APP_DEV_TASK_CONTROLS_ENABLED=false
 LEASE_DURATION_SECONDS=60
 HEARTBEAT_INTERVAL_SECONDS=15
 REAPER_INTERVAL_SECONDS=30

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,15 @@ DB_USER ?= $(if $(PYTHON),$(shell $(PYTHON) -c 'import sys; from urllib.parse im
 DB_PASSWORD ?= $(if $(PYTHON),$(shell $(PYTHON) -c 'import sys; from urllib.parse import urlparse, unquote; print(unquote(urlparse(sys.argv[1]).password or "postgres"))' "$(DB_DSN)"),postgres)
 SERVER_PORT ?= 8080
 VITE_API_BASE_URL ?= http://localhost:8080
-APP_DEV_TASK_CONTROLS_ENABLED ?= false
+# Local-dev default: ON. The Makefile is the local-development entry point;
+# dev task controls (``/v1/dev/tasks/*`` endpoints, ``dev_sleep`` tool, short
+# task timeouts) are what developers actually want when iterating. All three
+# services (API / Worker / Console) default to OFF in their own code when
+# the env var is unset, so this Makefile default does NOT leak into
+# production — production deploys (Helm / CDK / Lambda) don't invoke the
+# Makefile and therefore see the in-code ``false`` default.
+# Override for this session with: ``APP_DEV_TASK_CONTROLS_ENABLED=false make start``
+APP_DEV_TASK_CONTROLS_ENABLED ?= true
 VITE_DEV_TASK_CONTROLS_ENABLED ?= $(APP_DEV_TASK_CONTROLS_ENABLED)
 
 # Local-dev default: emit the per-turn compaction.projection_built DEBUG trace
@@ -60,6 +68,17 @@ VITE_DEV_TASK_CONTROLS_ENABLED ?= $(APP_DEV_TASK_CONTROLS_ENABLED)
 # override is Makefile-local. Override for a quieter log with:
 #   WORKER_LOG_LEVEL=INFO make start-worker
 WORKER_LOG_LEVEL ?= DEBUG
+
+# Prompt-cache marker injection is ON by default (managed-platform default;
+# caching always helps multi-turn agent loops and is provider-neutral). Flip
+# this to a truthy value (1 / true / yes / on) to suppress marker injection
+# fleet-wide — an operator kill switch for provider-side caching regressions
+# or debugging, NOT a per-agent tuning knob.
+#   WORKER_PROMPT_CACHE_DISABLED=1 make start-worker
+# Token-usage extraction continues regardless so OpenAI's automatic caching
+# still reports correctly. Per-agent toggling is deliberately not exposed —
+# disabling caching only raises costs, so we don't surface it as config.
+WORKER_PROMPT_CACHE_DISABLED ?=
 # Langfuse is now configured per-agent via the Console Settings page.
 # These defaults are only used by test-langfuse-up / dev-langfuse-up.
 LANGFUSE_HOST ?= http://127.0.0.1:3300
@@ -158,7 +177,8 @@ help:
 	@echo ""
 	@echo "$(CYAN)[Tips]$(NC)"
 	@echo "  $(YELLOW)make -n start N=3$(NC)   - 👀 Preview commands without executing them"
-	@echo "  $(YELLOW)APP_DEV_TASK_CONTROLS_ENABLED=true make start$(NC) - 🧪 Enable dev-only task controls locally"
+	@echo "  $(YELLOW)APP_DEV_TASK_CONTROLS_ENABLED=false make start$(NC) - 🔒 Disable dev-only task controls (default: enabled for local dev)"
+	@echo "  $(YELLOW)WORKER_PROMPT_CACHE_DISABLED=1 make start$(NC)     - 🔇 Operator kill switch: suppress prompt-cache markers fleet-wide"
 	@echo ""
 	@echo "$(CYAN)[Other Tools]$(NC)"
 	@echo "  $(YELLOW)make clean$(NC)          - 🧹 Clean temporary/cache files"
@@ -373,7 +393,7 @@ start-console:
 	else \
 		rm -f $(TMP_DIR)/console.pid; \
 		echo "$(CYAN)Starting Console...$(NC)"; \
-		nohup bash -lc "cd '$(CONSOLE_DIR)' && export PATH='$(CONSOLE_DIR)/node_modules/.bin':\$$PATH && exec node '$(CONSOLE_DIR)/scripts/dev.mjs'" > $(TMP_DIR)/console.log 2>&1 & echo $$! > $(TMP_DIR)/console.pid; \
+		nohup bash -lc "cd '$(CONSOLE_DIR)' && export PATH='$(CONSOLE_DIR)/node_modules/.bin':\$$PATH && VITE_DEV_TASK_CONTROLS_ENABLED='$(VITE_DEV_TASK_CONTROLS_ENABLED)' exec node '$(CONSOLE_DIR)/scripts/dev.mjs'" > $(TMP_DIR)/console.log 2>&1 & echo $$! > $(TMP_DIR)/console.pid; \
 		echo "$(GREEN)✅ Console started (Frontend bound to http://localhost:5173)$(NC)"; \
 	fi
 
@@ -398,7 +418,7 @@ start-api:
 	else \
 		rm -f $(TMP_DIR)/api.pid; \
 		echo "$(CYAN)Starting API...$(NC)"; \
-		nohup bash -lc "cd '$(API_DIR)' && exec '$(API_DIR)/gradlew' bootRun" > $(TMP_DIR)/api.log 2>&1 & echo $$! > $(TMP_DIR)/api.pid; \
+		nohup bash -lc "cd '$(API_DIR)' && APP_DEV_TASK_CONTROLS_ENABLED='$(APP_DEV_TASK_CONTROLS_ENABLED)' exec '$(API_DIR)/gradlew' bootRun" > $(TMP_DIR)/api.log 2>&1 & echo $$! > $(TMP_DIR)/api.pid; \
 		echo "$(GREEN)✅ API Service started$(NC)"; \
 	fi
 
@@ -417,7 +437,7 @@ start-worker:
 			skipped=$$((skipped + 1)); \
 		else \
 			rm -f $$pidfile; \
-			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$i.log 2>&1 & echo $$! > $$pidfile; \
+			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' WORKER_PROMPT_CACHE_DISABLED='$(WORKER_PROMPT_CACHE_DISABLED)' APP_DEV_TASK_CONTROLS_ENABLED='$(APP_DEV_TASK_CONTROLS_ENABLED)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$i.log 2>&1 & echo $$! > $$pidfile; \
 			started=$$((started + 1)); \
 		fi; \
 		i=$$((i + 1)); \
@@ -475,7 +495,7 @@ scale-worker:
 				slot=$$((slot + 1)); continue; \
 			fi; \
 			rm -f $$pidfile; \
-			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$slot.log 2>&1 & echo $$! > $$pidfile; \
+			nohup bash -c "cd $(WORKER_DIR) && source .venv/bin/activate && WORKER_LOG_LEVEL='$(WORKER_LOG_LEVEL)' WORKER_PROMPT_CACHE_DISABLED='$(WORKER_PROMPT_CACHE_DISABLED)' APP_DEV_TASK_CONTROLS_ENABLED='$(APP_DEV_TASK_CONTROLS_ENABLED)' exec python '$(WORKER_DIR)/main.py'" > $(TMP_DIR)/worker-$$slot.log 2>&1 & echo $$! > $$pidfile; \
 			started=$$((started + 1)); slot=$$((slot + 1)); \
 		done; \
 		echo "$(GREEN)✅ Scaled to $$target worker(s)$(NC)"; \

--- a/docs/CONSOLE_BROWSER_TESTING.md
+++ b/docs/CONSOLE_BROWSER_TESTING.md
@@ -97,7 +97,7 @@ What to verify:
 - Budget fields show dollar conversion below the microdollar input
 - **Sandbox sub-section** renders with an enable toggle; enabling reveals template, vCPU, memory (MB), and timeout (seconds) inputs. Each input has a stable `data-testid`.
 - **Memory sub-section** renders with an enable toggle; enabling reveals summarizer-model selector and max-entries input.
-- **Context-management sub-section** renders (always visible — no enable toggle) with summarizer-model dropdown (`data-testid="context-management-summarizer-model"`), exclude-tools chip input (`data-testid="context-management-exclude-tools"`), and pre-Tier-3 memory-flush toggle (`data-testid="context-management-pre-tier3-flush"`, disabled when memory is off).
+- **Context-management sub-section** renders (always visible — no enable toggle) with summarizer-model dropdown (`data-testid="context-management-summarizer-model"`), exclude-tools chip input (`data-testid="context-management-exclude-tools"`), and save-important-facts checkbox (`data-testid="context-management-pre-tier3-flush"`, disabled when memory is off).
 - After creating, the agent appears in the list; values set in the sandbox / memory / context-management sub-sections are present on the detail page
 - Clicking the agent name navigates to `/agents/:agentId`
 - The detail page shows read-only mode by default
@@ -296,17 +296,17 @@ Preconditions: two agents seeded — `agent-memory-on` (`agent_config.memory.ena
 
 ### Scenario 15: Context Management Section
 
-Covers Track 7 Task 11 — the new "Context management" section on the Agent edit form. Verifies all three tuning fields persist end-to-end, the 50-entry cap is enforced, and the `pre_tier3_memory_flush` toggle correctly reflects memory-enabled state.
+Covers Track 7 Task 11 — the new "Long-Running Task Context" section on the Agent edit form. Verifies all three tuning fields persist end-to-end, the 50-entry cap is enforced, and the `pre_tier3_memory_flush` toggle correctly reflects memory-enabled state.
 
 Preconditions: at least one agent exists. Both a memory-enabled agent (`agent_config.memory.enabled = true`) and a memory-disabled agent (or absent) are helpful for the disabled-toggle branch.
 
-1. Navigate to `/agents/:agentId` and click `Edit`. Assert the `Context management` section renders after the `Memory` section, contains a `Summarizer Model` dropdown, an `Exclude Tools` chip input, and a `Pre-Tier-3 Memory Flush` checkbox. Assert there is NO `enabled` toggle for context management. The section header reads "Context management is always-on platform infrastructure; the fields below are tuning knobs, not an enable toggle."
+1. Navigate to `/agents/:agentId` and click `Edit`. Assert the `Long-Running Task Context` section renders after the `Memory` section, contains a `Summarizer Model` dropdown with a visible chevron affordance, an `Always Keep Outputs From` chip input, and a `Save Important Facts Before Summarizing` checkbox. Assert there is NO `enabled` toggle for context management. The section intro reads "When tasks run for a long time, the platform may summarize older context to keep the agent effective. These are advanced settings."
 
 2. Select a model from the `Summarizer Model` dropdown (`data-testid="context-management-summarizer-model"`). Type a tool name (e.g., `web_search`) into the chip input (`data-testid="context-management-exclude-tools"`) and press Enter. Confirm the chip appears. Toggle `pre_tier3_memory_flush` on (`data-testid="context-management-pre-tier3-flush"`). Click `Save Changes`. Navigate away and return to the agent. Re-enter edit mode and assert all three fields retain their saved values.
 
 3. With 50 chips already entered in `exclude_tools`, type a 51st tool name and press Enter. Assert the inline error "Maximum 50 entries" appears. Assert the chip count stays at 50. Assert `Save Changes` is not blocked by this client-side error — the user can still save (the 51st entry was rejected, not added).
 
-4. With a memory-disabled agent (or disable memory for the test agent), open edit mode. Assert the `Pre-Tier-3 Memory Flush` checkbox is visually disabled and a note reads "Requires memory to be enabled." Enable memory in the Memory section. Assert the `Pre-Tier-3 Memory Flush` checkbox becomes enabled.
+4. With a memory-disabled agent (or disable memory for the test agent), open edit mode. Assert the `Save Important Facts Before Summarizing` checkbox is visually disabled and a note reads "Requires memory to be enabled." Enable memory in the Memory section. Assert the checkbox becomes enabled.
 
 5. Open edit mode without touching any context management field. Click `Save Changes`. Inspect the PUT request body via `browser_network_requests`. Assert the `agent_config` does NOT contain a `context_management` key (don't-send-defaults).
 
@@ -319,17 +319,17 @@ What it validates: The Create Agent dialog exposes the same context-management t
 What to verify:
 
 1. Navigate to `/agents` and click `Create Agent`. Assert the dialog opens as a modal and is scrollable.
-2. In the create dialog, confirm a `Context Management` section renders after the `Memory` section. Assert it contains:
+2. In the create dialog, confirm a `Long-Running Task Context` section renders after the `Memory` section. Assert it contains:
    - the `Summarizer Model` dropdown (`data-testid="context-management-summarizer-model"`)
-   - the `Exclude Tools from Compaction` chip input (`data-testid="context-management-exclude-tools"`)
-   - the `Pre-Tier-3 Memory Flush` checkbox (`data-testid="context-management-pre-tier3-flush"`)
+   - the `Always Keep Outputs From` chip input (`data-testid="context-management-exclude-tools"`)
+   - the `Save Important Facts Before Summarizing` checkbox (`data-testid="context-management-pre-tier3-flush"`)
    - no `Enable Context Management` toggle
-3. With memory disabled, assert `Pre-Tier-3 Memory Flush` is disabled and the helper text reads `Requires memory to be enabled.`
-4. Enable memory in the same dialog. Assert `Pre-Tier-3 Memory Flush` becomes enabled.
-5. Select a context summarizer model, add at least one excluded tool chip, enable `Pre-Tier-3 Memory Flush`, then submit the form. Inspect the POST request body via `browser_network_requests` and assert `agent_config.context_management` contains the selected `summarizer_model`, `exclude_tools`, and `pre_tier3_memory_flush: true`.
-6. **Partial-input faithfulness (P1 regression guard):** open a second create dialog. Set ONLY the `Summarizer Model`; leave the `Pre-Tier-3 Memory Flush` checkbox unchecked and do not add any excluded tools. Submit. Inspect the POST body and assert `agent_config.context_management.pre_tier3_memory_flush === false` — the key MUST be present and explicitly `false` (not missing, not `true`). Rationale: the worker defaults a missing value to `true`, so an absent key would silently override the UI's unchecked state.
-7. **Summarizer × provider parity (P2 regression guard):** in a third create dialog, keep the default `provider = anthropic` and open the `Summarizer Model` dropdown. Assert every option belongs to the `anthropic` provider (no OpenAI / other-provider options visible). Then change the primary model to an OpenAI entry. Assert the summarizer dropdown re-renders with only OpenAI options; if a summarizer was previously selected on `anthropic`, it is cleared (the dropdown reverts to `Platform default`).
-8. Re-open the created agent in `/agents/:agentId`, enter edit mode, and confirm the same context-management values are present there. Also confirm the edit form applies the same summarizer × provider filtering (only options for the agent's provider are visible).
+3. With memory disabled, assert `Save Important Facts Before Summarizing` is disabled and the helper text reads `Requires memory to be enabled.`
+4. Enable memory in the same dialog. Assert the checkbox becomes enabled.
+5. Select a context summarizer model, add at least one excluded tool chip, enable `Save Important Facts Before Summarizing`, then submit the form. Inspect the POST request body via `browser_network_requests` and assert `agent_config.context_management` contains the selected `summarizer_model`, `exclude_tools`, and `pre_tier3_memory_flush: true`.
+6. **Partial-input faithfulness (P1 regression guard):** open a second create dialog. Set ONLY the `Summarizer Model`; leave the checkbox unchecked and do not add any excluded tools. Submit. Inspect the POST body and assert `agent_config.context_management.pre_tier3_memory_flush === false` — the key MUST be present and explicitly `false` (not missing, not `true`). Rationale: the worker defaults a missing value to `true`, so an absent key would silently override the UI's unchecked state.
+7. **Cross-provider summarizer support (P2 regression guard):** in a third create dialog, keep the default agent provider/model on an Anthropic entry and open the `Summarizer Model` dropdown. Assert options from multiple providers are visible in the same list. Select a non-Anthropic summarizer option, submit the form, and inspect the POST body via `browser_network_requests`. Assert `agent_config.context_management` contains both `summarizer_model` and `summarizer_provider`, and that the provider matches the selected summarizer rather than the primary agent provider.
+8. Re-open the created agent in `/agents/:agentId`, enter edit mode, and confirm the same context-management values are present there. Change the primary agent model/provider to a different provider and assert the cross-provider summarizer selection remains intact instead of being cleared. Also confirm the read-only detail view renders the summarizer as `Model Name (Provider)`.
 9. `browser_console_messages` shows no uncaught exceptions during the flow.
 
 ### Scenario 17: Langfuse Trace — Context Window Management (Track 7 AC 14 manual)

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -27,7 +27,7 @@ make start
 - loads local overrides from `.env.localdev`
 - uses sensible local defaults for `DB_DSN` and `VITE_API_BASE_URL`
 - starts the local Langfuse Docker stack automatically
-- forwards `APP_DEV_TASK_CONTROLS_ENABLED` to the API, worker, and console when set
+- forwards `APP_DEV_TASK_CONTROLS_ENABLED` (default `true` for local dev) to the API, worker, and console, and `VITE_DEV_TASK_CONTROLS_ENABLED` (derived from it) to the console
 - checks the existing `persistent-agent-runtime-postgres` container and starts it if needed
 - expects dependencies to already be installed via `make install`
 - runs model discovery before starting services
@@ -169,6 +169,26 @@ grep '<task-id>' .tmp/worker-*.log | grep -v '^{'
 
 The worker service defaults to `INFO` in code (see `services/worker-service/core/logging.py`). DEBUG is enabled *only* by the Makefile's `WORKER_LOG_LEVEL ?= DEBUG`, which applies to `make start` / `make start-worker` / `make scale-worker`. Production deploys (Helm, CDK) must not set `WORKER_LOG_LEVEL` — at fleet scale DEBUG produces several MB of JSON per hour per worker.
 
+### Disabling prompt-cache markers (operator kill switch)
+
+Prompt caching is on by default — the worker adds provider-specific cache markers (`cache_control` for Anthropic, `cachePoint` for Bedrock Converse) to every LLM request so multi-turn agent loops cache their stable prefix. There is **no per-agent toggle** by design: disabling caching only raises costs, so the knob is deliberately not exposed as customer config.
+
+The `WORKER_PROMPT_CACHE_DISABLED` env var is an **operator-only emergency lever** — use it when a provider caching regression, a suspected SDK bug, or a debugging need requires suppressing markers without touching the database. The Makefile forwards it:
+
+```bash
+# Kill switch for this session — all workers start with markers suppressed
+WORKER_PROMPT_CACHE_DISABLED=1 make start
+
+# Restart just the workers with caching off, keeping the rest of the stack up
+WORKER_PROMPT_CACHE_DISABLED=1 make restart
+```
+
+Accepted truthy values (case-insensitive): `1`, `true`, `yes`, `on`. Anything else (including unset, empty, `0`, `false`) keeps caching enabled.
+
+Token-usage extraction is intentionally **not** gated on this flag — OpenAI caches prefixes automatically regardless of whether we inject markers, and we must keep extracting `cached_tokens` from their response metadata to avoid mis-reporting cached reads as regular input tokens (which would over-attribute spend by ~10× on cached turns).
+
+When the kill switch is active, the worker emits a single `prompt_cache.markers_disabled_via_env` warning at startup so it's clear in logs that markers are off on purpose.
+
 ## Dev-Only Task Controls
 
 The runtime includes dev-only endpoints and tools for testing failure and recovery flows locally:
@@ -177,18 +197,19 @@ The runtime includes dev-only endpoints and tools for testing failure and recove
 - `POST /v1/dev/tasks/{taskId}/force-dead-letter` — forces a task into the dead-letter path
 - `dev_sleep` tool — an agent tool that sleeps for a configurable duration, useful for exercising timeout and long-running-task behavior deterministically
 
-These are disabled by default. To enable them:
+**These are enabled by default under `make start`** — the Makefile sets `APP_DEV_TASK_CONTROLS_ENABLED ?= true` because local development is the Makefile's only audience. Production deploys (Helm, CDK, Lambda) don't invoke the Makefile and therefore see each service's code-level default of `false` when the env var is unset.
+
+To explicitly opt out for a local run:
 
 ```bash
-APP_DEV_TASK_CONTROLS_ENABLED=true make start
+APP_DEV_TASK_CONTROLS_ENABLED=false make start
 ```
 
 ## Timing Configuration
 
-For faster local recovery testing, you can shorten the lease, heartbeat, and reaper timings:
+For faster local recovery testing, you can shorten the lease, heartbeat, and reaper timings (dev task controls are already on under `make start`):
 
 ```bash
-APP_DEV_TASK_CONTROLS_ENABLED=true \
 LEASE_DURATION_SECONDS=10 \
 HEARTBEAT_INTERVAL_SECONDS=2 \
 REAPER_INTERVAL_SECONDS=5 \

--- a/docs/references/claudecode-compaction-mechanisms.md
+++ b/docs/references/claudecode-compaction-mechanisms.md
@@ -1,0 +1,736 @@
+# Compaction Mechanisms in `cc-haha`
+
+A survey of every mechanism that shrinks, rewrites, redirects, or otherwise compacts conversation state between the client and the Anthropic API. Written against the tree at `/Users/shenjianan/Project/cc-haha` (main branch, commit `5a86ab0`).
+
+---
+
+## 1. Framing: Three Distinct "Contexts"
+
+Compaction discussions get muddled when "context" means multiple things at once. This codebase operates on three distinct layers:
+
+| Layer | What it is | Persists across turns? |
+|---|---|---|
+| **Local `messages[]`** | The client-side transcript array. Powers REPL rendering, `/resume`, transcript writes. | Yes, on disk (session transcript) |
+| **Wire payload** | The JSON body of each HTTP POST to the API. | No — rebuilt each turn from `messages[]` plus directives |
+| **Effective model context** | The token stream attention actually runs over. | No — determined per-request by wire + server cache + server-side directives |
+
+A mechanism can touch any subset of these three. The most interesting trick in the codebase (cached microcompact) touches only the third. The simplest (time-based microcompact) touches all three.
+
+---
+
+## 2. Master Summary Table
+
+| # | Mechanism | When it fires | What it changes | Cache-stable? | Key files |
+|---|---|---|---|---|---|
+| 1 | **Per-tool size persistence** | Tool result > `maxResultSizeChars` (default 50K chars, hard cap 400KB) | `messages[]` + wire: block content → `<persisted-output>` preview + filepath. Full content → disk. | ✅ Yes, from turn 1 onwards | `src/utils/toolResultStorage.ts:272`, `src/constants/toolLimits.ts:13` |
+| 2 | **Per-message aggregate budget** | Parallel tool_results in one user-message total > 200K chars | Same as #1, applied to the largest fresh blocks until under budget | ✅ Yes (frozen decisions via `seenIds`) | `src/utils/toolResultStorage.ts:769` |
+| 3 | **Time-based microcompact** | Gap since last assistant > 60 min (GB-flagged, off by default) | `messages[]` + wire: compactable tool_results' content → `"[Old tool result content cleared]"` literal. Keeps last 5. | ❌ No — but cache was already cold | `src/services/compact/microCompact.ts:446`, `timeBasedMCConfig.ts` |
+| 4 | **Cached microcompact** (ant-only, stubbed in this build) | Count-based trigger on registered tool_results | Wire only: appends `cache_edits` directive; server drops tool_results from cached prompt. `messages[]` untouched. | ✅ Yes — designed for it | `src/services/compact/microCompact.ts:305`, `cachedMicrocompact.ts` (stub) |
+| 5 | **API-native context management** (ant-only) | `input_tokens` > 180K (target: shrink to 40K) | Wire only: `context_management` body param with `clear_tool_uses_20250919` and/or `clear_thinking_20251015`. Server-side. | ✅ Yes | `src/services/compact/apiMicrocompact.ts` |
+| 6 | **Session memory compact** | Token threshold, runs *before* legacy autocompact | `messages[]`: persistent markdown in `~/.claude/session-memory/*.md` + pruned message tail + boundary marker | ❌ No | `src/services/compact/sessionMemoryCompact.ts`, `src/services/SessionMemory/` |
+| 7 | **Autocompact (legacy)** | Token count > effective window − 13K (or `/compact` command, or PTL retry) | `messages[]`: full rewrite into `[boundary, summary, recentTail, attachments, hooks]` | ❌ No (cache baseline reset) | `src/services/compact/autoCompact.ts`, `compact.ts:387` |
+| 8 | **Session memory (async)** | Every ~3 turns or 50K tokens since last extraction (background) | External disk file (`~/.claude/session-memory/*.md`); cross-session | N/A — not wire-affecting | `src/services/SessionMemory/` |
+| 9 | **Prompt cache break detection** | Post-response, if `cacheReadTokens` drop > 5% and > 2K | Neither. Observational only — logs cause (model flip, tool schema change, etc.) | N/A | `src/services/api/promptCacheBreakDetection.ts` |
+| 10 | **Collapse / group (display only)** | Rendering time | UI only — groups read/search tool calls into `⎿` summary lines | N/A | `src/utils/collapseReadSearch.ts`, `src/utils/groupToolUses.ts` |
+| 11 | **`normalizeMessagesForAPI`** | Every API call | Wire only: filters progress/synthetic messages, merges consecutive user messages, strips `tool_reference` blocks, injects boundary markers | Designed to be | `src/utils/messages.ts:1989` |
+| 12 | **Cache breakpoint placement** | Every API call | Wire only: places exactly one `cache_control` marker at last-or-second-to-last message | Designed to be | `src/services/api/claude.ts:3063` |
+
+---
+
+## 3. Detailed Breakdown
+
+### 3.1 Per-tool size persistence
+
+**Trigger.** Each tool has a `maxResultSizeChars` declaration. The effective threshold is `min(toolDeclaredMax, DEFAULT_MAX_RESULT_SIZE_CHARS)` where the default is **50,000 chars** (`constants/toolLimits.ts:13`). A GrowthBook flag `tengu_satin_quoll` can override per-tool. Tools that opt out with `Infinity` (notably `Read`) are never persisted — that would create an infinite loop since Read itself is how the model reads persisted content back.
+
+**Action.** The full tool_result content is written to `projectDir/sessionId/tool-results/<tool_use_id>.<txt|json>` via `persistToolResult` (`toolResultStorage.ts:137`). The wire block's content is replaced with:
+
+```
+<persisted-output>
+Output too large (127.3 KB). Full output saved to: /path/to/file
+
+Preview (first 2.0 KB):
+<first ~2KB of original, cut at newline boundary>
+...
+</persisted-output>
+```
+
+Previews are 2KB (`PREVIEW_SIZE_BYTES`) cut at the nearest newline via `generatePreview` (`:339`).
+
+**Model access.** The model reads the file via the `Read` tool with `offset`/`limit`. Because Read is exempt from persistence (`maxResultSizeChars: Infinity`, short-circuited at `toolResultStorage.ts:62`), the round-trip works — if Read's own output got persisted too, the model would be reading-a-file-about-a-file-about-a-file and the loop never terminates.
+
+**Why chunked paging via Read instead of one big inline result.** Several compounding benefits, roughly in order of importance:
+
+1. **Preview usually suffices.** 2KB cut at a newline boundary is enough for most outputs — grep's first hits, shell status, web fetch's opening paragraphs. Paying full token cost 100% of the time for a <20% benefit is wasteful.
+2. **Prompt-cache friendliness.** The preview + filepath string is small, deterministic, and frozen — byte-identical on every subsequent turn, cache-stable forever.
+3. **Context-window budget.** One 350KB tool result would crowd every subsequent turn's context until a later compaction rescued it. Chunked paging keeps per-turn footprint low.
+4. **Selective access.** The model can offset/limit to a specific region, grep the file for a keyword, or skip irrelevant sections — beats scan-from-top every turn.
+5. **API ceilings.** Per-block and per-request token ceilings make 400KB inline impossible; paged reads fit.
+6. **Retry-ability.** The file persists on disk at a deterministic path even if the turn errors out or the user interrupts. No re-running the original (non-deterministic) tool.
+7. **Capture vs. consume separation.** Producing bytes (disk I/O, cheap) is split from consuming them (tokens, expensive). Only the model's judgment spends the expensive one.
+
+The net effect: an agent session can ingest arbitrarily large tool outputs — long diffs, web page dumps, command logs — without the conversation's token budget scaling with them. Disk absorbs the size; in-context footprint stays ~2KB per large result regardless of original size.
+
+**Cache stability.** Persistence happens on turn T and the preview string is byte-identical on every subsequent turn. `fs.writeFile` uses `flag: 'wx'` (`:162`) to avoid re-writing when microcompact replays original messages.
+
+**Benefits** (the user-facing "why"):
+1. Model usually doesn't need more than the 2KB preview → avoid paying full token cost 100% of the time for a benefit that materializes <20% of the time.
+2. Preview + filepath is small, deterministic, cache-friendly forever.
+3. One big tool call doesn't blow the entire conversation's token runway.
+4. Selective access (Read with offset, Grep on the filepath) beats sequential scan.
+5. API has per-block and per-request token ceilings; chunked reads fit, 400KB inline doesn't.
+6. Retry / debug: artifact is on disk at a deterministic path even if the turn errors out.
+
+### 3.2 Per-message aggregate budget
+
+**Trigger.** When parallel tool_results in a single user-message total more than **200,000 chars** (`MAX_TOOL_RESULTS_PER_MESSAGE_CHARS`, `toolLimits.ts:49`). GrowthBook flag `tengu_hawthorn_window` can override, gated by `tengu_hawthorn_steeple`.
+
+**Vocabulary: "message" means one API-level `user` message containing multiple tool_result blocks.** When the assistant calls N tools in parallel, the results come back as a single user message with N tool_result blocks. That's the unit the budget evaluates. Sequential tool calls across turns each live in *separate* user messages and are checked independently.
+
+- Budget-relevant: 10 parallel greps in one turn → one user message with 10 blocks → summed.
+- Budget-irrelevant: 10 sequential greps across 10 turns → each its own message → each checked alone.
+
+`collectCandidatesByMessage` (`toolResultStorage.ts:600`) mirrors `normalizeMessagesForAPI`'s consecutive-user-message merging so the budget groups the same way the wire does.
+
+**Three-way partition before selection.** `partitionByPriorDecision` (`:649`) sorts each message's candidates:
+
+- **mustReapply** — previously persisted. Re-apply the cached preview string via Map lookup. Zero I/O, byte-identical, cannot fail.
+- **frozen** — previously seen *unreplaced*. Off-limits: retroactively persisting would change a prefix already in cache and break the suffix.
+- **fresh** — never seen. Only these can be selected for new replacement.
+
+Every new turn adds at most one user message with fresh blocks; every prior message is 100% mustReapply + frozen. The budget check almost always just re-applies cached previews.
+
+**Greedy selection algorithm** (`selectFreshToReplace:675`):
+
+```ts
+const sorted = [...fresh].sort((a, b) => b.size - a.size)
+let remaining = frozenSize + fresh.reduce((s, c) => s + c.size, 0)
+for (const c of sorted) {
+  if (remaining <= limit) break
+  selected.push(c)
+  remaining -= c.size
+}
+```
+
+Sort fresh blocks by size descending, pick the biggest, subtract its size, stop when total is under budget. One or many blocks get persisted per message depending on how far over budget it is.
+
+Example: `[120K, 60K, 40K, 30K, 20K, 15K, 10K, 5K]` = 300K total, limit 200K. Pick 120K → remaining 180K → under limit → stop. **One** block persisted. The 120K becomes `<persisted-output>`; the other seven pass through unchanged.
+
+Example: `[80K, 80K, 80K, 80K, 80K]` = 400K. Pick 80K (320K), pick 80K (240K), pick 80K (160K, under), stop. **Three** blocks persisted.
+
+**Each persisted block is transformed independently** — its own filepath, its own 2KB preview of *its* content. Non-selected blocks in the same message are entirely unchanged.
+
+**Accepted overage.** If frozen alone > limit (possible after flag-change or pre-enablement history), fresh gets fully shed and the message still exceeds budget. Comment at `:672`: "accept the overage — microcompact will eventually clear them."
+
+**Tools exempt.** `Read` (and any tool with `maxResultSizeChars: Infinity`) is added to `seenIds` as frozen, never counted in `freshSize`, never selected (`:780`). Prevents the read-about-read loop.
+
+**Cache stability via frozen decisions.** Every tool_use_id's fate is decided on first pass and recorded in `state.seenIds` (`:390`). Replacements go in `state.replacements` as the exact preview string. Subsequent turns re-apply by Map lookup — byte-identical, zero I/O, cannot fail. Prefix cache survives.
+
+**Resume.** Decisions survive `/resume` via transcript records (`ContentReplacementRecord`, `:475`). Fork subagents inherit parent's replacements so cache-sharing forks make identical choices.
+
+### 3.3 Time-based microcompact
+
+**Trigger.** `evaluateTimeBasedTrigger` (`microCompact.ts:422`): when `(now − lastAssistantTimestamp) > gapThresholdMinutes` (default **60 min**), main-thread only, flag `tengu_slate_heron` with `enabled: false` default. The 60-min choice aligns with the server's 1h cache TTL — if it's been that long, the cache has expired anyway.
+
+**Action.** Keeps the last `keepRecent` (default 5) compactable tool_results, replaces the rest's content with the literal string `"[Old tool result content cleared]"` (`:36`). Only applies to a whitelist: `Read`, shell tools, `Grep`, `Glob`, `WebSearch`, `WebFetch`, `FileEdit`, `FileWrite` (`:41`). Other tool results (`Task`, `TodoWrite`, MCP calls, etc.) are left alone.
+
+**No reference left behind.** Unlike size-based persistence, the cleared message contains *no filepath* — the content is simply gone from the model's view. The original will still be in the on-disk transcript (for resume/display), but the model can't recover it mid-session.
+
+**Side effects.** Calls `resetMicrocompactState()` (`:517`) because the cache break invalidates any pending cached-MC state, and `notifyCacheDeletion()` so the break-detector doesn't flag the expected cache drop as an incident.
+
+### 3.4 Cached microcompact (ant-only, stubbed in this build)
+
+**Scaffolding lives at `microCompact.ts:305`; the real implementation is in `cachedMicrocompact.ts` which is a Proxy-stubbed no-op in external builds** (auto-generated from `scan-missing-imports`; header comment explicitly says `自动生成…ant-internal feature() gated 模块`). Gated by `feature('CACHED_MICROCOMPACT')`, a `bun:bundle` compile-time flag — the entire branch dead-codes out for non-ant builds.
+
+**Mechanism.** Uses Anthropic's beta `cache_edits` API directive:
+
+```ts
+type CachedMCEditsBlock = {
+  type: 'cache_edits'
+  edits: { type: 'delete'; cache_reference: string }[]
+}
+```
+
+`cache_reference` is the `tool_use_id` of a past tool call. The server drops its cached tool_result from the evaluated prompt while preserving every other cached token.
+
+**Flow per turn:**
+1. `registerToolResult` / `registerToolMessage` (`microCompact.ts:324-328`) tracks all compactable tool_results grouped by user-message.
+2. `getToolResultsToDelete` returns oldest IDs once count exceeds `triggerThreshold`, keeping the most recent `keepRecent`.
+3. A `cache_edits` block gets queued in `pendingCacheEdits` (`:338`).
+4. `addCacheBreakpoints` (`claude.ts:3141`) splices it into the last user message and calls `pinCacheEdits(i, ...)`.
+5. Every subsequent turn, `getPinnedCacheEdits()` re-inserts all prior edits at their original `userMessageIndex` (`claude.ts:3127-3139`).
+
+**Why the pins.** If turn T+1 dropped the `cache_edits` block, the cached prefix hash wouldn't match → cache miss → all benefit lost. And without re-applying the edit, the server would re-hydrate the deleted tool_results into the prompt.
+
+**What actually changes where:**
+- `messages[]`: unchanged (`:369` comment explicitly).
+- Wire payload: slightly *longer* (cache_edits directives append to it).
+- Model's effective context: *shorter* — attention runs over the edited prompt after the server applies the deletions.
+
+**This is the one mechanism in the codebase that decouples wire-size from model-context-size.**
+
+### 3.5 API-native context management
+
+**`apiMicrocompact.ts`** — a feature of the Anthropic API itself. The *server* does the compaction based on policies declared in the request body. The version-dated type names (`_20250919`, `_20251015`) are Anthropic-side behavior contracts that evolve with the platform.
+
+**Wire format:**
+
+```ts
+context_management: {
+  edits: [
+    {
+      type: 'clear_tool_uses_20250919',
+      trigger: { type: 'input_tokens', value: 180_000 },
+      clear_at_least: { type: 'input_tokens', value: 140_000 },
+      clear_tool_inputs: ['Bash', 'Grep', 'Read', ...]
+    },
+    {
+      type: 'clear_thinking_20251015',
+      keep: 'all'
+    }
+  ]
+}
+```
+
+**Two strategy types:**
+
+**`clear_tool_uses_20250919`** — triggers at `input_tokens > 180K` (`API_MAX_INPUT_TOKENS`), sheds at least 140K worth of tool content so the effective prompt lands near 40K (`API_TARGET_INPUT_TOKENS`). Two modifier modes:
+
+- **`clear_tool_inputs: [whitelist]`** (`useClearToolResults` branch, `:104-125`) — server may drop inputs AND outputs of listed tools. The whitelist is read-only / re-runnable tools: `SHELL_TOOL_NAMES`, `GLOB`, `GREP`, `READ`, `WEB_FETCH`, `WEB_SEARCH`. If the model needs the info back, it can just re-invoke.
+
+- **`exclude_tools: [blocklist]`** (`useClearToolUses` branch, `:128-150`) — server may clear tool uses of everything *except* these. The excluded list is mutating tools: `FILE_EDIT`, `FILE_WRITE`, `NOTEBOOK_EDIT`. Their tool_use records are irreplaceable — "I edited foo.ts line 42" can't be reconstructed and the mutation already happened on disk. Preserving them maintains the audit trail.
+
+Naming note: `TOOLS_CLEARABLE_USES` (the constant holding `[FILE_EDIT, FILE_WRITE, NOTEBOOK_EDIT]`) is confusingly named — it's actually the list of tools whose uses are **not** clearable (because they go into `exclude_tools`). Reads more naturally as "destructive tools whose use records we must preserve."
+
+**`clear_thinking_20251015`** — manages extended-thinking blocks (`:82-87`). Two modes: `keep: 'all'` (default when thinking is active, preserve every turn's thinking) or `keep: { type: 'thinking_turns', value: 1 }` (fires on `clearAllThinking=true`, which is set when idle > 1h — thinking blocks are cheap to drop when the cache is already cold). Skipped entirely when `isRedactThinkingActive` — redacted thinking has no model-visible content to manage.
+
+**Gating:**
+- `clear_thinking_20251015` — available to everyone. The ant check at `:90` happens *after* this strategy has already been pushed.
+- `clear_tool_uses_20250919` (both modes) — `USER_TYPE === 'ant'` AND env vars `USE_API_CLEAR_TOOL_RESULTS` / `USE_API_CLEAR_TOOL_USES` truthy. External users never see aggressive tool-clearing.
+
+**Key difference from cached microcompact:**
+- **Cached-MC** — client decides which `tool_use_id`s to drop (count-based, deterministic). "Keep the last 5 greps, drop the rest."
+- **API-native** — client declares a policy; server picks what to drop to meet a token budget. "Just keep us under 40K somehow."
+
+Cached-MC is surgical; API-native is budget-driven. They can run together — cached-MC handles steady-state pruning, API-native kicks in as a safety net.
+
+**Why server-side at all:**
+1. **Accurate token counts.** Client can only estimate (~4 bytes/token). Server knows exactly. Client-side trigger would either fire too early (waste) or too late (overflow).
+2. **Post-cache-hit evaluation.** Server applies the policy *after* matching the cached prefix, so the wire keeps sending full content for cache matching while the effective prompt shrinks. Doing this client-side would require mutating `messages[]` and breaking the cache.
+
+Both strategies are wire-only — no `messages[]` mutation. Same core trick as cached-MC: decouple wire bytes from model context.
+
+### 3.6 Session memory compact
+
+**A two-part system.** File header marks it `EXPERIMENT` (`sessionMemoryCompact.ts:2`). Off by default — requires BOTH `tengu_session_memory` AND `tengu_sm_compact` GrowthBook flags to be true (default false), or env override `ENABLE_CLAUDE_CODE_SM_COMPACT=1`.
+
+#### Part 1: Session memory (background extraction)
+
+A persistent markdown file at `~/.claude/session-memory/<session>.md`, maintained continuously by a post-sampling hook (`sessionMemory.ts:374`). Fixed template (`prompts.ts:11`) with structured sections:
+
+```
+# Session Title
+# Current State
+# Task specification
+# Files and Functions
+# Workflow
+# Errors & Corrections
+# Codebase and System Documentation
+# Learnings
+# Key results
+# Worklog
+```
+
+The hook periodically forks a subagent that reads recent history and edits the markdown via the `Edit` tool. Update rules force preservation of section headers + italic template descriptions; only content within sections is edited. "Current State" is flagged as always-refresh for post-compact continuity. Cost is amortized across turns and runs async (doesn't block user interaction).
+
+#### Part 2: SM-compact path (reusing the already-maintained summary)
+
+When autocompact is about to fire, `trySessionMemoryCompaction` (`sessionMemoryCompact.ts:514`) runs before the legacy path. If it succeeds, legacy is skipped.
+
+Output structure:
+```ts
+{
+  boundaryMarker,
+  summaryMessages: [<truncated memory markdown wrapped as user message>],
+  attachments: [planAttachment?],
+  hookResults: [SessionStart hooks],
+  messagesToKeep: <recent tail>,
+}
+```
+
+**No compact API call** — `:498` comment: "SM-compact has no compact-API-call." The summary already exists.
+
+**Tail sizing** (`calculateMessagesToKeepIndex:324`):
+- Start at `lastSummarizedMessageId + 1` (anchor from last memory-extraction pass).
+- Expand backward until `minTokens` (default 10K) AND `minTextBlockMessages` (default 5) are met.
+- Cap at `maxTokens` (default 40K).
+- `adjustIndexToPreserveAPIInvariants` ensures tool_use/tool_result pairs aren't split.
+
+#### Problems it solves vs. legacy full autocompact
+
+1. **Blocking latency.** Legacy requires a synchronous summarizer API call at compact time — typically 10-30 seconds of stall during which the user is waiting. SM-compact needs no API call; the summary already exists.
+2. **Compaction cost.** Legacy summarizer reads 180K+ input tokens per compact. SM-compact's incremental updates each process only ~50K of new content, amortized across turns, non-blocking.
+3. **Summary quality / drift.** Legacy's one-shot summarize-under-pressure loses detail; repeated compactions summarize-of-summary, compounding loss. SM-compact's structured template resists this — "Errors & Corrections" accumulates across turns via edits, never re-summarized.
+4. **Cross-session continuity.** Legacy summaries live in the transcript and don't survive session exit. SM's markdown file persists on disk for a future `/resume` or a fresh session referencing the same work.
+5. **No verbatim tail in legacy.** Legacy full-compact keeps zero messages verbatim. SM-compact keeps 10-40K tokens of recent messages untouched.
+
+#### Fallback paths
+
+Each logs a distinct event, each returns `null` to caller which falls through to legacy `compactConversation`:
+
+- Flags off (`shouldUseSessionMemoryCompaction` returns false).
+- `getSessionMemoryContent()` returns nothing (file never created).
+- `isSessionMemoryEmpty` (file exists but just the unfilled template).
+- `lastSummarizedMessageId` not found in current messages (stale after edit/fork).
+- Resulting `postCompactTokenCount >= autoCompactThreshold` (memory too long, would re-trigger immediately).
+
+#### Two scenarios handled
+
+- **Normal case** (`:548-560`): `lastSummarizedMessageId` set → keep messages after that anchor + backward expansion.
+- **Resumed session** (`:561-566`): memory has content but no anchor (likely pre-resume origin) → fall back to using memory as the full summary, no messages kept initially.
+
+#### The architectural bet
+
+Continuous, cheap, incremental, asynchronous summarization > one-shot, expensive, blocking summarization. For short sessions, SM-compact wastes background cycles. For long sessions, the trade heavily favors it: latency saved, tokens saved, quality preserved, cross-session continuity gained.
+
+### 3.6.1 Does autocompact keep the last N turns of tool results?
+
+Frequent question; deserves an explicit answer. **The main automatic path does not. Only SM-compact and manual partial compact preserve a tail.**
+
+| Path | Keeps recent tail? | Sizing |
+|---|---|---|
+| Session memory compact (tried first if enabled) | ✅ Yes | Token/text-block budget (10-40K tokens typically) |
+| Full autocompact (`compactConversation`, fallback) | ❌ No | `messagesToKeep` never set; `buildPostCompactMessages` produces `[boundary, summary, attachments, hooks]` |
+| Manual partial compact with `direction: 'up_to'` | ✅ Yes | User-chosen pivot index |
+
+The full autocompact's `CompactionResult` (at `compact.ts:738-748`) **never sets `messagesToKeep`**. Even though the type declares it `messagesToKeep?: Message[]`, only SM-compact and partial-compact populate it. So when the fallback path runs, every pre-compact message is replaced by summary prose. If the model needs a specific grep's exact output post-compact, it re-runs the grep.
+
+What the full path *does* inject is `postCompactFileAttachments` (`:532-585`): top 5 recently-read files, active skills, tool-schema deltas, agent deltas, MCP deltas, plan mode attachment. These restore *state the model needs to continue* but they are not kept original messages — the tool_use/tool_result for that read is gone.
+
+There is no "keep last N turns" turn-count configuration anywhere. Tailing is always token-sized, all-or-nothing, or user-directed.
+
+### 3.7 Autocompact (legacy full-rewrite)
+
+**Trigger** (`autoCompact.ts:72-91, 160-239`):
+- Token count > `getAutoCompactThreshold(model)` = effective-context-window − 13K buffer.
+- Not gated off by `DISABLE_COMPACT`, `DISABLE_AUTO_COMPACT`, or `userConfig.autoCompactEnabled: false`.
+- Not a subagent/forked-agent (recursion guard via querySource).
+- Not in reactive-compact or context-collapse mode.
+- Circuit breaker: skips after 3 consecutive failures (`autoCompact.ts:60, 260-265`) to avoid hammering the API on irrecoverable sessions.
+
+**Also manually triggered** by `/compact` command and by PTL (prompt-too-long) retry paths.
+
+**Action** (`compact.ts:387-763`): forks an agent via `streamCompactSummary`, feeds it all pre-compact messages and a 9-section summarization template (`prompt.ts:61-76`). The result replaces `messages[]` with:
+
+```
+[boundaryMarker(system) → summaryMessages(user) → messagesToKeep(optional) → postCompactFileAttachments(attachment) → hookMessages(hook_result)]
+```
+
+The boundary marker carries `compactMetadata`: `preCompactTokenCount`, preserved-segment UUIDs for relink.
+
+**Post-compact attachments** (`compact.ts:532-585`): top 5 recently-read files restored, active skill content re-attached, tool-schema deltas since compact start, agent deltas, MCP deltas. These backfill state the summary can't convey in plain text.
+
+**Cache stability.** Not stable by default — full array rewrite breaks prefix cache. Optimization attempt: `tengu_compact_cache_prefix` enables "prompt cache sharing" where the summarizer fork reuses the parent's cached prefix (reduces cache_creation cost) but the post-compact prefix itself is new. Cache baseline is reset via `notifyCompaction()` to suppress break-detector false-positives.
+
+### 3.7.1 The `/compact` prompt (deep dive)
+
+The actual summarization prompts used by autocompact and `/compact` live at `src/services/compact/prompt.ts`. This is where the quality of every post-compact session ultimately comes from — worth reading as its own artifact.
+
+#### Three template variants
+
+| Variant | Used by | Summary scope |
+|---|---|---|
+| `BASE_COMPACT_PROMPT` (`:61-143`) | `/compact` command and full autocompact | "the conversation" (everything) |
+| `PARTIAL_COMPACT_PROMPT` (`:145-204`) | Partial compact `direction: 'from'` | "the recent messages" (after pivot) |
+| `PARTIAL_COMPACT_UP_TO_PROMPT` (`:208-267`) | Partial compact `direction: 'up_to'` | Everything before pivot; summary precedes kept tail |
+
+All three are assembled via `getCompactPrompt` / `getPartialCompactPrompt` (`:274-303`) as `NO_TOOLS_PREAMBLE + <template> + [Additional Instructions] + NO_TOOLS_TRAILER`.
+
+#### The 9-section output schema (BASE template)
+
+The model is asked to produce summary output structured around nine numbered sections:
+
+1. **Primary Request and Intent** — all explicit user requests and intents in detail.
+2. **Key Technical Concepts** — technologies, frameworks, patterns.
+3. **Files and Code Sections** — "full code snippets where applicable" plus why each read/edit was important.
+4. **Errors and fixes** — with explicit attention to user feedback: "especially if the user told you to do something differently."
+5. **Problem Solving** — problems solved and ongoing troubleshooting.
+6. **All user messages** (not tool results) — "critical for understanding the users' feedback and changing intent."
+7. **Pending Tasks** — outstanding work.
+8. **Current Work** — precisely what was being worked on immediately before compaction.
+9. **Optional Next Step** — must be "DIRECTLY in line with the user's most recent explicit requests" AND should include **verbatim quotes** from the most recent conversation "to ensure there's no drift in task interpretation."
+
+**Anti-drift engineering.** Two of these sections (4 and 6) plus the detailed-analysis instruction all explicitly call out "user told you to do something differently." And Section 9 hard-codes a direct-quote requirement. These aren't decorative — they fight a specific observed failure mode: **compaction erasing user corrections**. User says "stop doing X" at turn 17; naive paraphrase loses that nuance; post-compact agent resumes doing X. Enumerating raw user messages and quoting recent exchanges verbatim is the cheapest defense against this.
+
+#### The `<analysis>` scratchpad
+
+Before the summary itself, the model is instructed (`:31-44`) to write its reasoning in `<analysis>` tags:
+
+```
+<analysis>
+1. Chronologically analyze each message and section...
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions, technical concepts and code patterns
+   - Specific details: file names, full code snippets, function signatures, file edits
+   - Errors that you ran into and how you fixed them
+   - Pay special attention to specific user feedback...
+2. Double-check for technical accuracy and completeness
+</analysis>
+
+<summary>
+[the 9 sections]
+</summary>
+```
+
+Then `formatCompactSummary` (`:311-335`) **strips the entire `<analysis>` block** before the summary enters context — only `<summary>` body survives (with tags replaced by a `Summary:` header).
+
+This is structured chain-of-thought: the model plans before committing, but the plan is discarded. Code comment at `:29-30`: "drafting scratchpad that formatCompactSummary() strips before the summary reaches context." You pay the output-token cost for reasoning once, at generation time; future cache reads never carry it.
+
+#### The aggressive no-tools enforcement
+
+Two bookends surround every template: a heavy `NO_TOOLS_PREAMBLE` at the top (`:19-26`) and a `NO_TOOLS_TRAILER` at the bottom (`:269-272`).
+
+**Preamble** (verbatim, placed *before* the "Your task is to..." opening):
+
+```
+CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
+
+- Do NOT use Read, Bash, Grep, Glob, Edit, Write, or ANY other tool.
+- You already have all the context you need in the conversation above.
+- Tool calls will be REJECTED and will waste your only turn — you will fail the task.
+- Your entire response must be plain text: an <analysis> block followed by a <summary> block.
+```
+
+**Trailer:**
+
+```
+REMINDER: Do NOT call any tools. Respond with plain text only —
+an <analysis> block followed by a <summary> block.
+Tool calls will be rejected and you will fail the task.
+```
+
+**Why it needs to be this aggressive.** The comment at `:12-18` explains. Compact runs with `maxTurns: 1` (`compact.ts:1194`) and inherits the parent's full tool set (required for cache-key matching on the cache-sharing fork path). On Sonnet 4.6+ adaptive-thinking models, the model attempted tool calls anyway **2.79% of the time on 4.6 vs 0.01% on 4.5** — a behavior regression. A denied tool call with `maxTurns: 1` produces no text output → falls through to streaming fallback → wasted API call.
+
+The preamble countermeasures:
+1. Placed **first**, before the friendly task description — the strongest instruction-following position.
+2. Explicitly enumerates tool names (`Read, Bash, Grep, Glob, Edit, Write`) rather than saying "tools" abstractly.
+3. Frames failure concretely (*"REJECTED ... waste your only turn ... you will fail the task"*) rather than abstractly.
+4. Repeated at the tail for recency bias.
+
+This is belt-and-suspenders prompt engineering driven by a specific eval-measured regression, not hypothetical safety. The 2.79% number survives as a commit comment because it justified shipping an aggressive, otherwise ugly preamble.
+
+#### The `up_to` variant has different sections
+
+Because a `direction: 'up_to'` summary sits *before* the kept tail on the wire, two sections are renamed:
+
+- Section 8 **"Current Work"** → **"Work Completed"** (past tense — more messages follow)
+- Section 9 **"Optional Next Step"** → **"Context for Continuing Work"** (no "next step" — the kept tail *is* the next steps)
+
+Framing also differs: "This summary will be placed at the start of a continuing session; newer messages that build on this context will follow after your summary (you do not see them here)."
+
+#### The post-compact wrapper message
+
+The raw summary isn't inserted as-is. `getCompactUserSummaryMessage` (`:337-374`) wraps it as a user message:
+
+```
+This session is being continued from a previous conversation that ran out of context.
+The summary below covers the earlier portion of the conversation.
+
+<formatted summary>
+
+If you need specific details from before compaction (like exact code snippets, error
+messages, or content you generated), read the full transcript at: <transcript path>
+
+Recent messages are preserved verbatim.    [only when SM-compact or partial-compact]
+```
+
+Notable additions:
+
+- **Transcript escape hatch.** The wrapper points to the on-disk transcript of the full pre-compact conversation. If the 9-section summary missed something, the model can Read the raw transcript. Same "preview + reference to source of truth" pattern as per-tool persistence, applied at the conversation level.
+- **"Recent messages are preserved verbatim"** only appears when `recentMessagesPreserved=true` (SM-compact and partial-compact paths). Tells the post-compact model not to re-explore work that's already in context as original messages.
+- **Follow-up suppression** (`:357-371`, enabled for autocompact): "Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, do not preface with 'I'll continue' or similar." Compaction should be invisible to the user.
+- **Proactive/autonomous mode extension** (`:361-368`): if `feature('PROACTIVE')` is on and the agent was running autonomously, adds "you were already working autonomously, continue your work loop" to prevent re-greeting.
+
+#### Custom instructions + hook injection
+
+Users can add their own compact instructions via `customInstructions` (`:284-286`), appended as an `"Additional Instructions:"` section. The BASE template even ships example shapes (`:133-142`):
+
+```
+## Compact Instructions
+When summarizing the conversation focus on typescript code changes and also
+remember the mistakes you made and how you fixed them.
+```
+
+Pre-compact hooks can also inject instructions at runtime — `compact.ts:420-422` merges them: `mergeHookInstructions(customInstructions, hookResult.newCustomInstructions)`. So project-level `.claude/` hooks can shape summaries per-repo.
+
+#### Design takeaways from this one prompt
+
+1. **Explicit anti-drift engineering for user corrections.** Two sections plus the analysis instruction all target "user told you to do something differently." Compaction erases nuance; the prompt fights this at the schema level.
+2. **Verbatim quote requirement** for "what was I doing right before the break" — paraphrase drift is the failure mode, verbatim is the cheapest defense.
+3. **Measurable tool-call regression documented in code.** A `2.79% vs 0.01%` eval delta is quoted inline, justifying the aggressive preamble's existence. Treats the prompt like production code — with scars, commit reasoning, and rollback criteria.
+4. **`<analysis>` as drafted-then-discarded CoT.** Structured reasoning at generation time, zero cost at future cache reads. More sophisticated than "think step by step" prompting.
+5. **Transcript-path escape hatch.** The summary is lossy by nature; pointing to the raw transcript on disk means the model has a fallback path when summary omissions bite.
+
+The prompt is aggressively opinionated, shows its scar tissue in code comments, and treats summarization as an adversarial production task rather than decoration. Worth studying as its own artifact even if you're prompting for completely different domains.
+
+### 3.8 Session memory (async, background)
+
+Not a compaction mechanism — included for completeness because it overlaps with session memory compact.
+
+- Runs **asynchronously** in a post-sampling hook.
+- Extraction thresholds: `turnsSinceLastExtraction >= 3` AND `tokensSinceLastExtraction >= 50K`.
+- Updates `~/.claude/session-memory/*.md` incrementally.
+- Not wire-affecting; doesn't touch `messages[]`.
+- Pipes into session memory compact when that path fires.
+
+### 3.9 Post-compact cleanup
+
+`src/services/compact/postCompactCleanup.ts` — one-time cleanup called after either auto or manual compact succeeds. Clears many module-level caches:
+
+- `microcompactState`
+- context-collapse state
+- `memoryFiles` cache
+- `getUserContext` cache
+- system-prompt sections
+- classifier approvals
+- bash-permission speculative checks
+- beta tracing state
+- attribution hooks
+- session-messages cache
+
+**Notable preservation.** `sentSkillNames` is intentionally NOT cleared — re-injecting full skill listings after compact would be pure cache_creation with marginal benefit.
+
+**Subagent safety.** Skips main-thread resets when invoked from an agent subagent to avoid corrupting parent's module state.
+
+### 3.10 Compact warning hook/state
+
+- `compactWarningState.ts`: external Zustand-like store for a boolean flag.
+- `compactWarningHook.ts`: React hook reading it.
+- `suppressCompactWarning()` is called immediately after any compact so stale token counts (not yet updated by the next API response) don't flash a bogus "near limit" banner.
+
+UI-only. Doesn't affect compaction logic.
+
+### 3.11 `normalizeMessagesForAPI`
+
+`src/utils/messages.ts:1989-2337` — every API call runs `messages[]` through this before serialization. Does:
+
+- Filters `progress` messages, non-local-command `system` messages, synthetic API errors.
+- Merges consecutive user messages (Bedrock compat; 1P does this server-side but normalizing here is deterministic).
+- Strips `tool_reference` blocks from tool_result content when tool search disabled.
+- Strips tool search beta fields (`caller` from tool_use) unless beta active.
+- Merges `system`/`local_command` into adjacent user messages.
+- Injects `TOOL_REFERENCE_TURN_BOUNDARY` text sibling when `tool_reference` appears at message tail (prevents ~10% premature stop-sequence sampling on capybara model).
+- Relocates tool_reference siblings to prevent two-consecutive-human-turns anomaly (`tengu_toolref_defer_j8m`).
+- Filters orphaned thinking-only assistant messages, strips trailing thinking, removes whitespace-only messages.
+
+**Why it matters for compaction.** The per-message budget in `enforceToolResultBudget` must group tool_results the same way `normalizeMessagesForAPI` merges them — otherwise a parallel-tool burst could split into N under-budget groups pre-merge and become one over-budget message post-merge. `collectCandidatesByMessage` in `toolResultStorage.ts:600` has extensive comments explaining this invariant.
+
+### 3.12 Cache breakpoint placement
+
+`addCacheBreakpoints` in `claude.ts:3063-3159`. Places **exactly one** `cache_control` marker per request at message index `length - 1` (or `length - 2` if `skipCacheWrite=true` for fire-and-forget forks). Also handles cache_edits insertion/pinning as described under cached microcompact.
+
+**Single-marker design.** Reduces local-attention KV page eviction vs. multiple markers. The single-marker-at-tail policy paired with append-only growth is what makes the prompt-cache optimization tractable in the first place.
+
+### 3.13 Prompt cache break detection
+
+`src/services/api/promptCacheBreakDetection.ts` — observational, not a compaction mechanism. Two-phase:
+
+**Phase 1** (`recordPromptState`, pre-call): hashes system prompt, tool schemas, cache_control scope/TTL, betas, model, effort, extraBodyParams. Stores pending changes.
+
+**Phase 2** (`checkResponseForCacheBreak`, post-call): if `cacheReadTokens` drops > 5% AND exceeds 2K min, fires. Attributes break to pending changes: model flip, system prompt delta, tool add/remove/schema change, cache_control flip, beta addition, auto/overage/cachedMC toggle, effort change.
+
+**Suppressions:**
+- `cacheDeletionsPending=true` (cached microcompact expected a deletion).
+- TTL expiry > 1h (server-side, not our fault).
+- Haiku models (different caching characteristics).
+
+**Emits** `tengu_prompt_cache_break` analytics + diff file (ants with `--debug` only).
+
+### 3.14 Collapse / group (UI-only)
+
+Two mechanisms that affect *only* rendering, not wire:
+
+- **`collapseReadSearch.ts`**: consecutive Read/Grep/Glob/WebFetch/WebSearch calls collapse into `⎿ (⏱ + count badge)` summary line. Memory-file writes also collapsible; Snip/ToolSearch are "absorbed-silently" (no count bump).
+- **`groupToolUses.ts`**: multiple tool_uses of the same name from the same `message.id` (same API response) render as one collapsed block. Skipped in verbose mode.
+
+Neither mutates `messages[]` or wire. Important to call out since "collapsed" in the UI can look like compaction but isn't.
+
+### 3.15 `grouping.ts` (inside compact/)
+
+`groupMessagesByApiRound()` — partitions messages at assistant-message-id boundaries (one group per API round-trip). Used only by compaction/reactive-compact to decide which messages to truncate for PTL retry. The grouping data structure itself isn't sent to the API; it's an intermediate for message-selection logic.
+
+---
+
+## 4. Interaction Map
+
+```
+Tool produces result
+    │
+    ▼
+Per-tool size persistence (#1) ──→ content > 50K? → <persisted-output> with filepath
+    │                                    │
+    ▼                                    └─ on-disk artifact
+Per-message aggregate budget (#2) ──→ sum > 200K? → pick largest, persist
+    │
+    ▼
+messages[] (local transcript)
+    │
+    ▼
+[Between turns, on idle]
+    │
+    ├─ gap > 60min? ──→ Time-based microcompact (#3) mutates messages[] → "[cleared]"
+    │
+    ├─ count-trigger? ──→ Cached microcompact (#4) queues cache_edits (wire-only)
+    │
+    └─ tokens > threshold?
+           │
+           ├─ Session memory compact (#6) first
+           ├─   if returns null: Autocompact (#7) full rewrite
+           │
+           └─ postCompactCleanup (#3.9)
+    │
+    ▼
+normalizeMessagesForAPI (#11) ──→ filter/merge/strip
+    │
+    ▼
+addCacheBreakpoints (#12) ──→ inject cache_control + pinned cache_edits
+    │
+    ▼
++ context_management body param (API-native MC, #5)
+    │
+    ▼
+Wire payload
+    │
+    ▼
+    ┌─────────────────────────────────────────┐
+    │ Server: prefix cache match + apply      │
+    │         cache_edits + context_management│
+    │         → effective prompt              │
+    └─────────────────────────────────────────┘
+    │
+    ▼
+Model attention runs over effective prompt
+    │
+    ▼
+Response
+    │
+    ▼
+checkResponseForCacheBreak (#9) ──→ attribute any cache drop
+Session memory async extraction (#8)
+```
+
+---
+
+## 5. Benefits by Design Axis
+
+### 5.1 Why persist-with-reference instead of truncate?
+
+Truncation throws away information. Persistence preserves it at a stable, model-addressable path. The model can Read any portion on demand. This separates:
+
+- **Capture cost** (cheap: disk I/O when the tool runs)
+- **Consumption cost** (expensive: tokens when the model actually reads)
+
+Inline-everything conflates them, paying consumption cost whether or not the model would have chosen to consume.
+
+### 5.2 Why so many thresholds?
+
+Different failure modes need different handlers:
+
+| Failure mode | Mechanism |
+|---|---|
+| One huge tool result | #1 per-tool size persistence |
+| Many medium parallel tool results | #2 per-message aggregate budget |
+| Idle conversation resumed after cache expiry | #3 time-based microcompact |
+| Long active session filling context with old tool results | #4 cached microcompact (ideal) / #5 API-native (fallback) |
+| Genuinely full context, no tool results to shed | #6 session memory compact → #7 autocompact |
+
+Trying to handle all of these with one threshold produces pathological behavior at the edges (e.g., one 300K result triggering a full summarize; or 10K of accumulated small results surviving forever).
+
+### 5.3 Why prompt-cache-stability drives so much complexity
+
+Anthropic's prompt cache has a 1h TTL and is prefix-keyed. A cache hit on a 100K-token prefix is ~90% cheaper than re-processing. Over a long conversation, cache-stable mechanisms (#1, #2, #4, #5) can save 10–100× on input-token cost vs. naive per-turn full processing. The code's `seenIds`-based frozen-decisions, replacement Map byte-identical re-apply, pinned cache_edits, and circuit-breaker isolation all exist to preserve cacheability.
+
+Time-based microcompact (#3) and autocompact (#7) are the "give up on current cache" paths — used when cache is either already cold (gap > TTL) or the situation is too severe to salvage incrementally.
+
+### 5.4 Why some mechanisms don't change `messages[]`
+
+`messages[]` is the client-side source of truth for rendering, `/resume`, transcript writes, and resumable subagent state. Mechanisms that mutate it (#3, #6, #7) lose information the resumed session can't recover. Mechanisms that operate wire-only (#4, #5, #11, #12) can aggressively shrink what the model sees while preserving everything the user and future sessions can re-access.
+
+---
+
+## 5.5 What's actually enabled in an external build?
+
+Several mechanisms in the table are scaffolding that's dormant for non-ant users. Clear picture of what actually runs:
+
+| Mechanism | External build status |
+|---|---|
+| Per-tool size persistence (#1) | ✅ Active, always on |
+| Per-message aggregate budget (#2) | ⚠️ Requires `tengu_hawthorn_steeple=true` (default unknown, likely on for ants) |
+| Time-based microcompact (#3) | ❌ Default `enabled: false` in `tengu_slate_heron` |
+| Cached microcompact (#4) | ❌ Stub only — `CACHED_MICROCOMPACT` compile-time feature flag is off; entire module DCE'd |
+| API-native `clear_thinking` (#5a) | ✅ Available to everyone when thinking is active |
+| API-native `clear_tool_uses` (#5b) | ❌ `USER_TYPE === 'ant'` + env vars required |
+| Session memory compact (#6) | ❌ Requires BOTH `tengu_session_memory` AND `tengu_sm_compact` (both default false) |
+| Autocompact (legacy #7) | ✅ Active, triggers at context-window − 13K |
+| Session memory extraction (#8) | ❌ Requires `tengu_session_memory` (default false) |
+| Prompt cache break detection (#9) | ✅ Active via `PROMPT_CACHE_BREAK_DETECTION` compile flag |
+| `normalizeMessagesForAPI` (#11) | ✅ Every API call |
+| Cache breakpoint placement (#12) | ✅ Every API call |
+
+**Net effect for an external user:** the observable compaction stack is basically (#1 per-tool size persistence) + (#2 per-message budget, conditionally) + (#7 legacy autocompact at 13K-below-window). The sophisticated cache-preserving paths (#4 cached-MC, #5b aggressive API-native, #6 SM-compact) are all ant-internal rollouts.
+
+## 6. The Core Insight (from the user's question)
+
+> "Wire ≠ model context."
+
+The cleanest conceptual takeaway: the Anthropic API lets clients send a "full" prompt while using directives (cache_edits, context_management) to instruct the server to evaluate a *different* prompt. This means:
+
+- Prompt cache prefixes can stay byte-identical (cache hits preserved).
+- The model's attention spans a smaller window (context budget preserved).
+- The client's `messages[]` can stay complete (resume/transcript preserved).
+
+All three constraints satisfied simultaneously. This is the core design principle that `cc-haha`'s multi-layered compaction stack is optimizing around.
+
+---
+
+## 7. Key Constants Reference
+
+| Constant | Value | Location |
+|---|---|---|
+| `DEFAULT_MAX_RESULT_SIZE_CHARS` | 50,000 | `src/constants/toolLimits.ts:13` |
+| `MAX_TOOL_RESULT_BYTES` | 400,000 (100K tokens × 4 bytes) | `src/constants/toolLimits.ts:33` |
+| `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS` | 200,000 | `src/constants/toolLimits.ts:49` |
+| `PREVIEW_SIZE_BYTES` | 2,000 | `src/utils/toolResultStorage.ts:109` |
+| `TIME_BASED_MC_CLEARED_MESSAGE` | `"[Old tool result content cleared]"` | `src/services/compact/microCompact.ts:36` |
+| Time-based MC default gap | 60 min | `src/services/compact/timeBasedMCConfig.ts:32` |
+| Time-based MC default `keepRecent` | 5 | `src/services/compact/timeBasedMCConfig.ts:33` |
+| Autocompact threshold | context window − 13K | `src/services/compact/autoCompact.ts:62` |
+| Autocompact circuit-breaker | 3 consecutive failures | `src/services/compact/autoCompact.ts:60` |
+| API_MAX_INPUT_TOKENS (native MC) | 180K | `src/services/compact/apiMicrocompact.ts` |
+| API_TARGET_INPUT_TOKENS (native MC) | 40K | `src/services/compact/apiMicrocompact.ts` |
+| Session-memory async thresholds | 3 turns + 50K tokens since last | `src/services/SessionMemory/` |
+| Cache-break detection min drop | 5% AND > 2K tokens | `src/services/api/promptCacheBreakDetection.ts` |
+
+---
+
+## 8. Feature Flags (GrowthBook)
+
+| Flag | Controls |
+|---|---|
+| `tengu_satin_quoll` | Per-tool persistence threshold overrides |
+| `tengu_hawthorn_steeple` | Per-message aggregate budget enable |
+| `tengu_hawthorn_window` | Per-message budget size override |
+| `tengu_slate_heron` | Time-based microcompact config |
+| `tengu_cache_plum_violet` | Legacy microcompact (always true now; legacy path removed) |
+| `tengu_session_memory` | Session memory feature |
+| `tengu_sm_config` | Session memory update thresholds |
+| `tengu_sm_compact_config` | Session memory compact thresholds |
+| `tengu_compact_cache_prefix` | Autocompact summarizer prompt cache sharing |
+| `PROMPT_CACHE_BREAK_DETECTION` | Break-detection emit |
+
+Compile-time flags (`bun:bundle`):
+
+| Flag | Controls |
+|---|---|
+| `CACHED_MICROCOMPACT` | Cached-microcompact module linking (ant-only) |

--- a/docs/references/opencode-compaction-report.md
+++ b/docs/references/opencode-compaction-report.md
@@ -1,0 +1,747 @@
+# opencode context-management / compaction investigation
+
+> Scope: the `sst/opencode` coding agent. The working tree is the
+> `anomalyco/opencode` fork, which tracks `sst/opencode` upstream — the
+> core files referenced below (session/compaction.ts, session/prompt.ts,
+> session/message-v2.ts, tool/truncate.ts, provider/transform.ts) are
+> the upstream files, shown at commit `d2181e927` on branch `dev`.
+
+---
+
+## 1. Intro
+
+opencode is a TypeScript monorepo (Bun workspace). The CLI/agent runtime
+lives in `packages/opencode/`. It is **multi-provider** — model access
+goes through Vercel AI SDK (`ai`) with per-provider `@ai-sdk/*` packages
+(Anthropic, OpenAI, Bedrock, Google, Vertex, OpenRouter, Gateway, Azure,
+GitHub Copilot, DashScope, etc.), plus a custom GitLab workflow model.
+
+The chat loop is `SessionPrompt.runLoop` in
+`packages/opencode/src/session/prompt.ts:1305`. Each iteration rebuilds
+the full local transcript from the database, runs any pending
+compaction/subtask task, and otherwise invokes the model stream via
+`LLM.run` at `packages/opencode/src/session/llm.ts:72`. Messages are
+serialised to the wire-level `ModelMessage[]` by
+`MessageV2.toModelMessagesEffect` in
+`packages/opencode/src/session/message-v2.ts:587`, after which
+`ProviderTransform.message` (`packages/opencode/src/provider/transform.ts:305`)
+applies per-provider fixups (including Anthropic prompt-cache markers).
+
+Context management is concentrated in three files under
+`packages/opencode/src/session/`:
+
+- `overflow.ts` — budget math (`usable`, `isOverflow`).
+- `compaction.ts` — tail-selection, full-conversation summarisation, and
+  tool-output pruning.
+- `message-v2.ts` — `filterCompacted` projection that the chat loop uses
+  to hide pre-compaction history, and `toModelMessagesEffect` which
+  applies the `[Old tool result content cleared]` substitution.
+
+Per-tool-result size handling lives in `tool/truncate.ts` and is
+wrapped around every tool by `tool/tool.ts` and `tool/registry.ts`.
+
+---
+
+## 2. Master summary table
+
+| Mechanism | Trigger | Local state | Wire payload | Model-visible context | Cache-stable | Key files |
+|---|---|---|---|---|---|---|
+| Per-tool-result truncation | Every tool returns > 2000 lines or > 50 KiB | Full output written to `$XDG_DATA/opencode/tool-output/<id>`; stored `output` is preview+hint | Same preview+hint goes over wire | Sees preview + path hint | n/a (happens once, then stable) | tool/truncate.ts:15-16, 71-126; tool/tool.ts:98-112 |
+| Bash streaming cap | Bash output exceeds 50 KiB during streaming | File sink opens; tail kept for final output | Final output = streamed tail + truncation hint | Same as wire | n/a | tool/bash.ts:411-569 |
+| Read tool cap | `read` of > 50 KiB or > 2000 lines | Output capped with "Use offset=N to continue" hint | Capped content sent | Capped content visible | n/a | tool/read.ts:15-19, 236-256, 309-319 |
+| Grep cap | > 100 matches | `truncated: true` in metadata, suffix added | Truncated list sent | Truncated list visible | n/a | tool/grep.ts:11, 102-127 |
+| Webfetch cap | Response > 5 MiB | Request rejected | — | — | n/a | tool/webfetch.ts:9, 95-100 |
+| Auto-compaction (overflow after turn) | After a step finish, `isOverflow({tokens, model})` true | Inserts a synthetic user message with a `compaction` part; next loop tick runs `compaction.process` | History up to `tail_start_id` replaced by assistant summary | Sees summary + preserved tail + optional auto-continue user message | **No** — rewrites prefix | session/compaction.ts:221-457; session/prompt.ts:1384-1391; session/processor.ts:397-402 |
+| Auto-compaction (overflow mid-stream) | Stream errors with `ContextOverflowError` | `needsCompaction = true`; loop returns `"compact"` | Same as above, plus `stripMedia: true` via overflow flag | Media files replaced with `[Attached <mime>: <name>]` text | **No** | session/processor.ts:526-530; session/prompt.ts:1514-1522; session/compaction.ts:242-258, 302-304, 429-432 |
+| Manual `/compact` | User invokes slash command | Same as above but `auto: false` | Same | Same | **No** | server/routes/instance/session.ts:536-599; cli/cmd/tui/routes/session/index.tsx:477-502 |
+| Tool-output pruning (microcompaction) | End of every chat loop (`runLoop` post-loop hook) | Older tool parts past a 40k-token tail get `state.time.compacted` set | `toModelMessagesEffect` replaces their `output` with `"[Old tool result content cleared]"`, drops attachments | Sees placeholder string | **No** — mutates prefix | session/compaction.ts:171-219; session/prompt.ts:1530; session/message-v2.ts:729-730 |
+| `filterCompacted` projection | Every loop iteration when building `msgs` | Hides messages older than the last compaction's `tail_start_id`; fully drops history before a completed compaction with no tail | Wire payload built from filtered set only | Sees only retained window | n/a (idempotent projection) | session/message-v2.ts:931-960; session/prompt.ts:1317 |
+| Message merging / dedup | Pre-send, Anthropic-family | Empty text/reasoning parts removed; `tool_use, tool_use, text` split into `[text], [tool_use…]` | Reshaped ModelMessage[] | Same | depends — mutates prefix only for malformed shapes | provider/transform.ts:48-176 |
+| Prompt-cache breakpoints | Pre-send, Anthropic/Bedrock/OpenRouter/OpenAI-compat/Copilot/Alibaba | Adds `cacheControl: {type: "ephemeral"}` on first 2 system + last 2 non-system messages | Same | Same | **Yes** — this is the cache mechanism | provider/transform.ts:216-265, 305-320 |
+| Per-provider `promptCacheKey`/`setCacheKey` | OpenAI / Azure / OpenRouter / Venice / opencode-hosted GPT-5 | Adds provider option `promptCacheKey = sessionID` | Same | Same | **Yes** | provider/transform.ts:814-847, 912-925 |
+| Gateway caching | AI SDK Gateway | Adds `providerOptions.gateway.caching = "auto"` | Same | Same | **Yes** (gateway decides) | provider/transform.ts:926-930 |
+| Agent-step cap | `step >= agent.steps` | Appends an assistant message with `max-steps.txt` instructing the model to stop using tools | Wire payload gets extra assistant turn | Model sees cap instruction | n/a | session/prompt.ts:1401-1402, 1489; session/prompt/max-steps.txt |
+| Doom-loop guard | Same tool+input 3 times in a row | Asks the user for `doom_loop` permission | Not a context change — a halt | n/a | n/a | session/processor.ts:24, 287-331 |
+| Plugin `experimental.chat.messages.transform` | Every LLM turn + every compaction | Arbitrary plugin mutation of `msgs` | Whatever plugins do | Whatever plugins do | plugin-dependent | session/prompt.ts:1471; session/compaction.ts:303 |
+
+---
+
+## 3. Per-mechanism detail
+
+### 3.1 Per-tool-result truncation — `Truncate.output`
+
+`packages/opencode/src/tool/truncate.ts:15-16`:
+
+```
+export const MAX_LINES = 2000
+export const MAX_BYTES = 50 * 1024
+```
+
+`Truncate.output(text, opts, agent)` at `truncate.ts:71-126`:
+
+1. If `lines.length ≤ MAX_LINES && byteLength ≤ MAX_BYTES`, return
+   unchanged (`truncated: false`).
+2. Otherwise write the full text to
+   `$XDG_DATA/opencode/tool-output/<ToolID>` (path constant
+   `TRUNCATION_DIR = Global.Path.data + /tool-output`;
+   `tool/truncation-dir.ts:4`, `global/index.ts:10`).
+3. Return a preview (head or tail, first `MAX_LINES`/`MAX_BYTES`), a
+   `…N lines truncated…` marker, and a hint telling the model either to
+   use the Task/explore agent (if allowed) or Grep/Read-with-offset.
+4. Truncated files older than 7 days are swept by `Truncate.cleanup`
+   on a 1-hour schedule (`truncate.ts:13, 50-62, 128-135`).
+
+This wrapper is applied universally:
+
+- Native tools — `Tool.define` wraps `execute` and calls
+  `truncate.output(result.output)` post-hoc unless the tool already set
+  its own `metadata.truncated` (tool/tool.ts:98-112). `read`, `grep`,
+  `webfetch`, and `bash` set their own truncation so `tool.ts` leaves
+  them alone.
+- File-based user-defined tools — `tool/registry.ts:139` runs
+  `truncate.output` on the returned string.
+- Plugin-defined MCP tools — `session/prompt.ts:494` runs
+  `truncate.output` on joined text parts before the result becomes a
+  MessageV2 tool-output.
+
+Note: **this truncation is per tool call, not per turn.** N parallel
+tool calls can each return up to 50 KiB of preview + path hints.
+
+### 3.2 Tool-specific caps
+
+- **Bash** (`tool/bash.ts:411-569`) streams output into a ring buffer
+  keeping `Truncate.MAX_BYTES * 2 = 100 KiB`. As soon as streamed bytes
+  exceed `MAX_BYTES`, the tool opens a file sink and continues writing
+  the full output there; the in-memory return is kept to the tail of
+  `MAX_LINES`/`MAX_BYTES`. Final payload is `...output truncated...
+  Full output saved to: <file>` followed by the tail. Default timeout
+  also caps output implicitly.
+- **Read** (`tool/read.ts:15-19, 236-256`) caps file reads at
+  `DEFAULT_READ_LIMIT = 2000` lines and `MAX_BYTES = 50 * 1024`; each
+  line also capped at `MAX_LINE_LENGTH = 2000` chars with a
+  `... (line truncated to 2000 chars)` suffix. The tool emits an
+  `offset=N` hint so the model can page.
+- **Grep** (`tool/grep.ts:11, 102-127`) `MAX_LINE_LENGTH = 2000` for
+  per-match excerpts; results hard-capped at `limit = 100` with a
+  `showing 100 of N matches` suffix.
+- **Webfetch** (`tool/webfetch.ts:9, 95-100`)
+  `MAX_RESPONSE_SIZE = 5 * 1024 * 1024`; requests over that are
+  rejected outright with an error.
+
+### 3.3 Context budget math — `overflow.ts`
+
+`packages/opencode/src/session/overflow.ts:6-26`:
+
+```
+const COMPACTION_BUFFER = 20_000
+
+usable(cfg, model):
+  if model.limit.context === 0: 0
+  reserved = cfg.compaction?.reserved
+           ?? min(20_000, maxOutputTokens(model))
+  return model.limit.input
+    ? max(0, model.limit.input - reserved)
+    : max(0, model.limit.context - maxOutputTokens(model))
+
+isOverflow(cfg, tokens, model):
+  if cfg.compaction?.auto === false: false
+  if model.limit.context === 0: false
+  count = tokens.total
+        || input + output + cache.read + cache.write
+  return count >= usable(cfg, model)
+```
+
+`maxOutputTokens` (`provider/transform.ts:1017-1019`) =
+`min(model.limit.output, OUTPUT_TOKEN_MAX)` where
+`OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX ||
+32_000` (`transform.ts:20`).
+
+`isOverflow` consumes **real provider token counts** — they come from
+`finish-step` via `Session.getUsage` (`session/session.ts:262-325`),
+which reads `usage.inputTokens`, `usage.outputTokens`,
+`usage.inputTokenDetails.cacheReadTokens`,
+`inputTokenDetails.cacheWriteTokens` (with per-provider fallbacks for
+anthropic/vertex/bedrock/venice). No local tokenisation — opencode
+uses a cheap `chars / 4` estimator only for internal bookkeeping in
+`compaction.ts` (see 3.6).
+
+### 3.4 Auto-compaction — post-turn path
+
+After each `finish-step` event (`session/processor.ts:357-403`) the
+processor checks overflow and, if positive and the current assistant
+message isn't itself a summary, sets
+`ctx.needsCompaction = true` so the stream is drained via
+`Stream.takeUntil` and `runLoop` returns to the top.
+
+`runLoop` then detects no pending compaction task and re-evaluates at
+`session/prompt.ts:1384-1391`:
+
+```ts
+if (lastFinished && lastFinished.summary !== true &&
+    (yield* compaction.isOverflow({ tokens, model }))) {
+  yield* compaction.create({ sessionID, agent, model, auto: true })
+  continue
+}
+```
+
+`compaction.create` (`session/compaction.ts:459-482`) writes a fresh
+**user message** with a single `CompactionPart`
+(`auto: true, overflow?: true`). Next loop iteration picks this up at
+`session/prompt.ts:1372` and hands off to `compaction.process`.
+
+### 3.5 Auto-compaction — overflow mid-stream
+
+If the provider rejects the request mid-stream with a context-overflow
+error, `MessageV2.fromError` maps it to `ContextOverflowError`
+(`session/message-v2.ts:1012-1025, 1044-1052`). `SessionProcessor.halt`
+detects this and sets `ctx.needsCompaction = true`
+(`session/processor.ts:526-530`), returning `"compact"`. The loop then
+calls `compaction.create({ …, auto: true, overflow:
+!handle.message.finish })` (`session/prompt.ts:1515-1522`).
+
+`overflow: true` changes behaviour in `compaction.process`
+(`session/compaction.ts:242-258`):
+
+- The most recent user message (the one that caused overflow) is
+  **removed** from the compaction input and held aside as `replay`.
+- Media attachments on the replay message are converted to
+  `[Attached <mime>: <file>]` text when re-injected
+  (`compaction.ts:386-398`).
+- The compaction summarisation itself runs with `stripMedia: true`
+  (`compaction.ts:304`, reading `message-v2.ts:665-680, 729-738`).
+- Auto-continue prepends a synthetic user note explaining media was
+  dropped (`compaction.ts:429-433`).
+
+If even stripping media isn't enough to fit, the compaction assistant
+message is marked as an error (`compaction.ts:354-363`).
+
+### 3.6 Tail selection — `select`
+
+`compaction.ts:130-169`:
+
+- `limit = cfg.compaction?.tail_turns ?? DEFAULT_TAIL_TURNS = 2`.
+- `budget = cfg.compaction?.preserve_recent_tokens ??
+  clamp(floor(usable(model) * 0.25), 2_000, 8_000)` —
+  constants `MIN_PRESERVE_RECENT_TOKENS = 2_000`,
+  `MAX_PRESERVE_RECENT_TOKENS = 8_000`
+  (`compaction.ts:37-38, 45-50`).
+- Turns are defined as "every user message that isn't a compaction
+  marker"; `turns()` groups messages by these anchors
+  (`compaction.ts:52-68`).
+- Going backwards through the last `limit` turns it accumulates
+  turn sizes (using `Token.estimate(JSON.stringify(model-messages))` —
+  the chars/4 heuristic, `compaction.ts:122-128, util/token.ts:3-5`)
+  until it would exceed `budget`.
+- If the last turn alone is larger than `budget`, it gives up
+  ("tail fallback") and summarises the whole history — no tail kept
+  (`compaction.ts:150-153`).
+- Otherwise it returns `head = messages[0 .. keep.start]` for
+  summarisation and `tail_start_id = keep.id` for the retained tail.
+
+### 3.7 Compaction prompt
+
+`compaction.ts:277-301` — default prompt is a templated Goal /
+Instructions / Discoveries / Accomplished / Relevant files report,
+joined with any plugin-provided `context`. A plugin can replace the
+prompt entirely via the `experimental.session.compacting` hook
+(`compaction.ts:272-276`). The "compaction" agent itself has its own
+system prompt in `agent/prompt/compaction.txt` and permissions set
+to `"*": "deny"` (`agent/agent.ts:188-202`), so it can't call tools.
+
+### 3.8 Auto-continue after compaction
+
+If `process` returns `"continue"` **and** `auto` was true,
+`compaction.ts:372-452` either:
+
+- replays the overflow message as a fresh user message with media
+  stripped (`compaction.ts:372-399`), or
+- adds a synthetic user prompt via the
+  `experimental.compaction.autocontinue` plugin hook
+  (`compaction.ts:401-451`). Default text: `"Continue if you have
+  next steps, or stop and ask for clarification if you are unsure
+  how to proceed."` The synthetic part carries
+  `metadata.compaction_continue: true`, which github-copilot uses to
+  mark the next request as agent-initiated
+  (`plugin/github-copilot/copilot.ts:365-376`).
+
+### 3.9 `filterCompacted` — the local projection
+
+Every chat loop tick starts with
+`msgs = yield* MessageV2.filterCompactedEffect(sessionID)`
+(`session/prompt.ts:1317`).
+
+Definition at `session/message-v2.ts:931-960`:
+
+- Walks messages newest → oldest (using `stream` which pages 50 at a
+  time — `message-v2.ts:887-899`).
+- Collects messages until it hits a **completed compaction** (a user
+  message that has a `compaction` part and for which the paired
+  assistant message is marked `summary: true, finish, !error`).
+- If the completed compaction has a `tail_start_id`, it continues
+  walking back until that ID (so recent turns still survive).
+- If it has no `tail_start_id`, it stops there — all older history is
+  hidden from the next wire payload.
+
+Net effect: a successful compaction permanently replaces the pre-tail
+history from the model's point of view, but all data is still in the
+database (inspectable via `filterCompacted = false` paths), and can be
+reverted with `SessionRevert` (`packages/opencode/src/session/revert.ts`).
+
+### 3.10 `prune` — tool-output microcompaction
+
+**When it runs, in plain terms:** after the LLM finishes responding to
+a user request (final answer delivered, no more tool calls pending).
+Nothing to do with closing the session — it fires once per user turn
+after the agent loop exits. Specifically, `compaction.ts:173-219`,
+called at the bottom of `runLoop` after the outer `while` has broken,
+via `yield* compaction.prune({ sessionID }).pipe(Effect.ignore,
+Effect.forkIn(scope))` (`session/prompt.ts:1530`). `Effect.forkIn`
+means it runs in the background — the user gets their response
+immediately and prune processes old tool outputs asynchronously.
+Effects land on the *next* user message (or possibly a later one,
+depending on scheduling).
+
+Timeline:
+
+1. User sends a message.
+2. Model streams, calls tools, may loop several times.
+3. Model finishes, final text delivered to the user.
+4. **Prune runs here, in the background.**
+5. The placeholder substitution takes effect on the next request.
+
+Gated by `cfg.compaction?.prune !== false` (default enabled).
+
+Algorithm:
+
+- Walks messages oldest → newest *is wrong* — it walks newest → oldest
+  (`for msgIndex = msgs.length - 1; msgIndex >= 0; …`).
+- Skips the two most recent user turns (`if (turns < 2) continue`).
+- For each completed `tool` part not in `PRUNE_PROTECTED_TOOLS =
+  ["skill"]` (`compaction.ts:35`):
+  - Stops if the part was already pruned (`time.compacted` set).
+  - Adds `Token.estimate(part.state.output)` to a running total.
+  - Once the running total exceeds `PRUNE_PROTECT = 40_000`
+    (`compaction.ts:34`), older parts are queued for pruning.
+- If total queued > `PRUNE_MINIMUM = 20_000` (`compaction.ts:33`),
+  every queued part has `state.time.compacted = Date.now()` set and
+  is persisted.
+- A pruned part's `output` string is not rewritten in the DB. The
+  substitution happens at serialisation time:
+  `toModelMessagesEffect` checks `part.state.time.compacted` and emits
+  `"[Old tool result content cleared]"` with empty attachments
+  (`message-v2.ts:729-730`).
+
+So prune is "protect the last ~40 k tokens of tool outputs, and if
+there's more than ~20 k tokens older than that, mark it for
+replacement." It runs **once per user request, as a forked async job**,
+and only ever marks things — never un-marks.
+
+### 3.11 UI-only collapsing vs wire-affecting
+
+The TUI's `routes/session/index.tsx:1249, 1314, 1880` renders
+CompactionPart headers and collapses compacted tool outputs visually
+(`part.state.time.compacted` -> hide). The same flag drives the
+wire-level substitution in `toModelMessagesEffect`
+(`message-v2.ts:729-730`), so here the UI and the wire are in sync.
+
+There is no TUI-only "collapse repeated tool calls" that leaves the
+wire unchanged — display and payload both see the same filtered
+message set.
+
+### 3.12 Prompt-cache breakpoint placement
+
+`provider/transform.ts:216-265, 305-320`. Invoked only for models
+matched as Anthropic-family (provider is anthropic/google-vertex-
+anthropic, `api.id`/`id` contains `claude`/`anthropic`, or
+`api.npm === @ai-sdk/anthropic` / `@ai-sdk/alibaba`) **and** not
+using `@ai-sdk/gateway`.
+
+`applyCaching`:
+
+- Picks first 2 system messages and last 2 non-system messages
+  (`transform.ts:217-218`). Note: this gives up to 4 distinct
+  breakpoints — Anthropic's public limit. Bedrock gets
+  `cachePoint: {type: "default"}`; others get
+  `cacheControl: {type: "ephemeral"}`.
+- For `@ai-sdk/anthropic` / `@ai-sdk/amazon-bedrock` the cache marker
+  is set at the **message** level; for everything else it's set at
+  the **last content part** of the message
+  (`transform.ts:241-262`).
+- TTL: always `type: "ephemeral"` (5 min on Anthropic). **Long
+  (1h) cache is not used** — `"1h"`, `extended_cache`, `cache_1h`
+  don't appear anywhere in the repo.
+
+`setCacheKey` / `promptCacheKey` (`transform.ts:814-847, 912-925`) is
+a separate mechanism for providers whose cache is keyed by an opaque
+string; opencode uses `sessionID` as the key so the same prompt
+coming from the same session hashes the same.
+
+**Compaction invalidates this prefix.** Compaction rewrites the head
+of the history, which changes the hash up through the new cache
+breakpoints. `prune` similarly changes `output` strings that sit
+before the last-two breakpoints, so it also invalidates.
+
+### 3.13 Cache-preserving shrinks (none)
+
+Grepped the entire repo for Anthropic's server-side context-management
+controls:
+
+```
+$ grep -r 'cache_edits\|context_management\|cacheEdits\|contextManagement' packages/
+(no matches)
+```
+
+opencode does not use Anthropic's `cache_edits` beta, the
+`context_management` body param, or OpenAI's equivalents. All context
+shrinking is done **client-side**, with the consequence that any
+shrink invalidates the prompt-cache prefix. This is a notable
+difference vs Claude Code.
+
+### 3.14 Pre-wire transformations
+
+`ProviderTransform.message` (`provider/transform.ts:305-349`) runs
+inside the `wrapLanguageModel` middleware hook
+(`session/llm.ts:387-400`). It's the last step before the SDK serialises
+to HTTP. It:
+
+- Rewrites empty text / reasoning parts out of Anthropic/Bedrock
+  requests (`transform.ts:55-73`).
+- Scrubs tool-call IDs for Claude (`transform.ts:75-102`, regex
+  `[^a-zA-Z0-9_-]` -> `_`) and Mistral/Devstral (`transform.ts:128-176`,
+  first 9 alphanumerics).
+- For Anthropic, splits malformed assistant turns of shape
+  `[tool_use, …, text]` into `[text]` + `[tool_use, …]`
+  (`transform.ts:103-127`).
+- For Mistral, when a tool message is followed by a user message,
+  injects a synthetic `assistant: "Done."` turn to satisfy
+  Mistral's ordering rules (`transform.ts:162-173`).
+- Filters unsupported modalities on models without that modality
+  capability, replacing them with a plain-text error note
+  (`transform.ts:267-303`).
+- For models with an `interleaved.field` capability, extracts
+  `reasoning` parts and moves them into
+  `providerOptions.openaiCompatible[field]`
+  (`transform.ts:178-210`).
+
+None of these are "context compaction" — they're payload shape fixups.
+They do not change logical context length.
+
+### 3.15 Plugin hooks that can rewrite context
+
+Two hooks run on every chat turn:
+
+- `experimental.chat.messages.transform` — arbitrary mutation of the
+  `msgs: MessageV2.WithParts[]` array before `toModelMessagesEffect`.
+  Called for normal turns (`session/prompt.ts:1471`) **and inside
+  compaction** (`session/compaction.ts:303`). Any plugin wiring this
+  can compact / rewrite context. No plugin in the repo currently
+  implements it.
+- `experimental.chat.system.transform` — arbitrary mutation of the
+  `system: string[]` array. `session/llm.ts:114-124` also contains a
+  tidy-up after this hook: if `system.length > 2` and the first
+  entry (the base system prompt) is unchanged, everything from the
+  second onward is rejoined into a single string so the 2-part
+  layout expected by `applyCaching` is preserved.
+
+### 3.16 `finish-step` snapshot / diff summaries (unrelated to context)
+
+`session/summary.ts` is a **file-diff** summariser, not a
+conversation summariser. It walks snapshot boundaries in
+`step-start`/`step-finish` parts and computes added/deleted/files
+counts per session and per user turn (`summary.ts:82-129`). It does
+not modify the message history; it only populates
+`session.summary.{additions, deletions, files, diffs}` for display in
+the TUI. Easy to confuse with compaction — it's not compaction.
+
+---
+
+## 4. Interaction map — what happens when the context pressure rises
+
+In one tick of `runLoop` (`session/prompt.ts:1305`):
+
+1. **Build the visible set.**
+   `MessageV2.filterCompactedEffect(sessionID)` projects the DB into
+   the window after the latest completed compaction
+   (`message-v2.ts:931-960`). Pre-compaction history is dropped here.
+2. **Pending compaction task?** If `tasks.pop()` yields a
+   `CompactionPart`, jump to `compaction.process` and return.
+3. **Post-turn overflow check.** If the last assistant reply was a
+   real turn (`lastFinished`, not a summary) and
+   `compaction.isOverflow({ tokens, model })` is true
+   (`session/prompt.ts:1384-1391`):
+   - `compaction.create({ auto: true })` appends a new user message
+     with a CompactionPart and **continues** (back to step 1).
+4. **Serialise for the model.**
+   `toModelMessagesEffect(msgs, model)` converts to `ModelMessage[]`,
+   substituting `[Old tool result content cleared]` for any tool
+   parts already marked `state.time.compacted` by prior pruning
+   (`message-v2.ts:649-840`).
+5. **Provider-specific pre-wire fixup.**
+   `ProviderTransform.message` inside the AI SDK middleware
+   (`llm.ts:387-400`). If Anthropic-family, `applyCaching` adds
+   `cacheControl: {type:"ephemeral"}` to 1st two system + last two
+   non-system messages (`transform.ts:216-265`).
+6. **Stream the call.** If the provider rejects with a context-limit
+   error, `fromError` returns `ContextOverflowError`; the processor
+   flips `needsCompaction = true` and the step returns `"compact"`.
+   The loop then `compaction.create({ auto: true, overflow: true })`
+   (`session/prompt.ts:1515-1522`) and continues.
+7. **Compaction run.** Next loop tick hits step 2.
+   `compaction.process` (`compaction.ts:221-457`):
+   1. Optionally pulls the overflow-causing user message aside as
+      `replay` and trims the compaction input
+      (`compaction.ts:242-258`).
+   2. `select` computes `(head, tail_start_id)` using `tail_turns`
+      and a 25%-of-usable (clamped [2k, 8k] tokens) recent budget.
+      If the last turn alone exceeds the budget, falls back to
+      summarising the whole history.
+   3. Runs plugin hooks
+      `experimental.session.compacting` +
+      `experimental.chat.messages.transform`.
+   4. Calls the compaction agent with
+      `toModelMessagesEffect(msgs, model, { stripMedia: true })` on
+      the head — media attachments become
+      `"[Attached <mime>: <file>]"`.
+   5. On success publishes the summary assistant message, updates the
+      CompactionPart's `tail_start_id` if `select` refined it, and if
+      `auto`:
+      - replays the trimmed user message verbatim (stripped media),
+        or
+      - asks `experimental.compaction.autocontinue` and, if
+        `enabled: true` (default), appends a synthetic continue
+        prompt with `metadata.compaction_continue: true`.
+   6. On failure, marks the assistant with a `ContextOverflowError`
+      and the loop breaks.
+8. **Post-loop prune.** After the outer loop exits,
+   `compaction.prune({ sessionID })` is forked
+   (`session/prompt.ts:1530`). It marks old tool outputs past the
+   last 40 k tokens as `time.compacted`, but only if total pruned
+   exceeds 20 k tokens. This does not interact with step 4 of the
+   current request (it ran after the user-visible output is done),
+   but it will take effect on the **next** request.
+
+Fallback order, then:
+
+- **Always running:** per-tool truncation (50 KiB / 2000 lines) +
+  per-tool internal caps.
+- **First line of context-pressure defense:** `filterCompacted` after
+  any earlier compaction.
+- **Second line:** auto-compaction triggered by token usage crossing
+  `usable(cfg, model)`.
+- **Third line:** auto-compaction triggered by the provider returning
+  a context-overflow error (media-stripping mode).
+- **Background maintenance:** `prune` after each user request.
+- **Not present:** idle/time-based compaction, cache_edits / server-
+  side context_management, per-turn aggregate output cap.
+
+---
+
+## 5. Constants reference
+
+| Constant | Value | Source | Used for |
+|---|---|---|---|
+| `MAX_LINES` | `2000` | tool/truncate.ts:15 | per-tool truncation line cap |
+| `MAX_BYTES` | `50 * 1024` (50 KiB) | tool/truncate.ts:16 | per-tool truncation byte cap |
+| `RETENTION` | `7 days` | tool/truncate.ts:13 | tool-output file retention |
+| `DEFAULT_READ_LIMIT` | `2000` | tool/read.ts:15 | Read tool default lines |
+| `MAX_LINE_LENGTH` (read) | `2000` | tool/read.ts:16 | Per-line cap in Read |
+| `MAX_BYTES` (read) | `50 * 1024` | tool/read.ts:18 | Read tool byte cap |
+| `MAX_LINE_LENGTH` (grep) | `2000` | tool/grep.ts:11 | Per-match excerpt cap |
+| Grep `limit` | `100` | tool/grep.ts:102 | Grep match count cap |
+| `MAX_RESPONSE_SIZE` (webfetch) | `5 * 1024 * 1024` (5 MiB) | tool/webfetch.ts:9 | Webfetch body cap |
+| `DEFAULT_TIMEOUT` (webfetch) | `30 * 1000` ms | tool/webfetch.ts:10 | |
+| `MAX_TIMEOUT` (webfetch) | `120 * 1000` ms | tool/webfetch.ts:11 | |
+| Bash `keep` ring buffer | `Truncate.MAX_BYTES * 2` = 100 KiB | tool/bash.ts:423-425 | bash streaming cap |
+| `COMPACTION_BUFFER` | `20_000` tokens | session/overflow.ts:6 | Default `reserved` cap value |
+| `PRUNE_MINIMUM` | `20_000` tokens | session/compaction.ts:33 | Min tokens of prune-able output to trigger prune |
+| `PRUNE_PROTECT` | `40_000` tokens | session/compaction.ts:34 | Recent tool-output tokens exempt from prune |
+| `PRUNE_PROTECTED_TOOLS` | `["skill"]` | session/compaction.ts:35 | Never-pruned tools |
+| `DEFAULT_TAIL_TURNS` | `2` | session/compaction.ts:36 | Default `tail_turns` |
+| `MIN_PRESERVE_RECENT_TOKENS` | `2_000` | session/compaction.ts:37 | Floor of auto `preserve_recent_tokens` |
+| `MAX_PRESERVE_RECENT_TOKENS` | `8_000` | session/compaction.ts:38 | Ceiling of auto `preserve_recent_tokens` |
+| Auto `preserve_recent_tokens` formula | `clamp(floor(usable * 0.25), 2k, 8k)` | session/compaction.ts:45-50 | Budget for retained tail |
+| `OUTPUT_TOKEN_MAX` | `32_000` (override via env) | provider/transform.ts:20 | Cap on requested `maxOutputTokens` |
+| `DOOM_LOOP_THRESHOLD` | `3` | session/processor.ts:24 | Identical tool-call repeats before asking |
+| `CHARS_PER_TOKEN` | `4` | util/token.ts:1 | Local token estimator |
+| Token-estimator output | `round(length / 4)` | util/token.ts:3-5 | Used by prune, compaction tail sizing |
+| Truncate cleanup cadence | hourly, 1-minute delay | tool/truncate.ts:133-134 | Cleanup schedule |
+| `RETENTION` on truncate files | 7 days | tool/truncate.ts:13 | |
+
+---
+
+## 6. Feature flags / config
+
+### Config (`packages/opencode/src/config/config.ts:207-226`)
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `compaction.auto` | boolean | `true` | Disable auto-compaction (`overflow.ts:20`) |
+| `compaction.prune` | boolean | `true` | Disable tool-output pruning (`compaction.ts:175`) |
+| `compaction.tail_turns` | int ≥ 0 | `2` | # recent user turns to keep verbatim (`compaction.ts:135`) |
+| `compaction.preserve_recent_tokens` | int ≥ 0 | auto-clamped 2k–8k | Token budget for the kept tail (`compaction.ts:47`) |
+| `compaction.reserved` | int ≥ 0 | `min(20_000, maxOutputTokens)` | Headroom subtracted from `input`/`context` (`overflow.ts:13`) |
+| `experimental.batch_tool` | boolean | `false` | Declared (`config.ts:230`) but no code currently reads it. Dead flag as of `d2181e927`. |
+| `experimental.continue_loop_on_deny` | boolean | `false` | Affects permission-deny doom-loop behaviour (`processor.ts:542`) — not a context mechanism. |
+
+### Env flags (`packages/opencode/src/flag/flag.ts`)
+
+| Env var | Default | Effect |
+|---|---|---|
+| `OPENCODE_DISABLE_AUTOCOMPACT` | off | Forces `compaction.auto = false` (`config.ts:686-687`) |
+| `OPENCODE_DISABLE_PRUNE` | off | Forces `compaction.prune = false` (`config.ts:689-691`) |
+| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` | unset → 32 000 | Overrides `OUTPUT_TOKEN_MAX` (`transform.ts:20`) |
+| `OPENCODE_EXPERIMENTAL` | off | Turns on several experimental features but not the compaction ones |
+
+### Agent
+
+Compaction is itself an agent named `"compaction"`
+(`agent/agent.ts:188-202`). It is `hidden: true, mode: "primary"`,
+permissions `"*": deny`, so it can't call tools. A user can override
+the model used for compaction via
+`agents.compaction.model` in config
+(`config.ts:176`).
+
+---
+
+## 7. What's actually enabled out of the box
+
+On a fresh install (no config, no env vars):
+
+- **Auto-compaction: ON.** Triggered whenever a `finish-step`
+  `tokens.total ≥ usable(model)` or the provider returns a
+  context-limit error.
+- **Prune: ON.** Runs after every user request, marks tool outputs
+  older than the last 40 k tokens of tool output (with a 20 k-token
+  minimum payoff) as compacted.
+- **Per-tool truncation: ON**, universal. 50 KiB / 2000 lines, hard.
+- **Prompt-cache breakpoints: ON** for Anthropic-family,
+  OpenRouter, OpenAI-compat, Copilot, Alibaba, Bedrock — ephemeral
+  5-min cache only.
+- **`promptCacheKey = sessionID`: ON** for OpenAI, Azure, OpenRouter,
+  Venice, and opencode-hosted GPT-5.
+- **Gateway caching `auto`: ON** when using `@ai-sdk/gateway`.
+- **Media stripping on overflow-retry: ON.**
+- **`filterCompacted` projection: ON** (always).
+- **Agent step cap via max-steps prompt: ON** when an agent sets
+  `steps`; most don't, so `agent.steps ?? Infinity`.
+
+Off by default / requires opt-in:
+
+- `experimental.batch_tool` (declared, unused).
+- `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` override.
+- Plugin `experimental.chat.messages.transform`,
+  `experimental.compaction.autocontinue`,
+  `experimental.session.compacting` — no plugin in the repo wires
+  them.
+- Any long (1 h) Anthropic cache TTL — **not implemented.**
+- Any Anthropic `context_management` / `cache_edits` betas — **not
+  implemented.**
+
+---
+
+## 8. Notable absences
+
+Searched for, not found:
+
+- **Idle / time-based compaction.** Nothing fires based on wall-clock
+  elapsed since last turn. The only time-based things are
+  `Truncate.cleanup` (7-day sweep of tool-output files, hourly) and
+  provider/session HTTP timeouts. `grep -r 'idle|cache.?TTL|cache.*1h'
+  packages/opencode/src` returns only unrelated matches (session UI
+  state, HTTP idle timeouts, provider ModelsDev cache).
+- **Per-turn aggregate output budget.** N parallel tool calls each
+  get their own 50 KiB envelope. No cap across a turn.
+- **Server-side cache-preserving shrinks.** No use of Anthropic
+  `context_management`, `cache_edits`, or equivalent. All shrinking
+  invalidates the cache prefix. `grep -r
+  'cache_edits|context_management' packages/` is empty.
+- **Long (1 h) Anthropic cache.** Only `{type: "ephemeral"}` (5 min)
+  is used. No `"1h"` / `cache_1h` anywhere.
+- **Local tokeniser.** `util/token.ts` is `chars / 4` only. Real
+  token counts come from the provider response and flow through
+  `Session.getUsage`.
+- **UI-only collapsing that differs from the wire.** The TUI hides
+  what is already marked compacted/summarised; the wire sees the
+  same thing. No display-only dedup of repeated tool calls.
+- **Separate `/compact` code path.** `/compact` in the TUI calls the
+  `/session/:id/summarize` HTTP route
+  (`cli/cmd/tui/routes/session/index.tsx:495-499`), which ends up
+  calling exactly the same `compaction.create({ auto: false })` plus
+  `prompt.loop` sequence as auto-compaction
+  (`server/routes/instance/session.ts:574-599`). `/compact`
+  == autocompact, modulo the `auto` flag that controls the
+  auto-continue behaviour.
+
+---
+
+## 9. Interesting findings
+
+- **The compaction "agent" is a real agent with `"*": deny`.** It
+  gets the system prompt from `agent/prompt/compaction.txt` layered
+  with the per-turn compaction prompt template. Because it shares
+  the regular processor pipeline
+  (`compaction.ts:333-352`), it also gets plugin hooks,
+  provider transforms, and prompt-cache markers. Tools are disabled
+  not via "no tools" but via a permission-deny rule — if a plugin
+  registers a tool the compaction agent still has its schema sent
+  on the wire, but permission-denied at call time
+  (`processor.ts:287-331`).
+
+- **`tail_fallback`.** If the single most-recent turn is bigger than
+  `preserve_recent_tokens`, the compaction *summarises the whole
+  history, no tail* (`compaction.ts:150-153`). This is a potential
+  foot-gun: a giant pasted file makes compaction drop everything
+  including the very message that caused the overflow. The
+  `overflow` branch mitigates this by pulling the overflowing user
+  message aside as `replay` and stripping media before replaying
+  (`compaction.ts:242-258, 386-398`).
+
+- **Compaction is durable.** The summary becomes a regular assistant
+  message with `summary: true, mode: "compaction"` stored in
+  session.sql. `SessionRevert` can undo it, so "full compaction
+  doesn't lose anything" is literally true — the raw history is
+  still in the DB, just not sent to the model. (See
+  `session/revert.ts` and `session/revert-compact.test.ts`.)
+
+- **Prune never un-prunes.** Once `state.time.compacted` is set it's
+  set forever (`compaction.ts:198` short-circuits on already-pruned
+  parts). There's no "if we're well below budget now, put tool
+  outputs back." Given `prune` runs after every user request, after
+  a long session nearly all non-tail tool outputs become permanent
+  `[Old tool result content cleared]` placeholders. The tail kept
+  depends only on the running total, not wall-clock staleness.
+
+- **The cache breakpoints' placement is brittle against plugin
+  `system.transform`.** `llm.ts:114-124` handles this explicitly: if
+  a plugin adds entries and the original first entry is still there,
+  the rest are rejoined into a single string so the final `system`
+  list is still 1 or 2 entries, matching what `applyCaching` expects.
+  This is an intentional "preserve the cache prefix" trick.
+
+- **A dummy `_noop` tool is injected** when a LiteLLM-like proxy
+  (or github-copilot) has no active tools but the history contains
+  tool calls (`llm.ts:213-228`). This happens in compaction (tools
+  are all denied), so opencode explicitly plans for a dummy-tool
+  round-trip through those proxies. The tool description tells the
+  model not to call it.
+
+- **Overflow replay converts media to text inline**
+  (`compaction.ts:386-398`): the replayed user message's file parts
+  become `[Attached image/png: foo.png]` etc. so the message shape
+  still makes sense — useful when a user's original message is
+  "look at this screenshot" and the screenshot is what blew up the
+  context.
+
+- **The tail budget auto-scales** with `usable(model) * 0.25`, so
+  bigger models get more tail preservation (up to the 8 k cap).
+  Small models land at the 2 k floor.
+
+- **`experimental.batch_tool` is declared in config schema but not
+  consumed anywhere.** It's either pre-wiring for a future tool or
+  dead code; a user setting it to `true` today does nothing.
+
+- **No "cache warming" on idle.** Because the only cache is
+  ephemeral (5 min), a session left for >5 minutes always cache-
+  misses on next turn. There's no heartbeat or pre-emptive
+  refresh. Combined with compaction also invalidating the prefix,
+  large-session cache hit rates are inherently upper-bounded.

--- a/infrastructure/database/migrations/0022_models_cache_pricing.sql
+++ b/infrastructure/database/migrations/0022_models_cache_pricing.sql
@@ -1,0 +1,15 @@
+-- 0022: Cache-token pricing for supported providers.
+--
+-- Prompt caching changes the cost shape: Anthropic charges ~1.25x the input
+-- rate for cache-creation tokens and ~0.1x for cache-read tokens; OpenAI
+-- simply charges a discounted read rate. To keep cost accounting faithful
+-- we store per-model cache rates alongside the existing input/output rates.
+--
+-- Both columns are nullable. When NULL the worker falls back to
+-- input_microdollars_per_million (conservative — over-reports cache-hit
+-- savings rather than under-reporting spend). model-discovery populates
+-- the explicit values for known Anthropic/Bedrock models on its next run.
+
+ALTER TABLE models
+    ADD COLUMN cache_creation_microdollars_per_million BIGINT,
+    ADD COLUMN cache_read_microdollars_per_million     BIGINT;

--- a/services/api-service/src/main/java/com/persistentagent/api/model/request/ContextManagementConfigRequest.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/model/request/ContextManagementConfigRequest.java
@@ -34,6 +34,14 @@ public record ContextManagementConfigRequest(
         String summarizerModel,
 
         /**
+         * Optional provider for {@code summarizer_model}. When absent, the API
+         * preserves legacy behaviour and treats the agent's primary provider as
+         * the summarizer provider.
+         */
+        @JsonProperty("summarizer_provider")
+        String summarizerProvider,
+
+        /**
          * Optional list of tool names whose results must never be masked by Tier 1
          * observation-clearing. Additive to the platform's built-in exclude list
          * ({@code memory_note}, {@code save_memory}, {@code request_human_input},

--- a/services/api-service/src/main/java/com/persistentagent/api/service/ConfigValidationHelper.java
+++ b/services/api-service/src/main/java/com/persistentagent/api/service/ConfigValidationHelper.java
@@ -219,7 +219,9 @@ public class ConfigValidationHelper {
      *
      * <ul>
      *   <li>{@code summarizerModel}, when non-blank, must resolve against the
-     *       {@code models} table for the agent's provider (same lookup as
+     *       {@code models} table for the chosen summarizer provider. When
+     *       {@code summarizerProvider} is absent, legacy behaviour applies and
+     *       the agent's provider is used (same lookup as
      *       {@link #validateModel(String, String)}). Additionally, when the DB
      *       exposes {@code context_window} for both the summarizer and the primary
      *       model, the summarizer's context window must be ≥ the primary model's
@@ -247,12 +249,17 @@ public class ConfigValidationHelper {
         }
 
         // summarizer_model: optional; when present and non-blank, must be active
-        // for the agent's provider. Reject blank strings — ambiguous with absence.
+        // for the chosen summarizer provider (legacy fallback: agent provider).
+        // Reject blank strings — ambiguous with absence.
         if (cm.summarizerModel() != null && !cm.summarizerModel().isBlank()) {
-            if (!modelRepository.isModelActive(provider, cm.summarizerModel())) {
+            String summarizerProvider = (cm.summarizerProvider() != null && !cm.summarizerProvider().isBlank())
+                    ? cm.summarizerProvider()
+                    : provider;
+
+            if (!modelRepository.isModelActive(summarizerProvider, cm.summarizerModel())) {
                 throw new ValidationException(
-                        "Unsupported context_management.summarizer_model or provider: "
-                                + provider + "/" + cm.summarizerModel()
+                        "Unsupported context_management summarizer selection: "
+                                + summarizerProvider + "/" + cm.summarizerModel()
                                 + ". Check GET /v1/models for supported ones.");
             }
 
@@ -264,7 +271,7 @@ public class ConfigValidationHelper {
             // When either window is NULL / missing from DB, we skip the check (graceful
             // degradation: older model seeds do not carry context_window yet; the
             // migration 0014_model_context_window.sql adds the column with DEFAULT NULL).
-            modelRepository.getContextWindow(provider, cm.summarizerModel())
+            modelRepository.getContextWindow(summarizerProvider, cm.summarizerModel())
                     .ifPresent(summarizerWindow -> {
                         modelRepository.getContextWindow(provider, model).ifPresent(primaryWindow -> {
                             // Mirror Task 3 resolve_thresholds formula.

--- a/services/api-service/src/test/java/com/persistentagent/api/service/AgentServiceTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/AgentServiceTest.java
@@ -600,7 +600,7 @@ class AgentServiceTest {
     void createAgent_contextManagementEmptyObject_roundTripsIntact() throws Exception {
         // Empty context_management sub-object (all fields null) — persisted JSON has the
         // context_management key with null fields, but the sub-object itself is present.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, null, null);
         AgentConfigRequest config = new AgentConfigRequest(
                 "prompt", "openai", "gpt-4o", 0.7, List.of(), null, null, null, cm);
         AgentCreateRequest request = new AgentCreateRequest("Agent", config, null, null, null);
@@ -635,7 +635,7 @@ class AgentServiceTest {
         // All three fields set — persisted JSON preserves them exactly with snake_case keys.
         List<String> excludeTools = List.of("web_search", "custom_tool_x");
         ContextManagementConfigRequest cm = new ContextManagementConfigRequest(
-                "claude-haiku-4-5", excludeTools, true, false);
+                "claude-haiku-4-5", null, excludeTools, true, false);
         AgentConfigRequest config = new AgentConfigRequest(
                 "prompt", "openai", "gpt-4o", 0.7, List.of(), null, null, null, cm);
         AgentCreateRequest request = new AgentCreateRequest("Agent", config, null, null, null);
@@ -677,7 +677,7 @@ class AgentServiceTest {
     @Test
     void updateAgent_contextManagement_roundTripsIntact() throws Exception {
         // PUT path must canonicalize context_management identically to POST.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, List.of("custom_tool"), false, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, List.of("custom_tool"), false, null);
         AgentConfigRequest config = new AgentConfigRequest(
                 "prompt", "openai", "gpt-4o", 0.7, List.of(), null, null, null, cm);
         AgentUpdateRequest request = new AgentUpdateRequest("Agent", config, "active", null, null, null);

--- a/services/api-service/src/test/java/com/persistentagent/api/service/ConfigValidationHelperTest.java
+++ b/services/api-service/src/test/java/com/persistentagent/api/service/ConfigValidationHelperTest.java
@@ -352,7 +352,7 @@ class ConfigValidationHelperTest {
     @Test
     void testValidateContextManagementConfig_allFieldsNull_ok() {
         // All fields null — no checks needed.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         verifyNoInteractions(modelRepository);
     }
@@ -364,15 +364,26 @@ class ConfigValidationHelperTest {
         // No context window available (returns empty) — check is skipped.
         when(modelRepository.getContextWindow("anthropic", "claude-haiku-4-5")).thenReturn(Optional.empty());
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
         verify(modelRepository).isModelActive("anthropic", "claude-haiku-4-5");
     }
 
     @Test
+    void testValidateContextManagementConfig_crossProviderSummarizerValid_ok() {
+        when(modelRepository.isModelActive("openai", "gpt-4o-mini")).thenReturn(true);
+        when(modelRepository.getContextWindow("openai", "gpt-4o-mini")).thenReturn(Optional.empty());
+
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(
+                "gpt-4o-mini", "openai", null, null, null);
+        assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
+        verify(modelRepository).isModelActive("openai", "gpt-4o-mini");
+    }
+
+    @Test
     void testValidateContextManagementConfig_summarizerModelBlankString_skipped() {
         // Empty or whitespace-only summarizer_model behaves like absence — no lookup.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("   ", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("   ", null, null, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         verifyNoInteractions(modelRepository);
     }
@@ -382,7 +393,7 @@ class ConfigValidationHelperTest {
         // Unknown summarizer_model — rejected with the same shape as validateModel.
         when(modelRepository.isModelActive("openai", "nonexistent-model")).thenReturn(false);
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("nonexistent-model", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("nonexistent-model", null, null, null, null);
         ValidationException ex = assertThrows(ValidationException.class,
                 () -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         assertTrue(ex.getMessage().contains("nonexistent-model"),
@@ -396,7 +407,7 @@ class ConfigValidationHelperTest {
         // Model exists but is inactive — same 400 path.
         when(modelRepository.isModelActive("openai", "retired-model")).thenReturn(false);
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("retired-model", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("retired-model", null, null, null, null);
         assertThrows(ValidationException.class,
                 () -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
     }
@@ -411,7 +422,7 @@ class ConfigValidationHelperTest {
         when(modelRepository.getContextWindow("anthropic", "claude-sonnet-4-6"))
                 .thenReturn(Optional.of(200_000));
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("small-model", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("small-model", null, null, null, null);
         ValidationException ex = assertThrows(ValidationException.class,
                 () -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
         assertTrue(ex.getMessage().contains("small-model"),
@@ -430,7 +441,7 @@ class ConfigValidationHelperTest {
         when(modelRepository.getContextWindow("anthropic", "claude-sonnet-4-6"))
                 .thenReturn(Optional.of(200_000));
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
     }
 
@@ -443,7 +454,7 @@ class ConfigValidationHelperTest {
         when(modelRepository.getContextWindow("anthropic", "claude-sonnet-4-6"))
                 .thenReturn(Optional.empty()); // primary window unknown
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("claude-haiku-4-5", null, null, null, null);
         // Skips the check when primary window is unknown — no 400.
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
     }
@@ -455,7 +466,7 @@ class ConfigValidationHelperTest {
         for (int i = 0; i < 50; i++) {
             tools.add("tool_" + i);
         }
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, tools, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, tools, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
     }
 
@@ -466,7 +477,7 @@ class ConfigValidationHelperTest {
         for (int i = 0; i < 51; i++) {
             tools.add("tool_" + i);
         }
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, tools, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, tools, null, null);
         ValidationException ex = assertThrows(ValidationException.class,
                 () -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         assertTrue(ex.getMessage().contains("50"),
@@ -477,21 +488,21 @@ class ConfigValidationHelperTest {
     void testValidateContextManagementConfig_excludeTools_unknownToolNames_ok() {
         // Unknown tool names are allowed — customers can add custom tools before wiring.
         List<String> tools = List.of("memory_note", "unknown_tool_xyz");
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, tools, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, tools, null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
     }
 
     @Test
     void testValidateContextManagementConfig_excludeTools_empty_ok() {
         // Empty exclude_tools list is valid.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, List.of(), null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, List.of(), null, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
     }
 
     @Test
     void testValidateContextManagementConfig_preTier3MemoryFlush_true_ok() {
         // pre_tier3_memory_flush=true is valid regardless of memory.enabled state.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, true, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, true, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         verifyNoInteractions(modelRepository);
     }
@@ -499,7 +510,7 @@ class ConfigValidationHelperTest {
     @Test
     void testValidateContextManagementConfig_preTier3MemoryFlush_false_ok() {
         // pre_tier3_memory_flush=false is also valid.
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, false, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest(null, null, null, false, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "openai", "gpt-4o"));
         verifyNoInteractions(modelRepository);
     }
@@ -515,7 +526,7 @@ class ConfigValidationHelperTest {
 
         List<String> tools = List.of("memory_note", "custom_tool");
         ContextManagementConfigRequest cm = new ContextManagementConfigRequest(
-                "claude-haiku-4-5", tools, true, null);
+                "claude-haiku-4-5", null, tools, true, null);
         assertDoesNotThrow(() -> helper.validateContextManagementConfig(cm, "anthropic", "claude-sonnet-4-6"));
     }
 
@@ -526,7 +537,7 @@ class ConfigValidationHelperTest {
         when(modelRepository.isModelActive("openai", "gpt-4o")).thenReturn(true);
         when(modelRepository.isModelActive("openai", "bad-cm-model")).thenReturn(false);
 
-        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("bad-cm-model", null, null, null);
+        ContextManagementConfigRequest cm = new ContextManagementConfigRequest("bad-cm-model", null, null, null, null);
         com.persistentagent.api.model.request.AgentConfigRequest config =
                 new com.persistentagent.api.model.request.AgentConfigRequest(
                         "prompt", "openai", "gpt-4o", 0.7, List.of(), null, null, null, cm);

--- a/services/console/src/features/agents/AgentDetailPage.test.tsx
+++ b/services/console/src/features/agents/AgentDetailPage.test.tsx
@@ -122,6 +122,19 @@ const MOCK_AGENT_WITH_MEMORY_DEFAULTS = {
     },
 };
 
+const MOCK_AGENT_WITH_CONTEXT_MANAGEMENT = {
+    ...MOCK_AGENT,
+    agent_config: {
+        ...MOCK_AGENT.agent_config,
+        context_management: {
+            summarizer_model: 'gpt-4o-mini',
+            summarizer_provider: 'openai',
+            exclude_tools: ['web_search'],
+            pre_tier3_memory_flush: true,
+        },
+    },
+};
+
 describe('AgentDetailPage', () => {
     it('shows sandbox info in read-only mode when sandbox is enabled', async () => {
         agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_SANDBOX, isLoading: false, error: null });
@@ -285,6 +298,22 @@ describe('AgentDetailPage', () => {
             screen.getByText('Platform default (runtime-configured; fallback: claude-haiku-4-5)')
         ).toBeInTheDocument();
         expect(screen.getByText('10,000')).toBeInTheDocument();
+    });
+
+    it('uses customer-facing labels for context management in the read-only overview', async () => {
+        agentMock.mockReturnValue({ data: MOCK_AGENT_WITH_CONTEXT_MANAGEMENT, isLoading: false, error: null });
+
+        render(<AgentDetailPage />, { wrapper: createWrapper() });
+
+        expect(await screen.findByRole('heading', { name: 'Research Agent' })).toBeInTheDocument();
+
+        expect(screen.getByText('Long-Running Task Context')).toBeInTheDocument();
+        expect(screen.getByText('Summarizer Model')).toBeInTheDocument();
+        expect(screen.getByText('gpt-4o-mini (OpenAI)')).toBeInTheDocument();
+        expect(screen.getByText('Always Keep Outputs From')).toBeInTheDocument();
+        expect(screen.getByText('Save Important Facts Before Summarizing')).toBeInTheDocument();
+        expect(screen.getByText('web_search')).toBeInTheDocument();
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
     });
 
     it('shows loading state', () => {

--- a/services/console/src/features/agents/AgentDetailPage.tsx
+++ b/services/console/src/features/agents/AgentDetailPage.tsx
@@ -5,9 +5,9 @@ import { z } from 'zod';
 import { useAgent, useUpdateAgent } from './useAgents';
 import { useModels } from '@/features/submit/useModels';
 import { ALL_TOOL_LABELS, HUMAN_INPUT_TOOL_ID } from '@/features/submit/schema';
-import { groupModelsByProvider } from '@/lib/models';
+import { formatProviderLabel, groupModelsByProvider } from '@/lib/models';
 import { toast } from 'sonner';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { formatUsd } from '@/lib/utils';
 import { useToolServers } from '../tool-servers/useToolServers';
 import { MemoryTab } from './memory/MemoryTab';
@@ -143,21 +143,21 @@ export function AgentDetailPage() {
         setCtxMgmt(next);
     }, []);
 
-    const selectedProvider = form.watch('provider');
-    const providerFilteredModels = useMemo(
-        () => models.filter((m) => m.provider === selectedProvider),
-        [models, selectedProvider],
-    );
-
     useEffect(() => {
         if (!ctxMgmt?.summarizer_model) return;
-        if (!selectedProvider) return;
-        const stillValid = providerFilteredModels.some((m) => m.model_id === ctxMgmt.summarizer_model);
+        const stillValid = models.some(
+            (m) => m.model_id === ctxMgmt.summarizer_model
+                && (!ctxMgmt.summarizer_provider || m.provider === ctxMgmt.summarizer_provider)
+        );
         if (!stillValid) {
             ctxMgmtDirty.current = true;
-            setCtxMgmt({ ...ctxMgmt, summarizer_model: undefined });
+            setCtxMgmt({
+                ...ctxMgmt,
+                summarizer_model: undefined,
+                summarizer_provider: undefined,
+            });
         }
-    }, [providerFilteredModels, ctxMgmt, selectedProvider]);
+    }, [models, ctxMgmt]);
 
     function onSubmit(data: AgentDetailFormValues) {
         if (!agentId) return;
@@ -193,10 +193,12 @@ export function AgentDetailPage() {
         const hasExistingCtxMgmt = !!loadedCtxMgmt.current;
         const shouldSendCtxMgmt = hasExistingCtxMgmt || ctxMgmtDirty.current;
         const summarizer = ctxMgmt?.summarizer_model?.trim();
+        const summarizerProvider = ctxMgmt?.summarizer_provider?.trim();
         const excludeTools = ctxMgmt?.exclude_tools ?? [];
         const contextManagementPayload: ContextManagementConfig | undefined = shouldSendCtxMgmt
             ? {
                 ...(summarizer ? { summarizer_model: summarizer } : {}),
+                ...(summarizer && summarizerProvider ? { summarizer_provider: summarizerProvider } : {}),
                 ...(excludeTools.length ? { exclude_tools: excludeTools } : {}),
                 pre_tier3_memory_flush: !!ctxMgmt?.pre_tier3_memory_flush,
             }
@@ -416,16 +418,20 @@ export function AgentDetailPage() {
                             )}
                             {agent?.agent_config?.context_management && (
                                 <div className="pt-4 border-t border-white/8 space-y-2">
-                                    <div className="uppercase tracking-widest text-muted-foreground text-[10px]">Context Management</div>
+                                    <div className="uppercase tracking-widest text-muted-foreground text-[10px]">Long-Running Task Context</div>
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                                         <div>
                                             <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Summarizer Model</span>
                                             <span className="text-foreground text-sm font-mono">
-                                                {agent.agent_config.context_management.summarizer_model || 'Platform default'}
+                                                {agent.agent_config.context_management.summarizer_model
+                                                    ? agent.agent_config.context_management.summarizer_provider
+                                                        ? `${agent.agent_config.context_management.summarizer_model} (${formatProviderLabel(agent.agent_config.context_management.summarizer_provider)})`
+                                                        : agent.agent_config.context_management.summarizer_model
+                                                    : 'Platform default'}
                                             </span>
                                         </div>
                                         <div>
-                                            <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Exclude Tools</span>
+                                            <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Always Keep Outputs From</span>
                                             <span className="text-foreground text-sm font-mono">
                                                 {agent.agent_config.context_management.exclude_tools?.length
                                                     ? agent.agent_config.context_management.exclude_tools.join(', ')
@@ -433,7 +439,7 @@ export function AgentDetailPage() {
                                             </span>
                                         </div>
                                         <div>
-                                            <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Pre-Tier-3 Memory Flush</span>
+                                            <span className="text-muted-foreground block mb-1 uppercase tracking-widest text-[10px]">Save Important Facts Before Summarizing</span>
                                             <span className="text-foreground text-sm font-mono">
                                                 {agent.agent_config.context_management.pre_tier3_memory_flush ? 'Enabled' : 'Disabled'}
                                             </span>
@@ -842,7 +848,7 @@ export function AgentDetailPage() {
                                 <ContextManagementSection
                                     value={ctxMgmt}
                                     memoryEnabled={memoryEnabledInForm}
-                                    availableSummarizerModels={providerFilteredModels}
+                                    availableSummarizerModels={models}
                                     onChange={handleCtxMgmtChange}
                                 />
                             </CardContent>

--- a/services/console/src/features/agents/ContextManagementSection.tsx
+++ b/services/console/src/features/agents/ContextManagementSection.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { X } from 'lucide-react';
-import { groupModelsByProvider } from '@/lib/models';
+import { ChevronDown, X } from 'lucide-react';
+import { formatProviderLabel, groupModelsByProvider } from '@/lib/models';
 import type { ModelResponse } from '@/types';
 
 export interface ContextManagementConfig {
     summarizer_model?: string;
+    summarizer_provider?: string;
     exclude_tools?: string[];
     pre_tier3_memory_flush?: boolean;
 }
@@ -31,13 +32,33 @@ export function ContextManagementSection({
     const currentValue: ContextManagementConfig = value ?? {};
     const excludeTools = currentValue.exclude_tools ?? [];
     const summarizerModel = currentValue.summarizer_model ?? '';
+    const summarizerProvider = currentValue.summarizer_provider ?? '';
     const preFlush = currentValue.pre_tier3_memory_flush ?? false;
+    const selectedSummarizerValue = summarizerModel
+        ? (summarizerProvider
+            ? `${summarizerProvider}|${summarizerModel}`
+            : (availableSummarizerModels.find((m) => m.model_id === summarizerModel)
+                ? `${availableSummarizerModels.find((m) => m.model_id === summarizerModel)?.provider}|${summarizerModel}`
+                : ''))
+        : '';
 
     function handleSummarizerModelChange(e: React.ChangeEvent<HTMLSelectElement>) {
         const next = e.target.value;
+        if (!next) {
+            onChange({
+                ...currentValue,
+                summarizer_model: undefined,
+                summarizer_provider: undefined,
+            });
+            return;
+        }
+        const separatorIndex = next.indexOf('|');
+        const provider = next.slice(0, separatorIndex);
+        const modelId = next.slice(separatorIndex + 1);
         onChange({
             ...currentValue,
-            summarizer_model: next || undefined,
+            summarizer_model: modelId || undefined,
+            summarizer_provider: provider || undefined,
         });
     }
 
@@ -92,11 +113,12 @@ export function ContextManagementSection({
     return (
         <div className="space-y-3">
             <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                Context Management
+                Long-Running Task Context
             </span>
             <div className="p-3 border border-border rounded-none bg-black/30 space-y-4">
                 <p className="text-xs text-muted-foreground">
-                    Context management is always-on platform infrastructure; the fields below are tuning knobs, not an enable toggle.
+                    When tasks run for a long time, the platform may summarize older context to keep the
+                    agent effective. These are advanced settings.
                 </p>
 
                 {/* summarizer_model */}
@@ -107,26 +129,40 @@ export function ContextManagementSection({
                     >
                         Summarizer Model
                     </label>
-                    <select
-                        id="ctx-summarizer-model"
-                        data-testid="context-management-summarizer-model"
-                        className="flex h-10 w-full border border-border bg-black/50 px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0 rounded-none appearance-none"
-                        value={summarizerModel}
-                        onChange={handleSummarizerModelChange}
-                    >
-                        <option value="">Platform default</option>
-                        {modelGroups.map((group) => (
-                            <optgroup key={group.provider} label={group.label}>
-                                {group.models.map((m) => (
-                                    <option key={m.model_id} value={m.model_id}>
-                                        {m.display_name}
-                                    </option>
-                                ))}
-                            </optgroup>
-                        ))}
-                    </select>
+                    <div className="relative">
+                        <select
+                            id="ctx-summarizer-model"
+                            data-testid="context-management-summarizer-model"
+                            className="flex h-10 w-full border border-border bg-black/50 px-3 py-2 pr-10 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0 rounded-none appearance-none"
+                            value={selectedSummarizerValue}
+                            onChange={handleSummarizerModelChange}
+                        >
+                            <option value="">Platform default</option>
+                            {modelGroups.map((group) => (
+                                <optgroup key={group.provider} label={group.label}>
+                                    {group.models.map((m) => (
+                                        <option key={`${m.provider}|${m.model_id}`} value={`${m.provider}|${m.model_id}`}>
+                                            {m.display_name}
+                                            {' '}
+                                            (
+                                            {formatProviderLabel(m.provider)}
+                                            )
+                                        </option>
+                                    ))}
+                                </optgroup>
+                            ))}
+                        </select>
+                        <ChevronDown
+                            aria-hidden="true"
+                            className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                        />
+                    </div>
                     <p className="text-xs text-muted-foreground mt-1">
-                        Model used for Tier 3 summarization. Leave as "Platform default" unless you need a specific model.
+                        Choose which model summarizes older context when a task gets long. Leave on
+                        {' '}
+                        Platform default
+                        {' '}
+                        unless you have a specific reason to change it.
                     </p>
                 </div>
 
@@ -137,7 +173,7 @@ export function ContextManagementSection({
                 >
                     <div className="flex items-center justify-between">
                         <label className="uppercase tracking-widest text-muted-foreground/70 text-[10px]">
-                            Exclude Tools from Compaction
+                            Always Keep Outputs From
                         </label>
                         <span className="text-[10px] text-muted-foreground">
                             {excludeTools.length}&nbsp;/&nbsp;50
@@ -185,7 +221,7 @@ export function ContextManagementSection({
                     )}
 
                     <p className="text-xs text-muted-foreground">
-                        Tool names whose results are never masked during Tier 1 compaction. Additive on top of the platform-seeded list.
+                        Preserve outputs from these tools even when older context is reduced.
                     </p>
                 </div>
 
@@ -206,11 +242,11 @@ export function ContextManagementSection({
                                 htmlFor="ctx-pre-tier3-flush"
                                 className="font-normal font-mono cursor-pointer text-sm"
                             >
-                                Pre-Tier-3 Memory Flush
+                                Save Important Facts Before Summarizing
                             </label>
                             <p className="text-xs text-muted-foreground mt-0.5">
-                                Before the first Tier 3 summarization in a task, give the agent a chance to
-                                call <code>memory_note</code> to preserve cross-task facts.
+                                Before older context is summarized for the first time, let the agent save
+                                durable facts to memory.
                             </p>
                             {!memoryEnabled && (
                                 <p className="text-xs text-amber-400 mt-0.5">

--- a/services/console/src/features/agents/CreateAgentDialog.test.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.test.tsx
@@ -78,10 +78,17 @@ describe('CreateAgentDialog', () => {
     it('renders context management controls and includes them in the create payload', async () => {
         render(<CreateAgentDialog open onOpenChange={() => {}} />, { wrapper: createWrapper() });
 
+        expect(screen.getByText('Long-Running Task Context')).toBeInTheDocument();
+        expect(
+            screen.getByText(/When tasks run for a long time, the platform may summarize older context/i)
+        ).toBeInTheDocument();
+        expect(screen.getByText('Always Keep Outputs From')).toBeInTheDocument();
+        expect(screen.getByText('Save Important Facts Before Summarizing')).toBeInTheDocument();
+
         fireEvent.change(screen.getByLabelText(/agent name/i), { target: { value: 'Context Agent' } });
         fireEvent.click(screen.getByText('Enable Memory'));
         fireEvent.change(screen.getByTestId('context-management-summarizer-model'), {
-            target: { value: 'claude-3-5-haiku-latest' },
+            target: { value: 'openai|gpt-4o-mini' },
         });
         fireEvent.change(screen.getByPlaceholderText(/add tool name and press enter/i), {
             target: { value: 'web_search' },
@@ -98,7 +105,8 @@ describe('CreateAgentDialog', () => {
             expect.objectContaining({
                 agent_config: expect.objectContaining({
                     context_management: {
-                        summarizer_model: 'claude-3-5-haiku-latest',
+                        summarizer_model: 'gpt-4o-mini',
+                        summarizer_provider: 'openai',
                         exclude_tools: ['web_search'],
                         pre_tier3_memory_flush: true,
                     },
@@ -113,7 +121,7 @@ describe('CreateAgentDialog', () => {
 
         fireEvent.change(screen.getByLabelText(/agent name/i), { target: { value: 'Partial Ctx Agent' } });
         fireEvent.change(screen.getByTestId('context-management-summarizer-model'), {
-            target: { value: 'claude-3-5-haiku-latest' },
+            target: { value: 'openai|gpt-4o-mini' },
         });
 
         fireEvent.click(screen.getByRole('button', { name: /create/i }));
@@ -122,21 +130,22 @@ describe('CreateAgentDialog', () => {
 
         const payload = createMock.mock.calls[0][0];
         expect(payload.agent_config.context_management).toEqual({
-            summarizer_model: 'claude-3-5-haiku-latest',
+            summarizer_model: 'gpt-4o-mini',
+            summarizer_provider: 'openai',
             pre_tier3_memory_flush: false,
         });
     });
 
-    it('filters summarizer-model options to the currently selected provider (P2 fix)', () => {
+    it('shows summarizer-model options across providers so customers can choose a cross-provider summarizer', () => {
         render(<CreateAgentDialog open onOpenChange={() => {}} />, { wrapper: createWrapper() });
 
         const summarizerSelect = screen.getByTestId('context-management-summarizer-model') as HTMLSelectElement;
         const optionValues = Array.from(summarizerSelect.querySelectorAll('option')).map((o) => o.value);
 
-        expect(optionValues).toContain('claude-3-5-sonnet-latest');
-        expect(optionValues).toContain('claude-3-5-haiku-latest');
-        expect(optionValues).not.toContain('gpt-4o');
-        expect(optionValues).not.toContain('gpt-4o-mini');
+        expect(optionValues).toContain('anthropic|claude-3-5-sonnet-latest');
+        expect(optionValues).toContain('anthropic|claude-3-5-haiku-latest');
+        expect(optionValues).toContain('openai|gpt-4o');
+        expect(optionValues).toContain('openai|gpt-4o-mini');
     });
 
     it('auto-selects the first available model so the display matches form state (no stale hardcoded default)', async () => {

--- a/services/console/src/features/agents/CreateAgentDialog.tsx
+++ b/services/console/src/features/agents/CreateAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -61,9 +61,11 @@ function buildContextManagementPayload(
     config: ContextManagementConfig | undefined,
 ): ContextManagementConfig {
     const summarizer = config?.summarizer_model?.trim();
+    const summarizerProvider = config?.summarizer_provider?.trim();
     const excludeTools = config?.exclude_tools ?? [];
     return {
         ...(summarizer ? { summarizer_model: summarizer } : {}),
+        ...(summarizer && summarizerProvider ? { summarizer_provider: summarizerProvider } : {}),
         ...(excludeTools.length ? { exclude_tools: excludeTools } : {}),
         pre_tier3_memory_flush: !!config?.pre_tier3_memory_flush,
     };
@@ -103,7 +105,6 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
     const selectedToolServers = form.watch('tool_servers');
     const sandboxEnabled = form.watch('sandbox_enabled');
     const memoryEnabled = form.watch('memory_enabled');
-    const selectedProvider = form.watch('provider');
     const selectedModel = form.watch('model');
 
     useEffect(() => {
@@ -113,19 +114,21 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
         form.setValue('provider', first.provider);
         form.setValue('model', first.model_id);
     }, [models, selectedModel, form]);
-    const providerFilteredModels = useMemo(
-        () => models.filter((m) => m.provider === selectedProvider),
-        [models, selectedProvider],
-    );
-
     useEffect(() => {
         if (!ctxMgmt?.summarizer_model) return;
-        const stillValid = providerFilteredModels.some((m) => m.model_id === ctxMgmt.summarizer_model);
+        const stillValid = models.some(
+            (m) => m.model_id === ctxMgmt.summarizer_model
+                && (!ctxMgmt.summarizer_provider || m.provider === ctxMgmt.summarizer_provider)
+        );
         if (!stillValid) {
             ctxMgmtDirty.current = true;
-            setCtxMgmt({ ...ctxMgmt, summarizer_model: undefined });
+            setCtxMgmt({
+                ...ctxMgmt,
+                summarizer_model: undefined,
+                summarizer_provider: undefined,
+            });
         }
-    }, [providerFilteredModels, ctxMgmt]);
+    }, [models, ctxMgmt]);
 
     const handleCtxMgmtChange = useCallback((next: ContextManagementConfig) => {
         ctxMgmtDirty.current = true;
@@ -561,7 +564,7 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
                         <ContextManagementSection
                             value={ctxMgmt}
                             memoryEnabled={memoryEnabled}
-                            availableSummarizerModels={providerFilteredModels}
+                            availableSummarizerModels={models}
                             onChange={handleCtxMgmtChange}
                         />
 

--- a/services/console/src/features/agents/__tests__/ContextManagementSection.test.tsx
+++ b/services/console/src/features/agents/__tests__/ContextManagementSection.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('ContextManagementSection', () => {
     describe('rendering', () => {
         it('renders section header copy describing always-on infrastructure', () => {
-            render(
+            const { container } = render(
                 <ContextManagementSection
                     value={undefined}
                     memoryEnabled={false}
@@ -26,8 +26,12 @@ describe('ContextManagementSection', () => {
                 />
             );
             expect(
-                screen.getByText(/Context management is always-on platform infrastructure/i)
+                screen.getByText('Long-Running Task Context')
             ).toBeInTheDocument();
+            expect(
+                screen.getByText(/When tasks run for a long time, the platform may summarize older context/i)
+            ).toBeInTheDocument();
+            expect(container.querySelector('svg.lucide-chevron-down')).toBeInTheDocument();
         });
 
         it('renders summarizer_model select with correct testid', () => {
@@ -120,9 +124,33 @@ describe('ContextManagementSection', () => {
                     onChange={vi.fn()}
                 />
             );
-            expect(screen.getByRole('option', { name: 'Claude Haiku 4.5' })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: 'Claude Sonnet 4.5' })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: 'GPT-4o' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Claude Haiku 4.5 (Anthropic)' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Claude Sonnet 4.5 (Anthropic)' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'GPT-4o (OpenAI)' })).toBeInTheDocument();
+        });
+
+        it('uses customer-facing labels and helper copy for advanced controls', () => {
+            render(
+                <ContextManagementSection
+                    value={undefined}
+                    memoryEnabled={false}
+                    availableSummarizerModels={MOCK_MODELS}
+                    onChange={vi.fn()}
+                />
+            );
+
+            expect(screen.getByText('Summarizer Model')).toBeInTheDocument();
+            expect(
+                screen.getByText(/Choose which model summarizes older context when a task gets long/i)
+            ).toBeInTheDocument();
+            expect(screen.getByText('Always Keep Outputs From')).toBeInTheDocument();
+            expect(
+                screen.getByText(/Preserve outputs from these tools even when older context is reduced/i)
+            ).toBeInTheDocument();
+            expect(screen.getByText('Save Important Facts Before Summarizing')).toBeInTheDocument();
+            expect(
+                screen.getByText(/Before older context is summarized for the first time, let the agent save durable facts to memory/i)
+            ).toBeInTheDocument();
         });
 
         it('renders existing exclude_tools chips when value is provided', () => {
@@ -177,9 +205,12 @@ describe('ContextManagementSection', () => {
                 />
             );
             const select = screen.getByTestId('context-management-summarizer-model');
-            fireEvent.change(select, { target: { value: 'claude-haiku-4-5' } });
+            fireEvent.change(select, { target: { value: 'anthropic|claude-haiku-4-5' } });
             expect(handleChange).toHaveBeenCalledWith(
-                expect.objectContaining({ summarizer_model: 'claude-haiku-4-5' })
+                expect.objectContaining({
+                    summarizer_model: 'claude-haiku-4-5',
+                    summarizer_provider: 'anthropic',
+                })
             );
         });
 
@@ -351,7 +382,7 @@ describe('ContextManagementSection', () => {
 
             // Verify all fields render with their existing values
             const select = screen.getByTestId('context-management-summarizer-model') as HTMLSelectElement;
-            expect(select.value).toBe('claude-haiku-4-5');
+            expect(select.value).toBe('anthropic|claude-haiku-4-5');
 
             expect(screen.getByText('web_search')).toBeInTheDocument();
 

--- a/services/console/src/types/index.ts
+++ b/services/console/src/types/index.ts
@@ -259,6 +259,7 @@ export interface MemoryConfig {
 
 export interface ContextManagementConfig {
     summarizer_model?: string;
+    summarizer_provider?: string;
     exclude_tools?: string[];
     pre_tier3_memory_flush?: boolean;
     /**

--- a/services/model-discovery/main.py
+++ b/services/model-discovery/main.py
@@ -11,39 +11,82 @@ from typing import Any, Mapping
 
 import psycopg
 
+
+def _with_anthropic_cache(input_rate: int, output_rate: int) -> dict:
+    """Anthropic published rates: cache_creation ≈ 1.25x input, cache_read
+    ≈ 0.1x input. Applies to both native Anthropic and Claude-on-Bedrock.
+    Integer math rounds toward zero; acceptable for microdollar precision.
+    """
+    return {
+        "input": input_rate,
+        "output": output_rate,
+        "cache_creation": (input_rate * 125) // 100,
+        "cache_read": input_rate // 10,
+    }
+
+
 # Prices in microdollars per million tokens (e.g. 3,000,000 = $3.00)
+# ``cache_creation`` / ``cache_read`` rates are optional — when absent the
+# worker falls back to the input rate (conservative: over-estimates cache
+# spend rather than under-reporting it).
 PRICING_DEFAULTS = {
     # Anthropic
-    "claude-3-7-sonnet-20250219": {"input": 3_000_000, "output": 15_000_000},
-    "claude-3-5-sonnet-20241022": {"input": 3_000_000, "output": 15_000_000},
-    "claude-3-5-haiku-20241022": {"input": 1_000_000, "output": 5_000_000},
+    "claude-3-7-sonnet-20250219": _with_anthropic_cache(3_000_000, 15_000_000),
+    "claude-3-5-sonnet-20241022": _with_anthropic_cache(3_000_000, 15_000_000),
+    "claude-3-5-haiku-20241022": _with_anthropic_cache(1_000_000, 5_000_000),
     # Claude Haiku 4.5 — published Bedrock/Anthropic rates are $0.80 / $4.00
     # per million input / output tokens.  Listed under both the bare family
     # alias (which is the platform default for the compaction summariser)
     # and the dated on-demand ID used by direct Anthropic API callers.
-    "claude-haiku-4-5": {"input": 800_000, "output": 4_000_000},
-    "claude-haiku-4-5-20251001": {"input": 800_000, "output": 4_000_000},
-    "claude-3-opus-20240229": {"input": 15_000_000, "output": 75_000_000},
-    # OpenAI
-    "gpt-4o": {"input": 2_500_000, "output": 10_000_000},
-    "gpt-4o-mini": {"input": 150_000, "output": 600_000},
-    "o1": {"input": 15_000_000, "output": 60_000_000},
-    "o1-mini": {"input": 3_000_000, "output": 12_000_000},
-    "o3-mini": {"input": 1_100_000, "output": 4_400_000},
+    "claude-haiku-4-5": _with_anthropic_cache(800_000, 4_000_000),
+    "claude-haiku-4-5-20251001": _with_anthropic_cache(800_000, 4_000_000),
+    "claude-3-opus-20240229": _with_anthropic_cache(15_000_000, 75_000_000),
+    # OpenAI — caching is automatic; cache_creation is always 0 for OpenAI,
+    # cache_read is ~0.5x input for GPT-4o family, ~0.5x for o-series.
+    "gpt-4o": {
+        "input": 2_500_000,
+        "output": 10_000_000,
+        "cache_creation": 0,
+        "cache_read": 1_250_000,
+    },
+    "gpt-4o-mini": {
+        "input": 150_000,
+        "output": 600_000,
+        "cache_creation": 0,
+        "cache_read": 75_000,
+    },
+    "o1": {
+        "input": 15_000_000,
+        "output": 60_000_000,
+        "cache_creation": 0,
+        "cache_read": 7_500_000,
+    },
+    "o1-mini": {
+        "input": 3_000_000,
+        "output": 12_000_000,
+        "cache_creation": 0,
+        "cache_read": 1_500_000,
+    },
+    "o3-mini": {
+        "input": 1_100_000,
+        "output": 4_400_000,
+        "cache_creation": 0,
+        "cache_read": 550_000,
+    },
     # Bedrock (Anthropic models via Bedrock use the same pricing)
-    "anthropic.claude-3-5-sonnet-20241022-v2:0": {"input": 3_000_000, "output": 15_000_000},
-    "anthropic.claude-3-5-haiku-20241022-v1:0": {"input": 1_000_000, "output": 5_000_000},
-    "anthropic.claude-3-opus-20240229-v1:0": {"input": 15_000_000, "output": 75_000_000},
-    "anthropic.claude-3-7-sonnet-20250219-v1:0": {"input": 3_000_000, "output": 15_000_000},
-    "anthropic.claude-sonnet-4-20250514-v1:0": {"input": 3_000_000, "output": 15_000_000},
-    "anthropic.claude-sonnet-4-5-20250929-v1:0": {"input": 3_000_000, "output": 15_000_000},
-    "anthropic.claude-sonnet-4-6": {"input": 3_000_000, "output": 15_000_000},
+    "anthropic.claude-3-5-sonnet-20241022-v2:0": _with_anthropic_cache(3_000_000, 15_000_000),
+    "anthropic.claude-3-5-haiku-20241022-v1:0": _with_anthropic_cache(1_000_000, 5_000_000),
+    "anthropic.claude-3-opus-20240229-v1:0": _with_anthropic_cache(15_000_000, 75_000_000),
+    "anthropic.claude-3-7-sonnet-20250219-v1:0": _with_anthropic_cache(3_000_000, 15_000_000),
+    "anthropic.claude-sonnet-4-20250514-v1:0": _with_anthropic_cache(3_000_000, 15_000_000),
+    "anthropic.claude-sonnet-4-5-20250929-v1:0": _with_anthropic_cache(3_000_000, 15_000_000),
+    "anthropic.claude-sonnet-4-6": _with_anthropic_cache(3_000_000, 15_000_000),
     # Claude Haiku 4.5 via Bedrock — $0.80 / $4.00 per million tokens.
-    "anthropic.claude-haiku-4-5-20251001-v1:0": {"input": 800_000, "output": 4_000_000},
-    "anthropic.claude-opus-4-20250514-v1:0": {"input": 15_000_000, "output": 75_000_000},
-    "anthropic.claude-opus-4-1-20250805-v1:0": {"input": 15_000_000, "output": 75_000_000},
-    "anthropic.claude-opus-4-5-20251101-v1:0": {"input": 15_000_000, "output": 75_000_000},
-    "anthropic.claude-opus-4-6-v1": {"input": 15_000_000, "output": 75_000_000},
+    "anthropic.claude-haiku-4-5-20251001-v1:0": _with_anthropic_cache(800_000, 4_000_000),
+    "anthropic.claude-opus-4-20250514-v1:0": _with_anthropic_cache(15_000_000, 75_000_000),
+    "anthropic.claude-opus-4-1-20250805-v1:0": _with_anthropic_cache(15_000_000, 75_000_000),
+    "anthropic.claude-opus-4-5-20251101-v1:0": _with_anthropic_cache(15_000_000, 75_000_000),
+    "anthropic.claude-opus-4-6-v1": _with_anthropic_cache(15_000_000, 75_000_000),
     "amazon.nova-pro-v1:0": {"input": 800_000, "output": 3_200_000},
     "amazon.nova-lite-v1:0": {"input": 60_000, "output": 240_000},
     "amazon.nova-micro-v1:0": {"input": 35_000, "output": 140_000},
@@ -582,16 +625,20 @@ def upsert_models(conn, provider_keys):
                             display_name,
                             input_microdollars_per_million,
                             output_microdollars_per_million,
+                            cache_creation_microdollars_per_million,
+                            cache_read_microdollars_per_million,
                             context_window,
                             is_active,
                             created_at
                         )
-                        VALUES (%s, %s, %s, %s, %s, %s, true, NOW())
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, true, NOW())
                         ON CONFLICT (provider_id, model_id) DO UPDATE SET
                             is_active = true,
                             display_name = EXCLUDED.display_name,
                             input_microdollars_per_million = EXCLUDED.input_microdollars_per_million,
                             output_microdollars_per_million = EXCLUDED.output_microdollars_per_million,
+                            cache_creation_microdollars_per_million = EXCLUDED.cache_creation_microdollars_per_million,
+                            cache_read_microdollars_per_million = EXCLUDED.cache_read_microdollars_per_million,
                             context_window = EXCLUDED.context_window
                         """,
                         (
@@ -600,6 +647,8 @@ def upsert_models(conn, provider_keys):
                             m["display_name"],
                             pricing["input"],
                             pricing["output"],
+                            pricing.get("cache_creation"),
+                            pricing.get("cache_read"),
                             context_window,
                         ),
                     )

--- a/services/worker-service/README.md
+++ b/services/worker-service/README.md
@@ -53,6 +53,7 @@ Create a `.env` file in `services/worker-service/` or export directly:
 | `MODEL_PRICING_FILE` | Custom model pricing map | `config/model_pricing.json` |
 | `MEMORY_DEFAULT_SUMMARIZER_MODEL` | Platform-default summarizer model for memory-enabled agents that don't set `agent_config.memory.summarizer_model` | `claude-haiku-4-5` |
 | `APP_DEV_TASK_CONTROLS_ENABLED` | Dev-only task controls and `dev_sleep` tool | `false` |
+| `WORKER_PROMPT_CACHE_DISABLED` | **Operator kill switch** for prompt-cache marker injection (Anthropic `cache_control`, Bedrock `cachePoint`). Set to `1` / `true` / `yes` / `on` to suppress markers fleet-wide. Token-usage extraction continues regardless so OpenAI's automatic caching still reports correctly. | unset (caching enabled) |
 
 > **Memory-enabled agents (Phase 2 Track 5).** Memory writes compute embeddings via
 > OpenAI's `text-embedding-3-small`. The worker reads the API key from the same

--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -55,6 +55,7 @@ from executor.compaction.tokens import (
     extract_text_content as _extract_message_text,
 )
 from executor.compaction.summarizer import summarize_slice
+from executor.prompt_cache import TokenUsage, get_strategy as _get_cache_strategy
 from executor.memory_graph import (
     DEAD_LETTER_REASON_CANCELLED_BY_USER,
     DEAD_LETTER_REASON_CONTEXT_EXCEEDED_IRRECOVERABLE,
@@ -157,6 +158,33 @@ logger = logging.getLogger(__name__)
 # task_id) are bound at emit time via kwargs.
 from core.logging import get_logger as _get_structlog_logger
 _compaction_logger = _get_structlog_logger(worker_id="graph")
+
+def _prompt_cache_markers_disabled_by_env() -> bool:
+    """Operator kill switch for prompt-cache marker injection.
+
+    Set ``WORKER_PROMPT_CACHE_DISABLED`` to ``1`` / ``true`` / ``yes`` / ``on``
+    (case-insensitive) to suppress provider-specific cache marker injection
+    (Anthropic ``cache_control`` blocks, Bedrock ``cachePoint`` blocks) across
+    the entire worker. Intended as an emergency lever — a provider caching
+    regression, a suspected SDK bug — not a per-agent tuning knob. Per-agent
+    overrides are deliberately out of scope: toggling caching off never helps
+    a workload, so we don't expose it as customer-facing config.
+
+    Token-usage extraction is intentionally NOT gated on this flag. OpenAI
+    caches prefixes automatically regardless of whether we set markers; if
+    extraction were skipped, cached reads would be attributed as regular
+    input tokens and cost reporting would silently inflate by ~10×.
+    """
+    raw = os.environ.get("WORKER_PROMPT_CACHE_DISABLED", "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# Evaluated once at module load — env vars are immutable for a worker's
+# lifetime.  The Makefile's ``start-worker`` target forwards this variable,
+# so ``WORKER_PROMPT_CACHE_DISABLED=1 make start`` is sufficient to disable
+# caching fleet-wide in local dev without touching code or config.
+_PROMPT_CACHE_MARKERS_ENABLED: bool = not _prompt_cache_markers_disabled_by_env()
+
 
 _FUTURE_WORK_PROMISE_RE = re.compile(
     r"\b(?:i(?:'| wi)ll|let me|next i(?:'| wi)ll|now i(?:'| wi)ll)\s+"
@@ -652,8 +680,34 @@ class GraphExecutor:
         self.config = config
         self.pool = pool
         self.deps = deps or create_default_dependencies()
-        # Per-model cost rate cache: {model_name: (input_rate, output_rate)}
-        self._cost_rate_cache: dict[str, tuple[int, int]] = {}
+        if not _PROMPT_CACHE_MARKERS_ENABLED:
+            # One structured log at worker init — operators who set the kill
+            # switch want confirmation it took effect without tailing every
+            # task.  Fires once per GraphExecutor (i.e. once per worker).
+            logger.warning(
+                "prompt_cache.markers_disabled_via_env "
+                "worker_id=%s env=WORKER_PROMPT_CACHE_DISABLED",
+                getattr(config, "worker_id", "unknown"),
+            )
+        # Per-model cost rate cache:
+        # {model_name: (input_rate, output_rate,
+        #               cache_creation_rate, cache_read_rate)}
+        # ``cache_creation_rate`` / ``cache_read_rate`` are ``None`` when the
+        # model row doesn't specify them — callers fall back to 0 so the
+        # ledger under-reports rather than 10x over-charging on Anthropic
+        # cache reads.
+        self._cost_rate_cache: dict[
+            str, tuple[int, int, int | None, int | None]
+        ] = {}
+        # One-shot dedup for missing-cache-rate warnings: ``(model, bucket)``
+        # pairs already warned about within this executor's lifetime. Keeps
+        # a noisy agent loop from burying the log while still surfacing the
+        # first occurrence loudly.
+        self._missing_cache_rate_warned: set[tuple[str, str]] = set()
+        # Same dedup for the "markers skipped on unsupported model" path —
+        # fleets mixing GLM/Llama with Claude/Nova would otherwise log it
+        # on every task. ``(provider, model)`` pairs already reported.
+        self._cache_skip_logged: set[tuple[str, str]] = set()
         if s3_client is not None:
             self.s3_client = s3_client
         else:
@@ -1065,6 +1119,39 @@ class GraphExecutor:
 
         llm = await providers.create_llm(self.pool, provider, model_name, temperature)
 
+        # Prompt caching is a strategy plug-in keyed by provider. The agent
+        # loop below does not branch on provider — ``_cache_strategy``
+        # handles marker placement for Anthropic-family providers,
+        # passes through unchanged for OpenAI (automatic caching), and is
+        # a no-op for anything else. Adding a provider = register in
+        # ``executor.prompt_cache.__init__``; the agent loop never grows.
+        _cache_strategy = _get_cache_strategy(provider)
+        # Model-level gate: Bedrock hosts third-party families (GLM, Llama,
+        # Mistral, Cohere) that reject ``cachePoint`` with
+        # ``AccessDeniedException``. Skip marker injection for them — usage
+        # extraction still runs so any provider-side automatic caching is
+        # attributed correctly.
+        _model_supports_caching = _cache_strategy.supports_caching(model_name)
+        _apply_cache_markers = (
+            _PROMPT_CACHE_MARKERS_ENABLED and _model_supports_caching
+        )
+        # Log once per (provider, model) per executor lifetime. Fleets
+        # running a mix of cache-capable and cache-incapable models would
+        # otherwise emit this line on every task.
+        if (
+            _PROMPT_CACHE_MARKERS_ENABLED
+            and not _model_supports_caching
+        ):
+            skip_key = (provider, model_name)
+            if skip_key not in self._cache_skip_logged:
+                self._cache_skip_logged.add(skip_key)
+                logger.info(
+                    "prompt_cache.markers_skipped_unsupported_model "
+                    "provider=%s model=%s",
+                    provider,
+                    model_name,
+                )
+
         # Register built-in tools (pass sandbox and s3_client for sandbox tools)
         tools = self._get_tools(
             allowed_tools,
@@ -1245,10 +1332,12 @@ class GraphExecutor:
             "callbacks": [],
             # Follow-up fix: expose the same pricing lookup used by the main-
             # agent cost path so compaction.tier3 ledger rows record real
-            # cost_microdollars instead of always being 0. Bound-method
-            # reference — the LRU cache inside GraphExecutor persists across
-            # compaction firings within one task.
-            "pricing_lookup": self._get_model_cost_rates,
+            # cost_microdollars instead of always being 0.  The summariser
+            # contract expects ``(input_rate, output_rate)`` — we drop the
+            # cache-rate tail (summariser is a one-shot call, never cached)
+            # rather than threading a wider pricing shape through that code
+            # path just for compaction telemetry.
+            "pricing_lookup": self._summarizer_pricing_lookup,
         }
 
         async def agent_node(state: RuntimeState, config: RunnableConfig):
@@ -1302,7 +1391,21 @@ class GraphExecutor:
                 platform_system_message=platform_system_msg if platform_system_msg else None,
                 summarizer_context_window=_summarizer_context_window,
             )
-            messages_for_llm = pass_result.messages
+            # The compaction hook produced the final projection; layer
+            # provider-specific prompt-cache markers on top before the LLM
+            # call. The strategy returns a new list so the pre-marker shape
+            # stays available for logging / replay diagnostics.
+            #
+            # ``WORKER_PROMPT_CACHE_DISABLED=1`` short-circuits marker
+            # injection worker-wide. Token-usage extraction stays on so
+            # providers that cache automatically (OpenAI) still report
+            # correctly.
+            if _apply_cache_markers:
+                messages_for_llm = _cache_strategy.apply_cache_markers(
+                    pass_result.messages
+                )
+            else:
+                messages_for_llm = list(pass_result.messages)
             compaction_state_updates = pass_result.state_updates
 
             # Emit structured-log events from the hook and raise immediately
@@ -1649,31 +1752,74 @@ class GraphExecutor:
         workflow.add_edge(START, "agent")
         return workflow
 
-    async def _get_model_cost_rates(self, model_name: str) -> tuple[int, int]:
-        """Fetch input/output cost rates (microdollars per million tokens) from DB.
-        Returns (input_rate, output_rate). Caches per model within a task execution."""
+    async def _get_model_cost_rates(
+        self, model_name: str
+    ) -> tuple[int, int, int | None, int | None]:
+        """Fetch cost rates (microdollars per million tokens) from DB.
+
+        Returns ``(input_rate, output_rate, cache_creation_rate,
+        cache_read_rate)``. The trailing two values are ``None`` when the
+        model row omits them — :func:`_calculate_step_cost` then falls back
+        to ``0`` and logs once per model so the ledger under-reports rather
+        than silently over-charging (Anthropic cache reads are 10% of input
+        rate; defaulting a NULL to the full input rate would 10x the
+        customer's cache-read spend). Model-discovery re-seeding is the
+        fix path; the logged warning tells operators which row needs it.
+        Cached per-model for the lifetime of this GraphExecutor.
+
+        The legacy two-tuple signature used by some callers (notably the
+        Tier-3 summariser pricing lookup) is preserved at the call site by
+        unpacking only the first two values; this method is the source of
+        truth and returns the full quadruple.
+        """
         if model_name in self._cost_rate_cache:
             return self._cost_rate_cache[model_name]
 
         try:
             row = await self.pool.fetchrow(
-                "SELECT input_microdollars_per_million, output_microdollars_per_million FROM models WHERE model_id = $1",
+                """SELECT input_microdollars_per_million,
+                          output_microdollars_per_million,
+                          cache_creation_microdollars_per_million,
+                          cache_read_microdollars_per_million
+                     FROM models WHERE model_id = $1""",
                 model_name,
             )
             if row is None:
                 logger.warning("Model %s not found in models table; using zero cost rates", model_name)
-                rates = (0, 0)
+                rates: tuple[int, int, int | None, int | None] = (0, 0, None, None)
             else:
+                cache_creation = row["cache_creation_microdollars_per_million"]
+                cache_read = row["cache_read_microdollars_per_million"]
                 rates = (
                     int(row["input_microdollars_per_million"] or 0),
                     int(row["output_microdollars_per_million"] or 0),
+                    int(cache_creation) if cache_creation is not None else None,
+                    int(cache_read) if cache_read is not None else None,
                 )
         except Exception:
             logger.warning("Failed to fetch cost rates for model %s; using zero cost rates", model_name, exc_info=True)
-            rates = (0, 0)
+            rates = (0, 0, None, None)
 
         self._cost_rate_cache[model_name] = rates
         return rates
+
+    def _warn_missing_cache_rate(self, model_name: str, bucket: str) -> None:
+        """Emit a single warning per (model, bucket) when cache pricing is NULL.
+
+        Caller only invokes this on turns where the bucket actually
+        accumulated tokens, so a model whose cache is never hit stays
+        silent. Model-discovery re-seeding clears the condition.
+        """
+        key = (model_name, bucket)
+        if key in self._missing_cache_rate_warned:
+            return
+        self._missing_cache_rate_warned.add(key)
+        logger.warning(
+            "prompt_cache.missing_rate model=%s bucket=%s "
+            "(defaulting to 0; re-run model-discovery to seed)",
+            model_name,
+            bucket,
+        )
 
     async def _get_model_context_window(self, model_name: str) -> int:
         """Fetch the context window token count for a model from the models table.
@@ -1716,18 +1862,33 @@ class GraphExecutor:
             )
             return self._DEFAULT_MODEL_CONTEXT_WINDOW
 
+    async def _summarizer_pricing_lookup(
+        self, model_name: str
+    ) -> tuple[int, int]:
+        """Two-tuple adapter for the compaction summariser.
+
+        ``summarize_slice`` unpacks ``(input_rate, output_rate)`` directly;
+        it has no concept of cache tokens (the summariser is a single
+        non-cached call per firing). This shim preserves the legacy shape
+        while :meth:`_get_model_cost_rates` returns the full quadruple for
+        the main agent cost path.
+        """
+        rates = await self._get_model_cost_rates(model_name)
+        return (rates[0], rates[1])
+
     @staticmethod
-    def _extract_tokens(metadata: dict) -> tuple[int, int]:
-        """Returns (input_tokens, output_tokens). Falls back to (0, 0) if not found."""
-        usage = (
-            metadata.get("usage")              # Anthropic, Google
-            or metadata.get("token_usage")     # OpenAI via LangChain
-            or metadata.get("usage_metadata")  # Bedrock
-            or {}
-        )
-        input_t = usage.get("input_tokens") or usage.get("prompt_tokens") or 0
-        output_t = usage.get("output_tokens") or usage.get("completion_tokens") or 0
-        return (int(input_t), int(output_t))
+    def _extract_token_usage(
+        metadata: dict, provider: str
+    ) -> TokenUsage:
+        """Delegate to the provider's :class:`PromptCacheStrategy`.
+
+        Centralising this keeps ``_calculate_step_cost`` provider-neutral —
+        any provider-specific metadata-key handling lives inside the
+        strategy, which is the single place callers add branches when
+        onboarding a new LLM.
+        """
+        strategy = _get_cache_strategy(provider)
+        return strategy.extract_token_usage(metadata)
 
     async def _record_step_cost(
         self, conn, task_id: str, tenant_id: str, agent_id: str,
@@ -1799,17 +1960,71 @@ class GraphExecutor:
 
         return (int(cumulative_task_cost), int(hourly_cost or 0))
 
-    async def _calculate_step_cost(self, response_metadata: dict, model_name: str) -> tuple[int, dict]:
+    async def _calculate_step_cost(
+        self,
+        response_metadata: dict,
+        model_name: str,
+        *,
+        provider: str | None = None,
+    ) -> tuple[int, dict]:
         """Extract tokens from response metadata and calculate cost in microdollars.
-        Returns (cost_microdollars, execution_metadata_dict)."""
-        input_tokens, output_tokens = self._extract_tokens(response_metadata)
-        input_rate, output_rate = await self._get_model_cost_rates(model_name)
-        cost_microdollars = (input_tokens * input_rate + output_tokens * output_rate) // 1_000_000
-        execution_metadata = {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
+
+        ``provider`` drives which :class:`PromptCacheStrategy` parses the
+        response. When omitted (legacy call sites — compaction summariser,
+        tests) we default to the no-op strategy, which still correctly
+        extracts ``input_tokens`` / ``output_tokens`` from the shapes this
+        project encounters but reports zero cache tokens. The main agent
+        cost path threads the real provider through.
+
+        Cache rates default to ``0`` when the model row omits them (NULL
+        in ``models.cache_creation_microdollars_per_million`` /
+        ``cache_read_microdollars_per_million``). Falling back to the input
+        rate would 10x cache-read cost on Anthropic (whose real rate is
+        10% of input); under-reporting is the safer default until
+        model-discovery re-seeds the row. ``_warn_missing_cache_rate``
+        emits a single warning per model so operators can act.
+        """
+        usage = self._extract_token_usage(
+            response_metadata, provider or "noop"
+        )
+        (
+            input_rate,
+            output_rate,
+            cache_creation_rate,
+            cache_read_rate,
+        ) = await self._get_model_cost_rates(model_name)
+
+        if cache_creation_rate is None and usage.cache_creation_input_tokens:
+            self._warn_missing_cache_rate(model_name, "cache_creation")
+        if cache_read_rate is None and usage.cache_read_input_tokens:
+            self._warn_missing_cache_rate(model_name, "cache_read")
+
+        effective_cache_creation_rate = cache_creation_rate or 0
+        effective_cache_read_rate = cache_read_rate or 0
+
+        cost_microdollars = (
+            usage.input_tokens * input_rate
+            + usage.output_tokens * output_rate
+            + usage.cache_creation_input_tokens * effective_cache_creation_rate
+            + usage.cache_read_input_tokens * effective_cache_read_rate
+        ) // 1_000_000
+
+        execution_metadata: dict[str, Any] = {
+            "input_tokens": usage.input_tokens,
+            "output_tokens": usage.output_tokens,
             "model": model_name,
         }
+        # Surface cache counters only when non-zero — keeps the metadata
+        # shape stable for non-caching providers (OpenAI automatic caching
+        # still surfaces the counters when a hit occurs).
+        if usage.cache_creation_input_tokens:
+            execution_metadata["cache_creation_input_tokens"] = (
+                usage.cache_creation_input_tokens
+            )
+        if usage.cache_read_input_tokens:
+            execution_metadata["cache_read_input_tokens"] = (
+                usage.cache_read_input_tokens
+            )
         return (cost_microdollars, execution_metadata)
 
     async def _inject_input_files(self, sandbox, task_id: str, tenant_id: str) -> list[str]:
@@ -2805,8 +3020,12 @@ class GraphExecutor:
                             resume_value = payload  # approval payload passed through
                             initial_input = Command(resume=resume_value)
 
-                # Track model name for per-step cost calculation
+                # Track model + provider for per-step cost calculation. The
+                # provider threads into ``_calculate_step_cost`` so the
+                # prompt-cache strategy can parse cache-token counters out
+                # of the response metadata in a provider-specific way.
                 model_name = agent_config.get("model", "claude-3-5-sonnet-latest")
+                provider = agent_config.get("provider", "anthropic")
                 # Track cumulative costs for Task 4 budget enforcement (added later)
                 cumulative_task_cost = 0
                 hourly_cost = 0
@@ -2865,7 +3084,7 @@ class GraphExecutor:
                                     if hasattr(ai_msg, 'usage_metadata') and ai_msg.usage_metadata:
                                         resp_meta.setdefault("usage_metadata", ai_msg.usage_metadata)
                                     step_cost, execution_metadata = await self._calculate_step_cost(
-                                        resp_meta, model_name
+                                        resp_meta, model_name, provider=provider,
                                     )
                                     async with self.pool.acquire() as cost_conn:
                                         checkpoint_id = await fetch_latest_checkpoint_id(

--- a/services/worker-service/executor/prompt_cache/__init__.py
+++ b/services/worker-service/executor/prompt_cache/__init__.py
@@ -1,0 +1,45 @@
+"""Provider-agnostic prompt caching.
+
+Adding a new provider:
+
+1. Create a new strategy class in its own module under this package that
+   implements :class:`PromptCacheStrategy` — at minimum
+   :meth:`apply_cache_markers` (can be a no-op if the provider caches
+   automatically) and :meth:`extract_token_usage` (returning a
+   :class:`TokenUsage` with ``cache_read_input_tokens`` populated from
+   whatever shape the provider uses).
+2. Register it in :data:`_REGISTRY` below under the same provider id that
+   :func:`executor.providers.create_llm` accepts.
+
+``executor.graph`` obtains a strategy via :func:`get_strategy` and otherwise
+stays provider-neutral — no ``if provider == "..."`` branches for cache
+handling live in the agent loop.
+"""
+
+from __future__ import annotations
+
+from executor.prompt_cache.anthropic import AnthropicPromptCacheStrategy
+from executor.prompt_cache.bedrock import BedrockPromptCacheStrategy
+from executor.prompt_cache.noop import NoopPromptCacheStrategy
+from executor.prompt_cache.openai import OpenAIPromptCacheStrategy
+from executor.prompt_cache.strategy import PromptCacheStrategy, TokenUsage
+
+_REGISTRY: dict[str, PromptCacheStrategy] = {
+    "anthropic": AnthropicPromptCacheStrategy(),
+    "bedrock": BedrockPromptCacheStrategy(),
+    "openai": OpenAIPromptCacheStrategy(),
+}
+
+_NOOP = NoopPromptCacheStrategy()
+
+
+def get_strategy(provider: str) -> PromptCacheStrategy:
+    """Return the cache strategy for *provider*, or the no-op fallback."""
+    return _REGISTRY.get(provider, _NOOP)
+
+
+__all__ = [
+    "PromptCacheStrategy",
+    "TokenUsage",
+    "get_strategy",
+]

--- a/services/worker-service/executor/prompt_cache/anthropic.py
+++ b/services/worker-service/executor/prompt_cache/anthropic.py
@@ -1,0 +1,198 @@
+"""Anthropic native prompt-cache strategy.
+
+Marker placement rationale
+--------------------------
+Anthropic allows up to four ``cache_control`` breakpoints per request.  We
+use at most two — enough for a high hit-rate in the multi-turn agent loop
+without spending breakpoints we can't justify:
+
+1. **Trailing SystemMessage.** The projection always leads with one or more
+   ``SystemMessage``s (platform system + user system + optional compaction
+   summary). Marking the last block of the last system message caches the
+   entire system region as a single prefix. The summary message mutates
+   only when Tier-3 fires, so this breakpoint stays valid across most turns.
+2. **Last message overall.** Usually a ``HumanMessage`` or ``ToolMessage``.
+   This is the sliding-window breakpoint: on turn ``N+1``, what was the
+   tail on turn ``N`` becomes an interior prefix, and the request enjoys a
+   cache hit for everything up to that point.
+
+Content reshaping
+-----------------
+Anthropic requires cache markers to live on individual content blocks, so
+if a message's ``content`` is a plain string we convert it to the list
+shape ``[{"type": "text", "text": ..., "cache_control": {...}}]``. List
+content is handled by mutating the last text-bearing block in place (on a
+copy) so provider-shaped blocks carrying prompt caching keys / reasoning
+state from earlier turns round-trip unchanged.
+
+Usage extraction
+----------------
+LangChain's ``ChatAnthropic`` surfaces cache tokens in
+``response.usage_metadata`` as ``input_token_details = {"cache_creation":
+N, "cache_read": M}`` and in the raw ``response_metadata["usage"]`` as
+``cache_creation_input_tokens`` / ``cache_read_input_tokens``. We read
+both shapes so older and newer LangChain versions both work, and so the
+native Anthropic SDK shape (used by the direct-SDK summariser path) is
+covered.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+from executor.prompt_cache.strategy import PromptCacheStrategy, TokenUsage
+
+
+_CACHE_CONTROL_EPHEMERAL = {"type": "ephemeral"}
+
+
+def _apply_marker_to_content(content: Any) -> Any:
+    """Return a new content value with a cache_control marker on the last
+    text-bearing block.
+
+    * ``str`` → wrap in a single text block with the marker.
+    * ``list`` → copy, find the last block that carries text (``type: text``
+      or a bare ``{"text": ...}`` dict), and add the marker in place.
+      Non-text trailing blocks (e.g. ``tool_use``, ``thinking``) are passed
+      over so we don't attach a marker to a block shape the provider doesn't
+      accept it on.
+    * Anything else → returned unchanged (defensive; the projection
+      shouldn't produce non-str / non-list content in practice).
+    """
+    if isinstance(content, str):
+        if not content:
+            # Empty string — no meaningful prefix to cache; skip.
+            return content
+        return [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": dict(_CACHE_CONTROL_EPHEMERAL),
+            }
+        ]
+    if isinstance(content, list):
+        new_content = deepcopy(content)
+        for idx in range(len(new_content) - 1, -1, -1):
+            block = new_content[idx]
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            has_text = isinstance(block.get("text"), str) and block["text"]
+            # Accept canonical text blocks and bare-dict {"text": "..."}
+            # shapes. Skip tool_use / tool_result / thinking / image blocks —
+            # cache_control on those shapes is not meaningful for our
+            # placement and some provider SDKs reject it.
+            if block_type in (None, "text") and has_text:
+                block["cache_control"] = dict(_CACHE_CONTROL_EPHEMERAL)
+                return new_content
+        # No eligible block found — leave content unchanged.
+        return new_content
+    return content
+
+
+def _mark_message(msg: BaseMessage) -> BaseMessage:
+    """Return a copy of *msg* with a cache marker on the last text block."""
+    new_content = _apply_marker_to_content(msg.content)
+    if new_content is msg.content:
+        return msg
+    return msg.model_copy(update={"content": new_content})
+
+
+class AnthropicPromptCacheStrategy(PromptCacheStrategy):
+    provider = "anthropic"
+
+    def supports_caching(self, model: str) -> bool:
+        # Every current Claude model on the native Anthropic API accepts
+        # cache_control (Claude 3, 3.5, 3.7, 4.x). We don't gate by model
+        # here — if a future model drops support, the call still succeeds
+        # (the field is silently ignored) and we'll notice via metrics.
+        return True
+
+    def apply_cache_markers(
+        self, messages: list[BaseMessage]
+    ) -> list[BaseMessage]:
+        if not messages:
+            return list(messages)
+
+        out = list(messages)
+        last_system_idx: int | None = None
+        for idx in range(len(out) - 1, -1, -1):
+            if isinstance(out[idx], SystemMessage):
+                last_system_idx = idx
+                break
+
+        if last_system_idx is not None:
+            out[last_system_idx] = _mark_message(out[last_system_idx])
+
+        # Mark the tail message too — gives us the sliding-window breakpoint.
+        # Skip the SystemMessage case (already marked) to avoid double-
+        # marking when the projection is system-only (shouldn't happen in the
+        # real agent loop, but be defensive).
+        tail_idx = len(out) - 1
+        if tail_idx != last_system_idx:
+            out[tail_idx] = _mark_message(out[tail_idx])
+
+        return out
+
+    def extract_token_usage(self, response_metadata: dict) -> TokenUsage:
+        # Anthropic usage surfaces in two shapes that DISAGREE on what
+        # ``input_tokens`` includes:
+        #   * Native SDK / raw response (``response_metadata["usage"]``):
+        #     ``input_tokens`` excludes cached tokens — total prompt =
+        #     input + cache_creation + cache_read.
+        #   * LangChain-normalized (``usage_metadata``): langchain-anthropic
+        #     rolls cache_read + cache_creation INTO ``input_tokens`` so
+        #     total_tokens math works out. See
+        #     ``langchain_anthropic.chat_models._create_usage_metadata`` —
+        #     "Calculate total input tokens: Anthropic's input_tokens
+        #     excludes cached tokens, so we manually add..."
+        #
+        # TokenUsage's contract is that ``input_tokens`` is the NON-CACHED
+        # portion. Normalize the LangChain shape by subtracting cache
+        # counters; the native shape needs no adjustment. Reading both
+        # lets the summarizer (direct SDK) and the agent loop (LangChain)
+        # share a single extractor.
+        usage_metadata = response_metadata.get("usage_metadata") or {}
+        usage_native = response_metadata.get("usage") or {}
+
+        # LangChain standardised input_token_details in langchain-core 0.3+;
+        # fall back to the native Anthropic keys for defence in depth.
+        details = usage_metadata.get("input_token_details") or {}
+        cache_creation = int(
+            details.get("cache_creation")
+            or usage_metadata.get("cache_creation_input_tokens")
+            or usage_native.get("cache_creation_input_tokens")
+            or 0
+        )
+        cache_read = int(
+            details.get("cache_read")
+            or usage_metadata.get("cache_read_input_tokens")
+            or usage_native.get("cache_read_input_tokens")
+            or 0
+        )
+
+        output_t = int(
+            usage_metadata.get("output_tokens")
+            or usage_native.get("output_tokens")
+            or 0
+        )
+
+        # Prefer the native shape (unambiguous). Fall back to LangChain
+        # shape with the inclusive-total adjustment.
+        if usage_native.get("input_tokens") is not None:
+            input_t = int(usage_native["input_tokens"] or 0)
+        elif usage_metadata.get("input_tokens") is not None:
+            raw = int(usage_metadata["input_tokens"] or 0)
+            input_t = max(0, raw - cache_creation - cache_read)
+        else:
+            input_t = 0
+
+        return TokenUsage(
+            input_tokens=input_t,
+            output_tokens=output_t,
+            cache_creation_input_tokens=cache_creation,
+            cache_read_input_tokens=cache_read,
+        )

--- a/services/worker-service/executor/prompt_cache/bedrock.py
+++ b/services/worker-service/executor/prompt_cache/bedrock.py
@@ -1,0 +1,177 @@
+"""Bedrock Converse prompt-cache strategy.
+
+Bedrock's Converse API exposes prompt caching via a dedicated
+``{"cachePoint": {"type": "default"}}`` block inserted *after* the block
+you want cached — the native Anthropic ``cache_control`` inline field on a
+text block is silently dropped by ``langchain-aws`` when it translates
+messages into Converse format (verified against ``langchain-aws==1.4.0``,
+``_lc_content_to_bedrock``). Using the Anthropic strategy verbatim on
+Bedrock would therefore produce requests that *look* cache-enabled in the
+LangChain layer but arrive uncached at the provider.
+
+Marker placement matches the Anthropic strategy conceptually — one
+breakpoint on the trailing system region, one on the tail message — but
+the *mechanism* differs: we convert string content to a list shape and
+append a ``cachePoint`` block rather than mutating a text block's
+``cache_control`` field. The translator forwards the ``cachePoint`` block
+unchanged because of its ``"type" not in block`` pass-through branch.
+
+Usage extraction reuses :class:`AnthropicPromptCacheStrategy`'s logic
+because Bedrock Converse reports cache tokens through the same
+``usage_metadata.input_token_details`` shape (``cache_creation`` /
+``cache_read`` keys) after LangChain normalisation.
+"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from typing import Any
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+from executor.prompt_cache.anthropic import AnthropicPromptCacheStrategy
+
+
+_CACHE_POINT_BLOCK: dict[str, Any] = {"cachePoint": {"type": "default"}}
+
+
+# Bedrock hosts many model families but only Anthropic Claude and Amazon
+# Nova currently accept prompt caching. Sending ``cachePoint`` to any other
+# family (GLM, Llama, Mistral, Cohere, AI21, Jamba) trips
+# ``AccessDeniedException: ... did not allow prompt caching`` and dead-letters
+# the task. Allowlist the two known-good markers; anything else is a no-op.
+#
+# Cross-region inference profiles prepend a region prefix to the model id
+# (see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).
+# Known prefixes as of 2026-04: ``us.``, ``us-gov.``, ``eu.``, ``apac.``,
+# ``au.``, ``ca.``, ``jp.``, ``global.``. Strip the first region segment
+# before the allowlist check. ``us-gov`` is listed before ``us`` so the
+# longer match wins.
+_BEDROCK_CACHE_CAPABLE_MARKERS: tuple[str, ...] = (
+    "anthropic.",
+    "amazon.nova-",
+)
+_BEDROCK_REGION_PREFIX_RE = re.compile(
+    r"^(us-gov|us|eu|apac|au|ca|jp|global)\."
+)
+
+
+def _bedrock_supports_caching(model: str) -> bool:
+    """Return True when *model* accepts Bedrock ``cachePoint`` markers.
+
+    Accepts bare model ids (``anthropic.claude-3-5-sonnet-...``), regional
+    inference profile ids (``us.anthropic.claude-3-5-sonnet-...``,
+    ``jp.amazon.nova-lite-v1:0``, ``us-gov.anthropic.claude-3-haiku-...``),
+    and full ARNs (``arn:aws:bedrock:us-east-1::foundation-model/anthropic.
+    claude-...`` or ``...:inference-profile/us.anthropic.claude-...``). The
+    ARN path falls back to a substring search so a future ARN layout
+    change doesn't silently turn caching off for the whole fleet.
+    """
+    if not model:
+        return False
+    lower = model.strip().lower()
+    # ARN / resource-path shape — match the family marker anywhere after a
+    # ``/`` or ``.`` separator. Accepts both foundation-model and
+    # inference-profile ARNs without prescribing the exact layout.
+    if lower.startswith("arn:"):
+        return any(
+            f"/{marker}" in lower or f".{marker}" in lower
+            for marker in _BEDROCK_CACHE_CAPABLE_MARKERS
+        )
+    normalized = _BEDROCK_REGION_PREFIX_RE.sub("", lower)
+    return any(
+        normalized.startswith(marker)
+        for marker in _BEDROCK_CACHE_CAPABLE_MARKERS
+    )
+
+
+def _has_cache_point_tail(content: Any) -> bool:
+    """Return True when *content* already ends with a cachePoint block."""
+    if not isinstance(content, list) or not content:
+        return False
+    tail = content[-1]
+    return (
+        isinstance(tail, dict)
+        and isinstance(tail.get("cachePoint"), dict)
+        and tail["cachePoint"].get("type") is not None
+    )
+
+
+def _append_cache_point(content: Any) -> Any:
+    """Return a new content list with a trailing cachePoint block.
+
+    * ``str`` → converted to ``[{"type": "text", "text": content},
+      cachePoint]``.
+    * ``list`` → deep-copied, cachePoint appended at the tail. Empty
+      lists and lists with no text-bearing block are left unchanged
+      (a cachePoint with nothing preceding it is not meaningful).
+    * Anything else → unchanged.
+    """
+    if isinstance(content, str):
+        if not content:
+            return content
+        return [
+            {"type": "text", "text": content},
+            dict(_CACHE_POINT_BLOCK),
+        ]
+    if isinstance(content, list):
+        if not content:
+            return content
+        if _has_cache_point_tail(content):
+            return content
+        # Only attach when there is at least one text-bearing block to
+        # cache — a cachePoint after pure tool_use blocks is a no-op from
+        # the Converse API's perspective and clutters the request.
+        has_text = any(
+            isinstance(b, dict)
+            and (
+                (b.get("type") == "text" and b.get("text"))
+                or (b.get("type") is None and isinstance(b.get("text"), str) and b["text"])
+            )
+            for b in content
+        )
+        if not has_text:
+            return content
+        new_content = deepcopy(content)
+        new_content.append(dict(_CACHE_POINT_BLOCK))
+        return new_content
+    return content
+
+
+def _mark_message(msg: BaseMessage) -> BaseMessage:
+    new_content = _append_cache_point(msg.content)
+    if new_content is msg.content:
+        return msg
+    return msg.model_copy(update={"content": new_content})
+
+
+class BedrockPromptCacheStrategy(AnthropicPromptCacheStrategy):
+    """Bedrock-specific marker placement; Anthropic-shaped usage extraction."""
+
+    provider = "bedrock"
+
+    def supports_caching(self, model: str) -> bool:
+        return _bedrock_supports_caching(model)
+
+    def apply_cache_markers(
+        self, messages: list[BaseMessage]
+    ) -> list[BaseMessage]:
+        if not messages:
+            return list(messages)
+
+        out = list(messages)
+        last_system_idx: int | None = None
+        for idx in range(len(out) - 1, -1, -1):
+            if isinstance(out[idx], SystemMessage):
+                last_system_idx = idx
+                break
+
+        if last_system_idx is not None:
+            out[last_system_idx] = _mark_message(out[last_system_idx])
+
+        tail_idx = len(out) - 1
+        if tail_idx != last_system_idx:
+            out[tail_idx] = _mark_message(out[tail_idx])
+
+        return out

--- a/services/worker-service/executor/prompt_cache/noop.py
+++ b/services/worker-service/executor/prompt_cache/noop.py
@@ -1,0 +1,35 @@
+"""No-op strategy for providers with no prompt-caching support."""
+
+from __future__ import annotations
+
+from langchain_core.messages import BaseMessage
+
+from executor.prompt_cache.strategy import PromptCacheStrategy, TokenUsage
+
+
+class NoopPromptCacheStrategy(PromptCacheStrategy):
+    provider = "noop"
+
+    def supports_caching(self, model: str) -> bool:
+        return False
+
+    def apply_cache_markers(
+        self, messages: list[BaseMessage]
+    ) -> list[BaseMessage]:
+        return list(messages)
+
+    def extract_token_usage(self, response_metadata: dict) -> TokenUsage:
+        usage = (
+            response_metadata.get("usage")
+            or response_metadata.get("token_usage")
+            or response_metadata.get("usage_metadata")
+            or {}
+        )
+        input_t = usage.get("input_tokens") or usage.get("prompt_tokens") or 0
+        output_t = (
+            usage.get("output_tokens") or usage.get("completion_tokens") or 0
+        )
+        return TokenUsage(
+            input_tokens=int(input_t),
+            output_tokens=int(output_t),
+        )

--- a/services/worker-service/executor/prompt_cache/openai.py
+++ b/services/worker-service/executor/prompt_cache/openai.py
@@ -1,0 +1,80 @@
+"""OpenAI prompt-cache strategy.
+
+OpenAI caches prompt prefixes automatically once a request exceeds ~1024
+tokens — there is no opt-in marker and no cache-creation concept exposed
+to callers, so :meth:`apply_cache_markers` is a no-op. Cache hits surface
+through ``usage.prompt_tokens_details.cached_tokens`` on the response and
+(in LangChain) through ``usage_metadata.input_token_details.cache_read``.
+
+We populate :attr:`TokenUsage.cache_read_input_tokens` from whichever shape
+is present so downstream cost accounting and Langfuse emission can track
+OpenAI cache-hit spend separately from uncached input tokens. Cache
+*creation* is always zero for OpenAI (the provider absorbs the cost).
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import BaseMessage
+
+from executor.prompt_cache.strategy import PromptCacheStrategy, TokenUsage
+
+
+class OpenAIPromptCacheStrategy(PromptCacheStrategy):
+    provider = "openai"
+
+    def supports_caching(self, model: str) -> bool:
+        # OpenAI caches prefixes automatically for all current chat models
+        # once the prompt crosses ~1024 tokens — there is no marker to
+        # reject, so this is always safe to return True.
+        return True
+
+    def apply_cache_markers(
+        self, messages: list[BaseMessage]
+    ) -> list[BaseMessage]:
+        return list(messages)
+
+    def extract_token_usage(self, response_metadata: dict) -> TokenUsage:
+        usage_metadata = response_metadata.get("usage_metadata") or {}
+        # ``token_usage`` is LangChain's canonical OpenAI shape on
+        # response_metadata; ``usage`` is the native OpenAI Python SDK
+        # shape (used by any code that bypasses LangChain's translator).
+        usage_native = (
+            response_metadata.get("token_usage")
+            or response_metadata.get("usage")
+            or {}
+        )
+
+        input_t = int(
+            usage_metadata.get("input_tokens")
+            or usage_native.get("prompt_tokens")
+            or usage_native.get("input_tokens")
+            or 0
+        )
+        output_t = int(
+            usage_metadata.get("output_tokens")
+            or usage_native.get("completion_tokens")
+            or usage_native.get("output_tokens")
+            or 0
+        )
+
+        details = usage_metadata.get("input_token_details") or {}
+        prompt_details = usage_native.get("prompt_tokens_details") or {}
+        cache_read = int(
+            details.get("cache_read")
+            or prompt_details.get("cached_tokens")
+            or 0
+        )
+
+        # OpenAI reports ``prompt_tokens`` as the total (cached + uncached).
+        # Normalise ``input_tokens`` to mean the non-cached portion so the
+        # ``TokenUsage`` invariant (``total = input + creation + read``)
+        # holds across providers.
+        if cache_read and input_t >= cache_read:
+            input_t = input_t - cache_read
+
+        return TokenUsage(
+            input_tokens=input_t,
+            output_tokens=output_t,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=cache_read,
+        )

--- a/services/worker-service/executor/prompt_cache/strategy.py
+++ b/services/worker-service/executor/prompt_cache/strategy.py
@@ -1,0 +1,83 @@
+"""Provider-agnostic prompt caching strategy.
+
+Prompt caching mechanisms differ per provider — Anthropic wants explicit
+``cache_control`` blocks on content, Bedrock Converse uses the same shape via
+LangChain's converse translator, OpenAI caches automatically and reports
+cached tokens in ``prompt_tokens_details``, and newer providers will bring
+their own. To keep the agent loop provider-neutral we funnel all of that
+through a :class:`PromptCacheStrategy` with two responsibilities:
+
+1. :meth:`apply_cache_markers` — given the final projection the agent is
+   about to send, annotate it with provider-specific cache hints. Must be
+   pure (return a new list) so callers can log/replay the pre- and
+   post-marker shapes without confusion.
+2. :meth:`extract_token_usage` — parse the provider's response metadata into
+   a common :class:`TokenUsage` with explicit cache creation / cache read
+   counters. Downstream cost accounting and Langfuse emission operate on the
+   common shape and never look at provider-specific keys directly.
+
+Adding a new provider is a one-file change in this package plus a registry
+entry at the bottom — ``executor.graph`` does not grow provider branches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from langchain_core.messages import BaseMessage
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Provider-neutral token counts.
+
+    ``cache_creation_input_tokens`` is Anthropic-specific (tokens written to
+    the cache on a cache-miss turn). ``cache_read_input_tokens`` is the
+    universal cache-hit counter — Anthropic reports it natively, Bedrock
+    returns the same name via Converse, OpenAI surfaces it as
+    ``prompt_tokens_details.cached_tokens``.
+
+    ``input_tokens`` excludes cache creation + cache read tokens; sum all
+    three to recover the provider's total prompt token count.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+    @property
+    def total_prompt_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+
+class PromptCacheStrategy(Protocol):
+    """Strategy contract — see module docstring."""
+
+    provider: str
+
+    def apply_cache_markers(
+        self, messages: list[BaseMessage]
+    ) -> list[BaseMessage]:
+        """Return a new message list with provider-specific cache hints."""
+        ...
+
+    def extract_token_usage(self, response_metadata: dict) -> TokenUsage:
+        """Parse the LLM's response metadata into a :class:`TokenUsage`."""
+        ...
+
+    def supports_caching(self, model: str) -> bool:
+        """Return True when *model* accepts this strategy's cache markers.
+
+        Primarily matters for Bedrock, which hosts many third-party model
+        families (Claude, Nova, GLM, Llama, Mistral, Cohere) — only Claude
+        and Nova accept ``cachePoint`` blocks; everything else returns
+        ``AccessDeniedException``. For Anthropic-native and OpenAI the
+        answer is effectively always True.
+        """
+        ...

--- a/services/worker-service/tests/test_langfuse_cost.py
+++ b/services/worker-service/tests/test_langfuse_cost.py
@@ -20,32 +20,73 @@ def _make_executor() -> GraphExecutor:
 
 
 # ---------------------------------------------------------------------------
-# _extract_tokens
+# _extract_token_usage
 # ---------------------------------------------------------------------------
+
+def _basic(metadata: dict, provider: str = "noop"):
+    usage = GraphExecutor._extract_token_usage(metadata, provider)
+    return (usage.input_tokens, usage.output_tokens)
+
 
 def test_extract_tokens_anthropic():
     metadata = {"usage": {"input_tokens": 100, "output_tokens": 50}}
-    assert GraphExecutor._extract_tokens(metadata) == (100, 50)
+    # The anthropic strategy reads the native ``usage`` shape directly.
+    assert _basic(metadata, "anthropic") == (100, 50)
 
 
 def test_extract_tokens_openai():
     metadata = {"token_usage": {"prompt_tokens": 100, "completion_tokens": 50}}
-    assert GraphExecutor._extract_tokens(metadata) == (100, 50)
+    assert _basic(metadata, "openai") == (100, 50)
 
 
 def test_extract_tokens_bedrock():
     metadata = {"usage_metadata": {"input_tokens": 100, "output_tokens": 50}}
-    assert GraphExecutor._extract_tokens(metadata) == (100, 50)
+    assert _basic(metadata, "bedrock") == (100, 50)
 
 
 def test_extract_tokens_empty():
-    assert GraphExecutor._extract_tokens({}) == (0, 0)
+    assert _basic({}, "noop") == (0, 0)
 
 
 def test_extract_tokens_partial():
     """Only input_tokens present, no output key — output should fall back to 0."""
     metadata = {"usage": {"input_tokens": 100}}
-    assert GraphExecutor._extract_tokens(metadata) == (100, 0)
+    assert _basic(metadata, "noop") == (100, 0)
+
+
+def test_extract_tokens_anthropic_cache_counters():
+    """Anthropic cache hit → cache_read_input_tokens populated; cost path
+    sees the non-cached portion of input as ``input_tokens``."""
+    metadata = {
+        "usage": {
+            "input_tokens": 20,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 1000,
+        }
+    }
+    usage = GraphExecutor._extract_token_usage(metadata, "anthropic")
+    assert usage.input_tokens == 20
+    assert usage.output_tokens == 50
+    assert usage.cache_creation_input_tokens == 5
+    assert usage.cache_read_input_tokens == 1000
+    assert usage.total_prompt_tokens == 1025
+
+
+def test_extract_tokens_openai_cached_tokens():
+    """OpenAI reports cached hits via prompt_tokens_details.cached_tokens;
+    the strategy normalises ``input_tokens`` to the non-cached portion."""
+    metadata = {
+        "token_usage": {
+            "prompt_tokens": 1200,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {"cached_tokens": 1000},
+        }
+    }
+    usage = GraphExecutor._extract_token_usage(metadata, "openai")
+    assert usage.input_tokens == 200
+    assert usage.cache_read_input_tokens == 1000
+    assert usage.output_tokens == 50
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +101,8 @@ async def test_calculate_cost_known_model():
     executor.pool.fetchrow = AsyncMock(return_value={
         "input_microdollars_per_million": input_rate,
         "output_microdollars_per_million": output_rate,
+        "cache_creation_microdollars_per_million": None,
+        "cache_read_microdollars_per_million": None,
     })
 
     input_tokens = 200
@@ -89,6 +132,8 @@ async def test_calculate_cost_returns_metadata():
     executor.pool.fetchrow = AsyncMock(return_value={
         "input_microdollars_per_million": 1_000,
         "output_microdollars_per_million": 2_000,
+        "cache_creation_microdollars_per_million": None,
+        "cache_read_microdollars_per_million": None,
     })
 
     model = "test-model"
@@ -99,6 +144,114 @@ async def test_calculate_cost_returns_metadata():
     assert exec_meta["input_tokens"] == 42
     assert exec_meta["output_tokens"] == 17
     assert exec_meta["model"] == model
+
+
+@pytest.mark.asyncio
+async def test_calculate_cost_null_cache_rates_default_to_zero():
+    """A row predating migration 0022 (or any model not yet re-seeded by
+    model-discovery) has NULL cache rates. The previous fallback charged
+    cache reads at the full input rate — which is 10× Anthropic's real
+    rate and would silently over-bill tenants on every cache hit. New
+    contract: NULL → 0, and emit a single warning per (model, bucket).
+    """
+    executor = _make_executor()
+    executor.pool.fetchrow = AsyncMock(return_value={
+        "input_microdollars_per_million": 3_000_000,
+        "output_microdollars_per_million": 15_000_000,
+        "cache_creation_microdollars_per_million": None,
+        "cache_read_microdollars_per_million": None,
+    })
+
+    metadata = {
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 5_000,
+        }
+    }
+    cost, exec_meta = await executor._calculate_step_cost(
+        metadata, "claude-haiku-4-5", provider="anthropic"
+    )
+
+    # cache_creation + cache_read contribute $0 when rates are NULL; only
+    # the uncached input and output portions bill. Previously this would
+    # have been (100 + 200 + 5000) * 3_000_000 → 10x over-charge on the
+    # cache bucket.
+    expected = (100 * 3_000_000 + 50 * 15_000_000) // 1_000_000
+    assert cost == expected
+    # Counters still surface in execution_metadata for observability.
+    assert exec_meta["cache_creation_input_tokens"] == 200
+    assert exec_meta["cache_read_input_tokens"] == 5_000
+
+
+@pytest.mark.asyncio
+async def test_calculate_cost_honors_populated_cache_rates():
+    """When the row has real cache pricing, the four buckets price
+    independently — regression guard against the NULL fix also zeroing
+    out seeded rates."""
+    executor = _make_executor()
+    executor.pool.fetchrow = AsyncMock(return_value={
+        "input_microdollars_per_million": 3_000_000,
+        "output_microdollars_per_million": 15_000_000,
+        "cache_creation_microdollars_per_million": 3_750_000,  # 1.25x
+        "cache_read_microdollars_per_million": 300_000,         # 0.10x
+    })
+
+    metadata = {
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 200,
+            "cache_read_input_tokens": 5_000,
+        }
+    }
+    cost, _ = await executor._calculate_step_cost(
+        metadata, "claude-haiku-4-5", provider="anthropic"
+    )
+    expected = (
+        100 * 3_000_000
+        + 50 * 15_000_000
+        + 200 * 3_750_000
+        + 5_000 * 300_000
+    ) // 1_000_000
+    assert cost == expected
+
+
+@pytest.mark.asyncio
+async def test_missing_cache_rate_warning_deduped_per_model_bucket(caplog):
+    """The missing-cache-rate log fires at most once per (model, bucket)
+    within the executor's lifetime. Agents looping with NULL rates would
+    otherwise bury the log."""
+    import logging
+    executor = _make_executor()
+    executor.pool.fetchrow = AsyncMock(return_value={
+        "input_microdollars_per_million": 3_000_000,
+        "output_microdollars_per_million": 15_000_000,
+        "cache_creation_microdollars_per_million": None,
+        "cache_read_microdollars_per_million": None,
+    })
+
+    metadata = {
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 100,
+        }
+    }
+
+    with caplog.at_level(logging.WARNING, logger="executor.graph"):
+        for _ in range(5):
+            await executor._calculate_step_cost(
+                metadata, "claude-haiku-4-5", provider="anthropic"
+            )
+
+    matched = [
+        r for r in caplog.records
+        if "prompt_cache.missing_rate" in r.getMessage()
+        and "cache_read" in r.getMessage()
+    ]
+    assert len(matched) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/services/worker-service/tests/test_prompt_cache.py
+++ b/services/worker-service/tests/test_prompt_cache.py
@@ -1,0 +1,586 @@
+"""Unit tests for the provider-agnostic prompt-cache strategy.
+
+Covers marker placement, content shape preservation, and token-usage
+extraction for each registered provider. These tests are the contract
+every new strategy must pass — if you add a provider, add tests here
+with the same structure.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from executor.prompt_cache import TokenUsage, get_strategy
+from executor.prompt_cache.anthropic import AnthropicPromptCacheStrategy
+from executor.prompt_cache.bedrock import BedrockPromptCacheStrategy
+from executor.prompt_cache.noop import NoopPromptCacheStrategy
+from executor.prompt_cache.openai import OpenAIPromptCacheStrategy
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_anthropic():
+    assert isinstance(get_strategy("anthropic"), AnthropicPromptCacheStrategy)
+
+
+def test_registry_bedrock():
+    assert isinstance(get_strategy("bedrock"), BedrockPromptCacheStrategy)
+
+
+def test_registry_openai():
+    assert isinstance(get_strategy("openai"), OpenAIPromptCacheStrategy)
+
+
+def test_registry_unknown_provider_falls_back_to_noop():
+    strat = get_strategy("some-future-provider")
+    assert isinstance(strat, NoopPromptCacheStrategy)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic: marker placement
+# ---------------------------------------------------------------------------
+
+
+def _find_cache_marked_blocks(content):
+    """Return the list of blocks whose ``cache_control`` field is set."""
+    if not isinstance(content, list):
+        return []
+    return [b for b in content if isinstance(b, dict) and b.get("cache_control")]
+
+
+def test_anthropic_marks_string_system_message():
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [SystemMessage(content="you are a helpful agent")]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert len(out) == 1
+    marked = _find_cache_marked_blocks(out[0].content)
+    assert len(marked) == 1
+    assert marked[0]["cache_control"] == {"type": "ephemeral"}
+    assert marked[0]["text"] == "you are a helpful agent"
+
+
+def test_anthropic_marks_last_system_and_last_message():
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [
+        SystemMessage(content="platform system"),
+        SystemMessage(content="user system"),
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+        HumanMessage(content="do the thing"),
+    ]
+    out = strategy.apply_cache_markers(msgs)
+
+    # Last SystemMessage (idx 1) marked.
+    assert _find_cache_marked_blocks(out[1].content)
+    # Intermediate messages not marked.
+    assert not _find_cache_marked_blocks(out[2].content)
+    assert not _find_cache_marked_blocks(out[3].content)
+    # Last message marked (sliding-window breakpoint).
+    assert _find_cache_marked_blocks(out[4].content)
+    # First SystemMessage (not last) not marked.
+    assert not _find_cache_marked_blocks(out[0].content)
+
+
+def test_anthropic_preserves_list_content_blocks():
+    """List-shape content with multiple blocks must keep all blocks; only
+    the last text-bearing block gains a cache marker."""
+    strategy = AnthropicPromptCacheStrategy()
+    original_blocks = [
+        {"type": "text", "text": "first paragraph"},
+        {"type": "text", "text": "second paragraph"},
+    ]
+    msgs = [SystemMessage(content=list(original_blocks))]
+    out = strategy.apply_cache_markers(msgs)
+
+    new_content = out[0].content
+    assert isinstance(new_content, list)
+    assert len(new_content) == 2
+    assert "cache_control" not in new_content[0]
+    assert new_content[1]["cache_control"] == {"type": "ephemeral"}
+
+    # Input list untouched.
+    assert "cache_control" not in original_blocks[0]
+    assert "cache_control" not in original_blocks[1]
+
+
+def test_anthropic_skips_tool_use_trailing_block():
+    """cache_control on ``tool_use`` blocks is not a supported placement;
+    the strategy must walk back to the nearest text block."""
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [
+        AIMessage(
+            content=[
+                {"type": "text", "text": "calling a tool"},
+                {
+                    "type": "tool_use",
+                    "id": "tool_0",
+                    "name": "search",
+                    "input": {},
+                },
+            ]
+        )
+    ]
+    out = strategy.apply_cache_markers(msgs)
+
+    new_content = out[0].content
+    # Text block gets the marker.
+    assert new_content[0].get("cache_control") == {"type": "ephemeral"}
+    # Tool-use block untouched.
+    assert "cache_control" not in new_content[1]
+
+
+def test_anthropic_no_text_block_noop():
+    """Content with no eligible text block → returned unchanged, not crashed."""
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [
+        AIMessage(
+            content=[
+                {"type": "tool_use", "id": "t0", "name": "s", "input": {}},
+            ]
+        )
+    ]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert len(out[0].content) == 1
+    assert "cache_control" not in out[0].content[0]
+
+
+def test_anthropic_empty_string_content_not_marked():
+    """An empty-string content has no meaningful prefix to cache; skip it."""
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [HumanMessage(content="")]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert out[0].content == ""
+
+
+def test_anthropic_returns_new_list_instance():
+    """Pure function: caller's list must not be mutated."""
+    strategy = AnthropicPromptCacheStrategy()
+    msgs = [SystemMessage(content="s"), HumanMessage(content="h")]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert out is not msgs
+    assert msgs[0].content == "s"
+
+
+def test_anthropic_empty_messages():
+    strategy = AnthropicPromptCacheStrategy()
+    assert strategy.apply_cache_markers([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Anthropic: token extraction
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_extracts_from_raw_usage():
+    strategy = AnthropicPromptCacheStrategy()
+    metadata = {
+        "usage": {
+            "input_tokens": 50,
+            "output_tokens": 25,
+            "cache_creation_input_tokens": 100,
+            "cache_read_input_tokens": 500,
+        }
+    }
+    usage = strategy.extract_token_usage(metadata)
+
+    assert usage == TokenUsage(
+        input_tokens=50,
+        output_tokens=25,
+        cache_creation_input_tokens=100,
+        cache_read_input_tokens=500,
+    )
+
+
+def test_anthropic_langchain_shape_subtracts_cache_from_input_tokens() -> None:
+    """``usage_metadata.input_tokens`` from langchain-anthropic INCLUDES
+    cache_read + cache_creation (see langchain-anthropic's
+    _create_usage_metadata: "we manually add cache_read and
+    cache_creation to get the true total"). Our extractor must subtract
+    them to preserve the TokenUsage invariant that ``input_tokens`` is
+    the non-cached portion. Double-counting would bill Anthropic cache
+    tokens both at input rate AND at their dedicated rate.
+    """
+    strategy = AnthropicPromptCacheStrategy()
+    usage = strategy.extract_token_usage(
+        {
+            # No native ``usage`` shape — force the fallback path.
+            "usage_metadata": {
+                "input_tokens": 10_000,  # base 1000 + cache_read 8000 + cache_creation 1000
+                "output_tokens": 150,
+                "input_token_details": {
+                    "cache_read": 8_000,
+                    "cache_creation": 1_000,
+                },
+            },
+        }
+    )
+    assert usage.input_tokens == 1_000
+    assert usage.cache_read_input_tokens == 8_000
+    assert usage.cache_creation_input_tokens == 1_000
+    # Invariant: input + cache_read + cache_creation = total prompt
+    assert usage.total_prompt_tokens == 10_000
+
+
+def test_anthropic_native_shape_keeps_input_tokens_unchanged() -> None:
+    """Native Anthropic SDK shape (used by the direct-SDK summarizer
+    path): ``usage.input_tokens`` is already the non-cached portion.
+    No subtraction needed."""
+    strategy = AnthropicPromptCacheStrategy()
+    usage = strategy.extract_token_usage(
+        {
+            "usage": {
+                "input_tokens": 1_000,
+                "output_tokens": 150,
+                "cache_read_input_tokens": 8_000,
+                "cache_creation_input_tokens": 1_000,
+            },
+        }
+    )
+    assert usage.input_tokens == 1_000
+    assert usage.cache_read_input_tokens == 8_000
+    assert usage.cache_creation_input_tokens == 1_000
+    assert usage.total_prompt_tokens == 10_000
+
+
+def test_anthropic_prefers_native_over_metadata_when_both_present() -> None:
+    """When both shapes are present (LangChain AIMessage with raw
+    response_metadata carried through), prefer the unambiguous native
+    shape. Defends against a future LangChain version silently changing
+    the ``usage_metadata.input_tokens`` convention."""
+    strategy = AnthropicPromptCacheStrategy()
+    usage = strategy.extract_token_usage(
+        {
+            "usage": {
+                "input_tokens": 1_000,
+                "output_tokens": 150,
+                "cache_read_input_tokens": 8_000,
+            },
+            "usage_metadata": {
+                "input_tokens": 9_000,  # inclusive — would double-count if preferred
+                "output_tokens": 150,
+                "input_token_details": {"cache_read": 8_000},
+            },
+        }
+    )
+    assert usage.input_tokens == 1_000  # native wins
+
+
+def test_anthropic_extracts_from_usage_metadata_details():
+    """LangChain-normalised shape: input_token_details carries the cache
+    counters."""
+    strategy = AnthropicPromptCacheStrategy()
+    metadata = {
+        "usage_metadata": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "input_token_details": {"cache_creation": 20, "cache_read": 80},
+        }
+    }
+    usage = strategy.extract_token_usage(metadata)
+
+    assert usage.cache_creation_input_tokens == 20
+    assert usage.cache_read_input_tokens == 80
+
+
+def test_anthropic_extracts_empty():
+    strategy = AnthropicPromptCacheStrategy()
+    usage = strategy.extract_token_usage({})
+    assert usage == TokenUsage(input_tokens=0, output_tokens=0)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI: marker is a no-op; cached_tokens are extracted
+# ---------------------------------------------------------------------------
+
+
+def test_openai_marker_is_noop():
+    strategy = OpenAIPromptCacheStrategy()
+    msgs = [SystemMessage(content="s"), HumanMessage(content="h")]
+    out = strategy.apply_cache_markers(msgs)
+
+    # Content unchanged.
+    assert out[0].content == "s"
+    assert out[1].content == "h"
+
+
+def test_openai_extracts_cached_tokens():
+    strategy = OpenAIPromptCacheStrategy()
+    metadata = {
+        "token_usage": {
+            "prompt_tokens": 1000,
+            "completion_tokens": 100,
+            "prompt_tokens_details": {"cached_tokens": 800},
+        }
+    }
+    usage = strategy.extract_token_usage(metadata)
+
+    # Normalised: input_tokens = prompt_tokens - cached_tokens
+    assert usage.input_tokens == 200
+    assert usage.output_tokens == 100
+    assert usage.cache_creation_input_tokens == 0
+    assert usage.cache_read_input_tokens == 800
+
+
+def test_openai_extracts_without_cache_details():
+    strategy = OpenAIPromptCacheStrategy()
+    metadata = {
+        "token_usage": {"prompt_tokens": 100, "completion_tokens": 50}
+    }
+    usage = strategy.extract_token_usage(metadata)
+
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 50
+    assert usage.cache_read_input_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Bedrock: cachePoint block placement (different mechanism than Anthropic)
+# ---------------------------------------------------------------------------
+
+
+def _has_cache_point_tail(content):
+    if not isinstance(content, list) or not content:
+        return False
+    tail = content[-1]
+    return (
+        isinstance(tail, dict)
+        and isinstance(tail.get("cachePoint"), dict)
+        and tail["cachePoint"].get("type") == "default"
+    )
+
+
+def test_bedrock_marks_last_system_and_last_message_with_cache_point_block():
+    """Verified against ``langchain-aws==1.4.0``: Bedrock Converse needs a
+    trailing ``{"cachePoint": {"type": "default"}}`` block, not an inline
+    ``cache_control`` field (which the translator drops)."""
+    strategy = BedrockPromptCacheStrategy()
+    msgs = [
+        SystemMessage(content="system"),
+        HumanMessage(content="prompt"),
+    ]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert _has_cache_point_tail(out[0].content)
+    assert _has_cache_point_tail(out[1].content)
+    # No inline cache_control fields should leak through — those do nothing
+    # on Bedrock and imply the wrong provider shape.
+    assert not _find_cache_marked_blocks(out[0].content)
+    assert not _find_cache_marked_blocks(out[1].content)
+
+
+def test_bedrock_string_content_is_wrapped_in_list_shape():
+    strategy = BedrockPromptCacheStrategy()
+    msgs = [SystemMessage(content="you are helpful")]
+    out = strategy.apply_cache_markers(msgs)
+
+    new_content = out[0].content
+    assert isinstance(new_content, list)
+    assert new_content[0] == {"type": "text", "text": "you are helpful"}
+    assert new_content[-1] == {"cachePoint": {"type": "default"}}
+
+
+def test_bedrock_empty_string_not_marked():
+    strategy = BedrockPromptCacheStrategy()
+    msgs = [HumanMessage(content="")]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert out[0].content == ""
+
+
+def test_bedrock_does_not_double_mark():
+    """Running the strategy twice must not produce two trailing cachePoint
+    blocks — the per-turn replay path calls it every LLM invocation."""
+    strategy = BedrockPromptCacheStrategy()
+    msgs = [HumanMessage(content="hi")]
+    once = strategy.apply_cache_markers(msgs)
+    twice = strategy.apply_cache_markers(once)
+
+    assert len(twice[0].content) == len(once[0].content)
+
+
+def test_bedrock_extracts_cache_tokens():
+    strategy = BedrockPromptCacheStrategy()
+    metadata = {
+        "usage_metadata": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "input_token_details": {"cache_creation": 0, "cache_read": 99},
+        }
+    }
+    usage = strategy.extract_token_usage(metadata)
+
+    assert usage.cache_read_input_tokens == 99
+
+
+# ---------------------------------------------------------------------------
+# Noop: both methods are pure passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_noop_passthrough():
+    strategy = NoopPromptCacheStrategy()
+    msgs = [HumanMessage(content="hi"), ToolMessage(content="result", tool_call_id="t0")]
+    out = strategy.apply_cache_markers(msgs)
+
+    assert out[0].content == "hi"
+    assert out[1].content == "result"
+
+
+def test_noop_extracts_basic_usage():
+    strategy = NoopPromptCacheStrategy()
+    usage = strategy.extract_token_usage(
+        {"usage": {"input_tokens": 10, "output_tokens": 5}}
+    )
+    assert usage == TokenUsage(input_tokens=10, output_tokens=5)
+
+
+# ---------------------------------------------------------------------------
+# WORKER_PROMPT_CACHE_DISABLED kill switch
+# ---------------------------------------------------------------------------
+#
+# The env var is parsed by ``_prompt_cache_markers_disabled_by_env`` in
+# ``executor.graph`` and frozen into the module-level constant
+# ``_PROMPT_CACHE_MARKERS_ENABLED`` at import time.  These tests exercise the
+# parser directly — testing the module constant would require a module reload
+# dance that isn't worth the complexity for such a simple lever.
+
+
+import os
+
+from executor.graph import _prompt_cache_markers_disabled_by_env
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("  1  ", True),  # whitespace tolerated
+    ],
+)
+def test_kill_switch_recognizes_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
+) -> None:
+    monkeypatch.setenv("WORKER_PROMPT_CACHE_DISABLED", value)
+    assert _prompt_cache_markers_disabled_by_env() is expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "0", "false", "False", "no", "off", "unexpected", "  "],
+)
+def test_kill_switch_ignores_falsy_or_unknown_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """The env var is a disable flag; only explicit truthy values disable.
+    Ambiguous input stays enabled (safer default — caching only helps)."""
+    monkeypatch.setenv("WORKER_PROMPT_CACHE_DISABLED", value)
+    assert _prompt_cache_markers_disabled_by_env() is False
+
+
+def test_kill_switch_defaults_to_enabled_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WORKER_PROMPT_CACHE_DISABLED", raising=False)
+    assert _prompt_cache_markers_disabled_by_env() is False
+
+
+# ---------------------------------------------------------------------------
+# Model-level support gate
+# ---------------------------------------------------------------------------
+#
+# Bedrock hosts many families; only Anthropic Claude and Amazon Nova accept
+# ``cachePoint`` blocks. Sending markers to anything else (GLM, Llama,
+# Mistral, Cohere) dead-letters the task with AccessDeniedException. The
+# ``supports_caching(model)`` hook lets the graph skip marker injection for
+# incompatible models without losing token-usage extraction.
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "anthropic.claude-opus-4-v1:0",
+        "anthropic.claude-haiku-4-5-v1:0",
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "global.anthropic.claude-opus-4-v1:0",
+        "amazon.nova-lite-v1:0",
+        "amazon.nova-pro-v1:0",
+        "amazon.nova-micro-v1:0",
+        "us.amazon.nova-lite-v1:0",
+        # Regional inference profiles beyond the initial us/eu/apac/global set.
+        "us-gov.anthropic.claude-3-haiku-v1:0",
+        "au.anthropic.claude-sonnet-4-5-v1:0",
+        "ca.amazon.nova-lite-v1:0",
+        "jp.anthropic.claude-haiku-4-5-v1:0",
+        # Full ARNs — foundation-model and inference-profile layouts.
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "arn:aws:bedrock:ap-northeast-1::foundation-model/amazon.nova-lite-v1:0",
+    ],
+)
+def test_bedrock_supports_caching_for_known_families(model_id: str) -> None:
+    assert BedrockPromptCacheStrategy().supports_caching(model_id) is True
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "zai.glm-5",
+        "meta.llama3-70b-instruct-v1:0",
+        "mistral.mistral-large-2407-v1:0",
+        "cohere.command-r-plus-v1:0",
+        "ai21.jamba-1-5-large-v1:0",
+        "amazon.titan-text-express-v1",  # Titan (not Nova) — no caching
+        "us.meta.llama3-70b-instruct-v1:0",
+        "",
+    ],
+)
+def test_bedrock_supports_caching_false_for_unsupported(model_id: str) -> None:
+    assert BedrockPromptCacheStrategy().supports_caching(model_id) is False
+
+
+def test_anthropic_and_openai_always_support_caching() -> None:
+    assert AnthropicPromptCacheStrategy().supports_caching("claude-opus-4-7") is True
+    assert AnthropicPromptCacheStrategy().supports_caching("") is True
+    assert OpenAIPromptCacheStrategy().supports_caching("gpt-4o-mini") is True
+    assert OpenAIPromptCacheStrategy().supports_caching("") is True
+
+
+def test_noop_never_supports_caching() -> None:
+    assert NoopPromptCacheStrategy().supports_caching("anything") is False
+
+
+def test_kill_switch_only_suppresses_injection_not_extraction() -> None:
+    """Documented invariant: the kill switch suppresses marker INJECTION
+    only. Token-usage extraction must continue so OpenAI's automatic
+    caching still reports correctly. This test is a contract reminder —
+    it checks the registry still hands out real strategies regardless of
+    env state, because extraction lives on the strategy.
+    """
+    for provider in ("anthropic", "bedrock", "openai", "some-unknown-future-provider"):
+        strategy = get_strategy(provider)
+        # Strategy resolution is provider-keyed; the env var is checked at
+        # the agent_node call site, not inside strategies themselves.
+        assert hasattr(strategy, "extract_token_usage")
+        assert hasattr(strategy, "apply_cache_markers")

--- a/tests/test_discover_models.py
+++ b/tests/test_discover_models.py
@@ -70,7 +70,15 @@ def test_resolve_model_pricing_returns_explicit_price_for_known_model():
 
     pricing = discover_models.resolve_model_pricing("openai", "gpt-4o")
 
-    assert pricing == {"input": 2_500_000, "output": 10_000_000}
+    # OpenAI automatic caching: ``cache_creation`` is always 0 (the provider
+    # absorbs the write cost), ``cache_read`` is 50% of input for the 4o
+    # family.
+    assert pricing == {
+        "input": 2_500_000,
+        "output": 10_000_000,
+        "cache_creation": 0,
+        "cache_read": 1_250_000,
+    }
 
 
 def test_resolve_model_pricing_uses_provider_fallback_for_unknown_model():


### PR DESCRIPTION
Two related improvements to long-running-task plumbing, bundled since they touch adjacent code (Context Management agent config + the worker's cost/cache path).

## 1. Provider-agnostic prompt caching + billing fixes

- New `executor/prompt_cache/` package — strategy-pattern cache subsystem. Adding a provider = one file + registry entry; agent loop stays provider-neutral. Ships Anthropic (`cache_control` inline), Bedrock Converse (`cachePoint` block), OpenAI (automatic, no-op markers), noop fallback.
- Model-level gate (`supports_caching(model)`) — Bedrock hosts many third-party families (GLM / Llama / Mistral / Cohere / AI21) that reject `cachePoint` with `AccessDeniedException`. Allowlist `anthropic.` + `amazon.nova-`, matched against bare ids, regional inference-profile ids (`us.`, `us-gov.`, `eu.`, `apac.`, `au.`, `ca.`, `jp.`, `global.`), and full foundation-model / inference-profile ARNs.
- **Billing fix (Anthropic double-count).** `langchain-anthropic`'s `_create_usage_metadata` rolls `cache_read + cache_creation` INTO `usage_metadata.input_tokens`. Our extractor treated that field as the non-cached portion, so cache tokens were billed both at `input_rate` AND at their dedicated rate. Now prefers the unambiguous native `usage` shape; subtracts when falling back.
- **Billing fix (NULL cache rate).** Previous fallback charged cache reads at full input rate — 10× Anthropic's real rate. New contract: NULL → 0, with a single warning per (model, bucket) per executor lifetime.
- **Operator kill switch.** `WORKER_PROMPT_CACHE_DISABLED=1` suppresses marker injection fleet-wide while token-usage extraction continues (so OpenAI's automatic caching still reports correctly). Makefile forwards it explicitly through `start-worker` / `scale-worker`.
- **Log rate-limit.** `prompt_cache.markers_skipped_unsupported_model` is now once per (provider, model) per executor, not once per task.
- **Local-dev default flip.** `APP_DEV_TASK_CONTROLS_ENABLED` defaults to `true` under `make start`. Explicit env forwarding (console / api / worker) replaces implicit shell inheritance.
- Migration 0022 adds cache-pricing columns on `models`; model-discovery seeds them via `_with_anthropic_cache(input, output)` (1.25× / 0.1×).

## 2. Cross-provider summarizer selection

Agent creation / detail UI no longer restricts the summarizer to the agent's primary provider. An OpenAI-primary agent can summarize with Claude Haiku (or vice versa) — pick whichever has the right cost / context-window / latency profile for long-running tasks.

- New `summarizer_provider` field on `ContextManagementConfigRequest`, persisted alongside `summarizer_model`. Absent → legacy behaviour (agent's provider is assumed; backward compatible).
- `ContextManagementSection` groups the summarizer dropdown by provider; option value is `provider|model_id`; both fields update on change.
- `CreateAgentDialog` / `AgentDetailPage` pass the full (unfiltered) model list; "still-valid" checks consider both fields.
- `ConfigValidationHelper` resolves against `summarizer_provider` when present, falling back to the agent's provider. Error message names the summarizer selection explicitly.
- Section label renamed "Context Management" → "Long-Running Task Context" — operators kept asking what it was for.
- Reference docs added under `docs/references/` covering Claude Code and opencode compaction mechanisms (informed the design).

## Test plan

- [x] 936 worker unit tests pass (+13 new — Anthropic double-count, regional prefixes & ARNs, NULL fallback, warning dedup).
- [x] 43 console UI tests pass (ContextManagementSection 23, AgentDetailPage 14, CreateAgentDialog 6).
- [x] Java `ConfigValidationHelperTest` + `AgentServiceTest` pass.
- [x] Model-discovery pricing-shape test updated for new cache fields.
- [x] Dead-lettered `zai.glm-5` / Bedrock task redriven and completed cleanly.
- [x] Submitted two GLM tasks back-to-back — log fires exactly once.
- [x] Verified `langchain-aws==1.4.0` drops `cache_control` and forwards `cachePoint` via the fallthrough branch (installed SDK source).
- [x] Verified `langchain-anthropic` inclusive-total convention for `usage_metadata.input_tokens` in installed SDK source.
- [x] **Reviewer**: confirm `supports_caching` allowlist matches your org's Bedrock roster (Claude + Nova across 8 regional profiles + ARNs).

## Follow-ups

Tracked in #100 — runtime fallback on provider rejection, Langfuse `usage_details` wiring, summarizer provider threading through cost path, OpenAI cache-rate audit for o3 / o1-pro / gpt-5.x, full `agent_node` integration test, two minor edge cases (Bedrock tool-use-only tails, OpenAI `service_tier_prefix`).

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)