### PR TITLE
make: run worker-test from a git worktree (venv + .env.localdev fallback)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,26 @@ SHELL := /bin/bash
 
 # --- Configuration & Environment ---
 
-# Load local environment variables if present
+# Checkout roots, resolved BEFORE loading env files. ROOT_DIR is the current
+# checkout (a git worktree or the primary checkout); MAIN_ROOT is the primary
+# checkout, which holds the shared Python .venv and the local .env.localdev.
+# They are equal in a normal checkout. Resolving MAIN_ROOT from git's common
+# dir lets `make` targets run from a worktree borrow the primary checkout's
+# venv and secrets instead of failing on a venv the worktree doesn't have.
+ROOT_DIR := $(shell pwd)
+MAIN_ROOT := $(shell d=$$(git rev-parse --git-common-dir 2>/dev/null); \
+	[ -n "$$d" ] && (cd "$$d/.." && pwd) || pwd)
+
+# Load local environment variables if present. From a worktree, load the
+# primary checkout's file FIRST, then the worktree-local one LAST so a
+# per-worktree override wins for any overlapping key.
+ifneq ($(MAIN_ROOT),$(ROOT_DIR))
+-include $(MAIN_ROOT)/.env.localdev
+endif
 -include .env.localdev
 .EXPORT_ALL_VARIABLES:
 
 # Default Paths & Variables
-ROOT_DIR := $(shell pwd)
 WORKER_DIR := $(ROOT_DIR)/services/worker-service
 API_DIR := $(ROOT_DIR)/services/api-service
 CONSOLE_DIR := $(ROOT_DIR)/services/console
@@ -22,7 +36,15 @@ MIGRATION_FILES := $(sort $(wildcard $(ROOT_DIR)/infrastructure/database/migrati
 LANGFUSE_COMPOSE_FILE := $(ROOT_DIR)/tests/fixtures/langfuse/docker-compose.yml
 LANGFUSE_DOCKER_PROJECT ?= persistent-agent-runtime-langfuse
 
+# Prefer this checkout's own venv; fall back to the primary checkout's venv
+# when run from a worktree that has none. We don't auto-create a per-worktree
+# venv — borrowing the primary checkout's is correct and avoids a slow reinstall
+# per worktree. (Source still comes from $(WORKER_DIR), i.e. the worktree, so a
+# worktree's code is what gets tested.)
 WORKER_VENV_DIR := $(WORKER_DIR)/.venv
+ifeq ($(wildcard $(WORKER_VENV_DIR)/bin/python),)
+WORKER_VENV_DIR := $(MAIN_ROOT)/services/worker-service/.venv
+endif
 WORKER_VENV_PYTHON := $(WORKER_VENV_DIR)/bin/python
 
 PYTHON ?= $(shell \


### PR DESCRIPTION
## Problem

`make worker-test` (and other venv/secret-dependent targets) fails when run from inside a git worktree:

```
/…/.claude/worktrees/<wt>/services/worker-service/.venv/bin/python: No such file or directory
make: *** [worker-test] Error 127
```

A worktree is a separate working tree that doesn't carry the primary checkout's local-only, gitignored files:

1. `WORKER_VENV_DIR := $(WORKER_DIR)/.venv` resolves to a venv the worktree doesn't have.
2. `-include .env.localdev` loads local secrets (API keys) relative to CWD, so a worktree silently misses them.

## Fix

Resolve `MAIN_ROOT` (the primary checkout) from `git rev-parse --git-common-dir`, then:

- **venv fallback** — use `$(MAIN_ROOT)`'s worker venv when the current checkout has none (no per-worktree venv auto-create — borrowing is correct and avoids a slow reinstall).
- **secrets fallback** — also `-include $(MAIN_ROOT)/.env.localdev` from a worktree, loaded **before** the worktree-local file so a per-worktree override wins for overlapping keys.

`$(WORKER_DIR)` (the source under test) still points at the **current** checkout, so a worktree tests its own code — only the venv + secrets are borrowed.

## Safety

In a normal checkout `MAIN_ROOT == ROOT_DIR`, so both `ifneq`/`ifeq` guards are no-ops and behaviour is byte-identical (CI runs from a normal checkout, unaffected).

## Verification

| Context | Before | After |
|---|---|---|
| `make worker-test` from a worktree | `Error 127` (no python, 0 tests collected) | **1047 passed** against the shared test DB |
| Variable resolution from a worktree | venv → worktree (missing) | `WORKER_DIR` → worktree source; `WORKER_VENV_PYTHON` → primary checkout venv |
| Normal checkout | baseline | guards no-op → unchanged |

## Out of scope (noted, not fixed)

`make start` / `make scale-worker` spawn workers with a relative `source .venv/bin/activate`, which would also miss in a worktree — but live-stack targets bind global ports (5173/8080) and are meant to run from the primary checkout, so they're intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
