### PR TITLE
Isolate E2E/integration test infra per git worktree (#112)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ make help        # list all targets with descriptions
 make init        # first-time setup
 make install     # install deps across services
 make test        # unit tests (fast, no infra)
-make e2e-test    # E2E on isolated infra (DB port 55433)
+make e2e-test    # E2E on per-worktree isolated infra (DB 55433 on primary checkout; dynamic in worktrees)
 make test-all    # unit + E2E
 make start       # live stack: Console :5173, API :8080
 make stop        # stop live stack
@@ -80,7 +80,7 @@ Applies to research, design docs, task specs, PR descriptions, code review comme
 **Never:**
 - Assert a fact or recommend a practice without a verifiable citation — web reference for external claims, `path:line` for internal claims (§Claims Require Evidence)
 - Use bare `python3` or `uv run` for worker code — always the pinned venv at `services/worker-service/.venv/` (§Local Validation Notes)
-- Point tests at the dev DB (port 55432) — tests use `par-e2e-postgres` on 55433 (§Local Validation Notes)
+- Point tests at the dev DB (port 55432) — tests use a per-worktree `par-e2e-postgres[-<slug>]` container on a dynamic port (the fixed 55433 only on the primary checkout) (§Local Validation Notes)
 - Link to PRs in third-party repos from commits or PR descriptions (§External Pull Request References)
 - Commit or open a PR with unverified Console UI (§Browser Verification (Console Changes))
 - Merge without running the narrowest-scope tests that cover your change (§Testing (Mandatory))
@@ -133,7 +133,7 @@ If an external PR reference slips in, rewrite the commit / PR description before
 - See `README.md` and `docs/LOCAL_DEVELOPMENT.md` for setup details.
 - When validating background `Makefile` targets (`make start`, `make status`, `make stop`), prefer an interactive shell / PTY.
 - **Python venv:** the worker venv at `services/worker-service/.venv/` has all deps pinned. Activate with `source services/worker-service/.venv/bin/activate` or call `services/worker-service/.venv/bin/python` directly.
-- **Test DB isolation:** `par-e2e-postgres` on port **55433** is the tests' DB; the dev DB on 55432 is off-limits for tests (it corrupts local state). `make worker-test` passes `E2E_DB_DSN`; `make e2e-test` passes `E2E_DB_*` vars.
+- **Test DB isolation (per-worktree):** `make worker-test` / `make e2e-test` self-provision isolated test infra keyed by the checkout — same command, no manual steps, no port-picking. From a **git worktree** each gets its own Postgres container `par-e2e-postgres-<slug>` on a dynamically allocated host port, its own S3 bucket `platform-artifacts-<slug>`, and (for e2e-test) its own API + embedding-mock ports, all recorded in `<worktree>/.tmp/e2e.env` — so multiple agents in multiple worktrees run tests concurrently without clobbering each other (one shared LocalStack on `:4566` is reused). The **primary checkout** (not a worktree) keeps the fixed `par-e2e-postgres` / DB 55433 / API 8081 / embedding-mock 18099 / bucket `platform-artifacts` for CI parity. Run a single test through the isolated harness with `make e2e-test PYTEST_ARGS='-k my_test'` — **never run raw `pytest tests/backend-integration` in a worktree**, it hits the fixed default ports (55433/8081/18099) and can collide. Each run **disposes its DB container by default** when it finishes — primary checkout and worktree alike — so a run always cleans up after itself; `E2E_KEEP=1 make worker-test` is the opt-out that leaves it (and the API/bucket) up so a fix→test loop reuses them. `make e2e-reap` GCs leftover per-worktree containers/buckets from crashed agents (fleet hygiene — a single agent never needs it, since deterministic names mean a re-run replaces its own container). The shared `platform-artifacts` bucket and LocalStack are never torn down. The dev DB on 55432 stays off-limits for tests (using it corrupts local state).
 - **Tracking a running task:** two surfaces answer "what's this task doing?" — the worker log (`.tmp/worker-*.log`) for runtime decisions (lifecycle, compaction, memory routing, dead-letter, retries) and `GET /v1/tasks/<id>/conversation` for what the agent actually did (turns / tool calls / tool results). `make start` runs workers at `WORKER_LOG_LEVEL=DEBUG` by default so per-turn compaction traces are already there; quiet it with `WORKER_LOG_LEVEL=INFO make start-worker`. See [Tracking a running task](./docs/LOCAL_DEVELOPMENT.md#tracking-a-running-task) for the event catalogue and jq recipes.
 
 ## Testing (Mandatory)
@@ -141,6 +141,7 @@ If an external PR reference slips in, rewrite the commit / PR description before
 **Every code change must be tested before it is considered done.** No exceptions. See [LOCAL_DEVELOPMENT.md](./docs/LOCAL_DEVELOPMENT.md) for test locations, single-test commands, and conventions.
 
 - Write tests covering the change, including failure scenarios.
+- **Tests must be worktree-concurrency-safe:** a test that binds a TCP port or spawns a server subprocess must use an **ephemeral/free port** (bind to `:0`, or call `scripts/e2e/free-port.py`), never a hardcoded one. Two worktrees run the same test simultaneously, so a fixed port collides — see the dynamic-port helpers in `services/worker-service/tests/test_mcp_http_integration.py` and `test_custom_tool_integration.py` for the pattern.
 - Run the **narrowest scope** that covers your change (a single test file or package is fine — you don't need to run the whole `make test` suite if it doesn't touch your change). Run `make e2e-test` after DB/schema or cross-service changes. If tests fail — including pre-existing failures — fix them before moving on.
 - **CI maintenance:** when adding DB migrations, new service containers, or infra deps, verify `.github/workflows/ci.yml` picks them up. Migrations auto-apply via glob (`[0-9][0-9][0-9][0-9]_*.sql`); new services (e.g., LocalStack) must be added as CI service containers manually.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,9 @@ Applies to research, design docs, task specs, PR descriptions, code review comme
 - Invoke relevant superpowers skills (§Agent Skills (Superpowers))
 - Use `isolation: "worktree"` when parallel subagents could touch overlapping files (§Parallel Subagent Safety)
 
+**Prefer:**
+- Do PR work in a **git worktree** when it may run alongside other agents (or when the user is fanning out several tasks). This repo is built for it — the test infra is per-worktree isolated (#112) and the worker venv / `.env.localdev` fall back to the primary checkout (#111), so there's no bootstrap penalty. Reserve the **primary checkout** for single-stream work and CI-parity runs (which need the fixed `par-e2e-postgres` / 55433 / 8081). Not required for a lone serial task. (§Local Validation Notes)
+
 ## Parallel Subagent Safety
 
 When orchestrating parallel subagents via the Agent tool, **always use `isolation: "worktree"`** if there is any chance two agents modify the same file — even different methods in the same file. Without worktrees, concurrent Edit tool calls on the same file can clobber each other (last writer wins, or `old_string` match fails silently).

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ SHELL := /bin/bash
 ROOT_DIR := $(shell pwd)
 MAIN_ROOT := $(shell d=$$(git rev-parse --git-common-dir 2>/dev/null); \
 	[ -n "$$d" ] && (cd "$$d/.." && pwd) || pwd)
+# RUN_ID namespaces per-worktree test infra (issue #112). Empty on the primary
+# checkout (ROOT_DIR == MAIN_ROOT) so container/bucket/port names stay fixed and
+# CI is byte-identical; a lowercase slug of the worktree basename otherwise.
+# MUST match scripts/e2e/common.sh:e2e_run_id. Uses /bin/sh ($(shell) ignores
+# SHELL), so keep it POSIX.
+RUN_ID := $(shell if [ "$(ROOT_DIR)" = "$(MAIN_ROOT)" ]; then echo ""; \
+	else s=$$(basename "$(ROOT_DIR)" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-+//; s/-+$$//'); \
+	[ -n "$$s" ] && echo "$$s" || echo "wt-$$(basename "$(ROOT_DIR)" | cksum | cut -d' ' -f1)"; fi)
 
 # Load local environment variables if present. From a worktree, load the
 # primary checkout's file FIRST, then the worktree-local one LAST so a
@@ -130,6 +138,14 @@ E2E_EMBEDDING_MOCK_PORT ?= 18099
 E2E_EMBEDDING_MOCK_PROVIDER_ID ?= memory-mock
 E2E_EMBEDDING_MOCK_ENDPOINT ?= http://127.0.0.1:$(E2E_EMBEDDING_MOCK_PORT)/v1/embeddings
 
+# Per-worktree test harness knobs (issue #112).
+# PYTEST_ARGS: extra args (e.g. -k name, a test path) passed THROUGH the isolated
+#   harness — prefer this over running raw `pytest` in a worktree, which would hit
+#   conftest's fixed default ports and collide.
+# E2E_KEEP=1: skip teardown so a fix→test loop reuses the run's container.
+PYTEST_ARGS ?=
+E2E_KEEP ?=
+
 # Color Output
 GREEN := $(shell printf '\033[0;32m')
 YELLOW := $(shell printf '\033[0;33m')
@@ -142,7 +158,7 @@ NC := $(shell printf '\033[0m')
         scale-worker \
         status check check-env check-python db-up db-down db-status db-migrate db-reset-verify \
         test-langfuse-up test-langfuse-down test-langfuse-status \
-        test test-all api-test worker-test console-test e2e-test e2e-up e2e-down e2e-clean e2e-status \
+        test test-all api-test worker-test console-test e2e-test e2e-up e2e-down e2e-clean e2e-status e2e-reap e2e-scripts-test \
         test-e2e-langfuse local-ci clean logs
 
 
@@ -820,38 +836,50 @@ api-test:
 	@echo "$(CYAN)🧪 Running API tests...$(NC)"
 	@cd $(API_DIR) && ./gradlew test
 
-worker-test: test-db-up
-	@echo "$(CYAN)🧪 Running Worker tests...$(NC)"
-	@E2E_DB_DSN=$(E2E_DB_DSN) $(WORKER_VENV_PYTHON) -m pytest $(WORKER_DIR)/tests -q
+worker-test:
+	@echo "$(CYAN)🧪 Running Worker tests (run: $(if $(RUN_ID),$(RUN_ID),primary))...$(NC)"
+	@$(ROOT_DIR)/scripts/e2e/provision.sh
+	@set -a; . $(TMP_DIR)/e2e.env; set +a; \
+	  rc=0; \
+	  $(WORKER_VENV_PYTHON) -m pytest $(WORKER_DIR)/tests $(PYTEST_ARGS) -q || rc=$$?; \
+	  $(ROOT_DIR)/scripts/e2e/teardown.sh; \
+	  exit $$rc
 
 console-test:
 	@echo "$(CYAN)🧪 Running Console tests...$(NC)"
 	@cd $(CONSOLE_DIR) && npm test
 
-e2e-test: e2e-up
-	@echo "$(CYAN)🧪 Running E2E tests (isolated infra: DB :$(E2E_DB_PORT), API :$(E2E_API_PORT))...$(NC)"
+e2e-test:
+	@echo "$(CYAN)🧪 Running E2E tests (run: $(if $(RUN_ID),$(RUN_ID),primary))...$(NC)"
+	@E2E_NEED_API=1 $(ROOT_DIR)/scripts/e2e/provision.sh
 	@mkdir -p $(TMP_DIR)
-	@E2E_DB_HOST=$(E2E_DB_HOST) \
-	 E2E_DB_PORT=$(E2E_DB_PORT) \
-	 E2E_DB_NAME=$(E2E_DB_NAME) \
-	 E2E_DB_USER=$(E2E_DB_USER) \
-	 E2E_DB_PASSWORD=$(E2E_DB_PASSWORD) \
-	 E2E_DB_DSN=$(E2E_DB_DSN) \
-	 E2E_PG_CONTAINER=$(E2E_PG_CONTAINER) \
-	 E2E_PG_IMAGE=$(E2E_PG_IMAGE) \
-	 E2E_API_PORT=$(E2E_API_PORT) \
-	 E2E_API_BASE=$(E2E_API_BASE) \
-	 E2E_EMBEDDING_MOCK_PORT=$(E2E_EMBEDDING_MOCK_PORT) \
-	 E2E_EMBEDDING_MOCK_PROVIDER_ID=$(E2E_EMBEDDING_MOCK_PROVIDER_ID) \
-	 APP_DEV_TASK_CONTROLS_ENABLED=true \
-	 $(WORKER_VENV_PYTHON) -m pytest tests/backend-integration -v --tb=short -ra 2>&1 | tee $(TMP_DIR)/e2e-test.log; \
-	 e2e_exit=$${PIPESTATUS[0]}; \
-	 $(MAKE) e2e-down; \
-	 if [ $$e2e_exit -ne 0 ]; then \
-	   echo "$(RED)❌ E2E tests failed. Full log: $(TMP_DIR)/e2e-test.log$(NC)"; \
-	   echo "$(YELLOW)   API log: $(E2E_API_LOG)$(NC)"; \
-	   exit $$e2e_exit; \
-	 fi
+	@set -a; . $(TMP_DIR)/e2e.env; set +a; \
+	  echo "$(CYAN)   DB :$$E2E_DB_PORT  API :$$E2E_API_PORT  embed :$$E2E_EMBEDDING_MOCK_PORT  bucket $$S3_BUCKET_NAME$(NC)"; \
+	  if ! curl -sf $$E2E_API_BASE/health >/dev/null 2>&1; then \
+	    echo "$(YELLOW)▶ Starting E2E API on port $$E2E_API_PORT...$(NC)"; \
+	    DB_HOST=$$E2E_DB_HOST DB_PORT=$$E2E_DB_PORT DB_NAME=$$E2E_DB_NAME \
+	    DB_USER=$$E2E_DB_USER DB_PASSWORD=$$E2E_DB_PASSWORD \
+	    SERVER_PORT=$$E2E_API_PORT APP_DEV_TASK_CONTROLS_ENABLED=true \
+	    APP_MEMORY_EMBEDDING_ENDPOINT=$$E2E_EMBEDDING_MOCK_ENDPOINT \
+	    APP_MEMORY_EMBEDDING_PROVIDER_ID=$$E2E_EMBEDDING_MOCK_PROVIDER_ID \
+	    nohup $(API_DIR)/gradlew bootRun -p $(API_DIR) > $(E2E_API_LOG) 2>&1 & \
+	    echo $$! > $(TMP_DIR)/e2e-api.pid; \
+	    echo "$(YELLOW)⏳ Waiting for E2E API health...$(NC)"; \
+	    for i in $$(seq 1 120); do curl -sf $$E2E_API_BASE/health >/dev/null 2>&1 && break; sleep 1; done; \
+	    if ! curl -sf $$E2E_API_BASE/health >/dev/null 2>&1; then \
+	      echo "$(RED)❌ E2E API failed to start. Check $(E2E_API_LOG)$(NC)"; \
+	      $(ROOT_DIR)/scripts/e2e/teardown.sh; \
+	      exit 1; \
+	    fi; \
+	  fi; \
+	  $(WORKER_VENV_PYTHON) -m pytest tests/backend-integration $(PYTEST_ARGS) -v --tb=short -ra 2>&1 | tee $(TMP_DIR)/e2e-test.log; \
+	  e2e_exit=$${PIPESTATUS[0]}; \
+	  $(ROOT_DIR)/scripts/e2e/teardown.sh; \
+	  if [ $$e2e_exit -ne 0 ]; then \
+	    echo "$(RED)❌ E2E tests failed. Full log: $(TMP_DIR)/e2e-test.log$(NC)"; \
+	    echo "$(YELLOW)   API log: $(E2E_API_LOG)$(NC)"; \
+	    exit $$e2e_exit; \
+	  fi
 
 test-e2e-langfuse: ## Run Langfuse E2E tests (requires: make test-langfuse-up && make start)
 	@echo "$(CYAN)🧪 Running Langfuse E2E tests...$(NC)"
@@ -995,6 +1023,12 @@ e2e-status:
 	else \
 		echo "$(RED)not running$(NC)"; \
 	fi
+
+e2e-reap: ## GC per-worktree test containers/buckets left by crashed agents (run when agents are idle)
+	@$(ROOT_DIR)/scripts/e2e/reap.sh
+
+e2e-scripts-test: ## Unit-test the scripts/e2e helpers (free-port, RUN_ID, provision/teardown)
+	@$(WORKER_VENV_PYTHON) -m pytest $(ROOT_DIR)/tests/e2e-scripts -q
 
 local-ci:
 	@echo "$(CYAN)🚀 Running Local CI checks...$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ MAIN_ROOT := $(shell d=$$(git rev-parse --git-common-dir 2>/dev/null); \
 # SHELL), so keep it POSIX.
 RUN_ID := $(shell if [ "$(ROOT_DIR)" = "$(MAIN_ROOT)" ]; then echo ""; \
 	else s=$$(basename "$(ROOT_DIR)" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-+//; s/-+$$//'); \
-	[ -n "$$s" ] && echo "$$s" || echo "wt-$$(basename "$(ROOT_DIR)" | cksum | cut -d' ' -f1)"; fi)
+	h=$$(printf '%s' "$(ROOT_DIR)" | cksum | cut -d' ' -f1); \
+	[ -n "$$s" ] && echo "$$s-$$h" || echo "wt-$$h"; fi)
 
 # Load local environment variables if present. From a worktree, load the
 # primary checkout's file FIRST, then the worktree-local one LAST so a

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -315,12 +315,12 @@ make e2e-test PYTEST_ARGS='-k my_test'
 # Skip teardown so a fix→test loop reuses this run's container
 E2E_KEEP=1 make worker-test
 
-# Or manage E2E infra manually
-make e2e-up        # start isolated DB + API
+# Or manage E2E infra manually — PRIMARY CHECKOUT ONLY (see note below)
+make e2e-up        # start the fixed primary DB + API (par-e2e-postgres / 8081)
 make e2e-status    # check what's running
-make e2e-down      # stop E2E stack
+make e2e-down      # stop the primary E2E stack
 
-# If something failed mid-run, force-clean leftovers
+# If something failed mid-run, force-clean leftovers (primary checkout)
 make e2e-clean
 
 # GC per-worktree containers/buckets left behind by crashed agents (fleet hygiene)
@@ -330,6 +330,8 @@ make e2e-reap
 `make e2e-test` uses `-v --tb=short -ra` for verbose progress and failure details. Logs are written to `.tmp/e2e-test.log` and `.tmp/e2e-api-service.log`.
 
 **Teardown contract (both checkouts):** by default every `make worker-test` / `make e2e-test` run **disposes its DB container** (`docker rm -f`) when it finishes — on the primary checkout and inside a worktree alike — so a run always cleans up after itself. `E2E_KEEP=1` is the opt-out: it leaves the container (and the API/bucket) up so the next run reuses them for a faster fix→test loop. The shared `platform-artifacts` bucket and the shared LocalStack are never torn down (only per-worktree `platform-artifacts-<slug>` buckets are). The legacy `make e2e-up` / `make e2e-down` targets are the exception — they `docker stop` (not remove) the primary container for a manual reuse lifecycle.
+
+> **`make e2e-up` / `e2e-down` / `e2e-status` / `e2e-clean` are primary-checkout-only.** They use the fixed names/ports (`par-e2e-postgres`, 55433/8081) and do **not** read `.tmp/e2e.env`, so running them from a worktree operates on the *primary* infra — it won't manage that worktree's isolated run and can collide with the primary checkout or another worktree. From a worktree, use `make worker-test` / `make e2e-test` (which self-provision and tear down per run); to clean up a crashed worktree run, re-run it (deterministic names replace it in place) or `make e2e-reap`.
 
 `PYTEST_ARGS` is forwarded to both `make worker-test` and `make e2e-test`, so a single test always runs against this checkout's isolated infra. `make e2e-reap` garbage-collects leftover per-worktree containers and buckets from agents that crashed before teardown — run it when agents are idle. A single agent normally never needs `e2e-reap`: container/bucket names are deterministic per checkout, so a re-run replaces its own infra in place.
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -277,20 +277,43 @@ make db-reset-verify
 
 ## E2E Tests (Isolated Infrastructure)
 
-E2E tests run against **fully isolated infrastructure** that does not interfere with local development:
+E2E tests run against **fully isolated infrastructure** that does not interfere with local development. `make worker-test` and `make e2e-test` self-provision this infra keyed by the checkout — the command you run is unchanged, with no manual steps or port-picking.
 
-| Resource   | Local Dev          | E2E Tests                    |
-|------------|--------------------|------------------------------|
-| Postgres   | `:55432`           | `:55433`                     |
-| API        | `:8080`            | `:8081`                      |
-| DB name    | `persistent_agent_runtime` | `persistent_agent_runtime_e2e` |
-| Container  | `persistent-agent-runtime-postgres` | `par-e2e-postgres` |
+**Primary checkout** (the main working tree, not a worktree) uses fixed values, byte-identical to before — this is the path CI runs:
+
+| Resource          | Local Dev                           | E2E Tests (primary checkout)   |
+|-------------------|-------------------------------------|--------------------------------|
+| Postgres          | `:55432`                            | `:55433`                       |
+| API               | `:8080`                             | `:8081`                        |
+| Embedding mock    | —                                   | `:18099`                       |
+| DB name           | `persistent_agent_runtime`          | `persistent_agent_runtime_e2e` |
+| Postgres container| `persistent-agent-runtime-postgres` | `par-e2e-postgres`             |
+| S3 bucket         | —                                   | `platform-artifacts`           |
+
+**Inside a git worktree**, each checkout gets its **own** isolated infra so multiple agents can run `make worker-test` / `make e2e-test` concurrently without clobbering each other:
+
+| Resource          | E2E Tests (in a worktree)                  |
+|-------------------|--------------------------------------------|
+| Postgres container| `par-e2e-postgres-<slug>`                  |
+| Postgres port     | dynamically allocated host port            |
+| API / embed ports | dynamically allocated (e2e-test)           |
+| S3 bucket         | `platform-artifacts-<slug>`                |
+
+`<slug>` is a lowercase slug of the worktree directory name. The resolved container names, ports, and bucket are recorded in the contract file `<worktree>/.tmp/e2e.env`. One shared LocalStack (`:4566`) is reused by all checkouts. Implementation lives in `scripts/e2e/` (`provision.sh`, `teardown.sh`, `reap.sh`, `free-port.py`, `common.sh`).
+
+> **From a worktree, always use `make e2e-test` / `make worker-test`, never raw `pytest`.** Raw `pytest tests/backend-integration` hits the fixed default ports (55433 / 8081 / 18099) and can collide with the primary checkout or another worktree. To run a single test through the isolated harness, pass `PYTEST_ARGS` (see below).
 
 ### Running E2E tests
 
 ```bash
-# Run E2E tests (auto-starts isolated Postgres + API if needed)
+# Run E2E tests (auto-provisions isolated infra for this checkout if needed)
 make e2e-test
+
+# Run a single test THROUGH the isolated harness
+make e2e-test PYTEST_ARGS='-k my_test'
+
+# Skip teardown so a fix→test loop reuses this run's container
+E2E_KEEP=1 make worker-test
 
 # Or manage E2E infra manually
 make e2e-up        # start isolated DB + API
@@ -299,9 +322,16 @@ make e2e-down      # stop E2E stack
 
 # If something failed mid-run, force-clean leftovers
 make e2e-clean
+
+# GC per-worktree containers/buckets left behind by crashed agents (fleet hygiene)
+make e2e-reap
 ```
 
 `make e2e-test` uses `-v --tb=short -ra` for verbose progress and failure details. Logs are written to `.tmp/e2e-test.log` and `.tmp/e2e-api-service.log`.
+
+**Teardown contract (both checkouts):** by default every `make worker-test` / `make e2e-test` run **disposes its DB container** (`docker rm -f`) when it finishes — on the primary checkout and inside a worktree alike — so a run always cleans up after itself. `E2E_KEEP=1` is the opt-out: it leaves the container (and the API/bucket) up so the next run reuses them for a faster fix→test loop. The shared `platform-artifacts` bucket and the shared LocalStack are never torn down (only per-worktree `platform-artifacts-<slug>` buckets are). The legacy `make e2e-up` / `make e2e-down` targets are the exception — they `docker stop` (not remove) the primary container for a manual reuse lifecycle.
+
+`PYTEST_ARGS` is forwarded to both `make worker-test` and `make e2e-test`, so a single test always runs against this checkout's isolated infra. `make e2e-reap` garbage-collects leftover per-worktree containers and buckets from agents that crashed before teardown — run it when agents are idle. A single agent normally never needs `e2e-reap`: container/bucket names are deterministic per checkout, so a re-run replaces its own infra in place.
 
 ### Test targets
 
@@ -378,11 +408,11 @@ npx vitest run --reporter=verbose -t "renders budget fields"
 
 ### Infrastructure prerequisites for tests
 
-**All tests use an isolated test database — never the local dev database.** Worker integration tests and E2E tests both connect to a dedicated test PostgreSQL container (`par-e2e-postgres`) on port **55433**, separate from the local dev DB on port 55432. This ensures tests never destroy your local development data.
+**All tests use an isolated test database — never the local dev database.** Worker integration tests and E2E tests both connect to a dedicated test PostgreSQL container, separate from the local dev DB on port 55432. On the **primary checkout** that container is `par-e2e-postgres` on port **55433**; **inside a git worktree** it is `par-e2e-postgres-<slug>` on a dynamically allocated port (see [E2E Tests (Isolated Infrastructure)](#e2e-tests-isolated-infrastructure) above for the full per-worktree model and the `.tmp/e2e.env` contract file). Either way, tests never destroy your local development data — and from a worktree you must use `make worker-test` / `make e2e-test`, not raw `pytest`, so the run targets this checkout's isolated infra rather than the fixed default ports.
 
-`make worker-test` automatically starts the test database container and applies migrations via the `test-db-up` dependency. If you see `N passed, 12 skipped` in worker test output, it means Docker is not running — start Docker Desktop and re-run.
+`make worker-test` automatically provisions the test database container and applies migrations. If you see `N passed, 12 skipped` in worker test output, it means Docker is not running — start Docker Desktop and re-run.
 
-`make e2e-test` also depends on the test database (via `e2e-up → test-db-up`) plus an API service on port 8081. LocalStack on port 4566 must be running for artifact-related E2E tests — `make db-up` starts both the dev PostgreSQL and LocalStack containers.
+`make e2e-test` also provisions the test database plus an isolated API service (port 8081 on the primary checkout; dynamic in a worktree). LocalStack on port 4566 must be running for artifact-related E2E tests and is shared across all checkouts — `make db-up` starts both the dev PostgreSQL and LocalStack containers.
 
 ### Pre-existing test failures
 

--- a/scripts/e2e/common.sh
+++ b/scripts/e2e/common.sh
@@ -35,10 +35,10 @@ e2e_main_root() {
   fi
 }
 
-# RUN_ID: empty on the primary checkout, else a lowercase slug of the worktree
-# basename. MUST match the Makefile's RUN_ID derivation.
+# RUN_ID: empty on the primary checkout, else a readable slug of the worktree
+# basename plus a hash of the FULL path. MUST match the Makefile's RUN_ID.
 e2e_run_id() {
-  local root main slug
+  local root main slug hash
   root=$(e2e_root_dir)
   main=$(e2e_main_root)
   if [ "$root" = "$main" ]; then
@@ -46,14 +46,18 @@ e2e_run_id() {
     return
   fi
   slug=$(basename "$root" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-+//; s/-+$//')
-  # A worktree whose basename is all punctuation slugs to empty — which would be
-  # misread as the primary checkout and collide with it. Fall back to a stable
-  # non-empty token so a worktree is NEVER classified as primary. (cksum is the
-  # same binary Make's $(shell) sees, so RUN_ID parity holds on this machine.)
+  # Hash the FULL path, not just the basename: two worktrees that share a leaf
+  # name (…/a/feature vs …/b/feature) would otherwise derive the same RUN_ID and
+  # clobber each other's container/bucket. The hash guarantees uniqueness; the
+  # slug is just a readable prefix (and is omitted when the basename is all
+  # punctuation, so a worktree is never misread as the primary checkout). cksum
+  # is the same binary Make's $(shell) sees, so RUN_ID parity holds per machine.
+  hash=$(printf '%s' "$root" | cksum | cut -d' ' -f1)
   if [ -z "$slug" ]; then
-    slug="wt-$(basename "$root" | cksum | cut -d' ' -f1)"
+    printf 'wt-%s' "$hash"
+  else
+    printf '%s-%s' "$slug" "$hash"
   fi
-  printf '%s' "$slug"
 }
 
 # --- Fixed constants (match Makefile defaults) -----------------------------
@@ -115,16 +119,20 @@ e2e_discover_pg_port() {
   docker port "$container" 5432/tcp 2>/dev/null | head -1 | sed -E 's/.*:([0-9]+)$/\1/'
 }
 
-# Ensure the shared LocalStack container is up and S3 is answering. Idempotent;
-# safe to call concurrently (guarded by a running-check, then compose up).
+# Ensure the shared LocalStack container is up AND S3 is answering. Idempotent
+# and concurrency-safe.
 e2e_ensure_localstack() {
-  if docker ps --format '{{.Names}}' | grep -qx "$LOCALSTACK_CONTAINER_NAME"; then
-    return 0
+  if ! docker ps --format '{{.Names}}' | grep -qx "$LOCALSTACK_CONTAINER_NAME"; then
+    # `|| true`: two concurrent cold provisions may both race `compose up` on the
+    # shared fixed container_name and one returns non-zero — tolerate it and let
+    # the readiness loop below be the real gate.
+    docker compose -f "$(e2e_compose_file)" up -d localstack >/dev/null 2>&1 || true
   fi
-  # `|| true`: two concurrent cold provisions may both race `compose up` on the
-  # shared fixed container_name and one returns non-zero — tolerate it and let
-  # the readiness loop below be the real gate.
-  docker compose -f "$(e2e_compose_file)" up -d localstack >/dev/null 2>&1 || true
+  # ALWAYS wait for S3 to actually answer — a running container does NOT imply a
+  # ready S3 endpoint. If a concurrent provision just started LocalStack, the
+  # container shows "running" before `awslocal s3 ls` works; returning early here
+  # would let `awslocal s3 mb` (which swallows errors with `|| true`) no-op, so
+  # artifact tests would run without their bucket.
   local attempts=0
   until docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 ls >/dev/null 2>&1; do
     attempts=$((attempts + 1))

--- a/scripts/e2e/common.sh
+++ b/scripts/e2e/common.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Shared helpers for the per-worktree E2E test harness (issue #112).
+#
+# Sourced by provision.sh / teardown.sh / reap.sh. Keep this POSIX-friendly
+# bash (macOS ships bash 3.2): no mapfile, no ${var,,}, no associative arrays.
+#
+# The "run" is keyed by RUN_ID — a slug of the current checkout directory.
+# On the primary checkout (ROOT_DIR == MAIN_ROOT) RUN_ID is empty and every
+# name/port falls back to today's fixed single-instance values so CI and the
+# main-checkout workflow stay byte-identical. Inside a git worktree RUN_ID is
+# non-empty and names are suffixed, ports are dynamically allocated.
+
+# --- Roots -----------------------------------------------------------------
+# Make exports ROOT_DIR / MAIN_ROOT via .EXPORT_ALL_VARIABLES, but the scripts
+# also work standalone: fall back to pwd / git.
+e2e_root_dir() {
+  if [ -n "${ROOT_DIR:-}" ]; then
+    printf '%s' "$ROOT_DIR"
+  else
+    pwd
+  fi
+}
+
+e2e_main_root() {
+  if [ -n "${MAIN_ROOT:-}" ]; then
+    printf '%s' "$MAIN_ROOT"
+    return
+  fi
+  local d
+  d=$(git rev-parse --git-common-dir 2>/dev/null || true)
+  if [ -n "$d" ]; then
+    (cd "$d/.." && pwd)
+  else
+    pwd
+  fi
+}
+
+# RUN_ID: empty on the primary checkout, else a lowercase slug of the worktree
+# basename. MUST match the Makefile's RUN_ID derivation.
+e2e_run_id() {
+  local root main slug
+  root=$(e2e_root_dir)
+  main=$(e2e_main_root)
+  if [ "$root" = "$main" ]; then
+    printf ''
+    return
+  fi
+  slug=$(basename "$root" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-+//; s/-+$//')
+  # A worktree whose basename is all punctuation slugs to empty — which would be
+  # misread as the primary checkout and collide with it. Fall back to a stable
+  # non-empty token so a worktree is NEVER classified as primary. (cksum is the
+  # same binary Make's $(shell) sees, so RUN_ID parity holds on this machine.)
+  if [ -z "$slug" ]; then
+    slug="wt-$(basename "$root" | cksum | cut -d' ' -f1)"
+  fi
+  printf '%s' "$slug"
+}
+
+# --- Fixed constants (match Makefile defaults) -----------------------------
+E2E_DB_NAME="${E2E_DB_NAME:-persistent_agent_runtime_e2e}"
+E2E_DB_USER="${E2E_DB_USER:-postgres}"
+E2E_DB_PASSWORD="${E2E_DB_PASSWORD:-postgres}"
+E2E_DB_HOST="${E2E_DB_HOST:-localhost}"
+E2E_PG_IMAGE="${E2E_PG_IMAGE:-pgvector/pgvector:pg16}"
+LOCALSTACK_CONTAINER_NAME="${LOCALSTACK_CONTAINER_NAME:-persistent-agent-runtime-localstack}"
+S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-http://localhost:4566}"
+S3_BUCKET_BASE="${S3_BUCKET_BASE:-platform-artifacts}"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+E2E_EMBEDDING_MOCK_PROVIDER_ID="${E2E_EMBEDDING_MOCK_PROVIDER_ID:-memory-mock}"
+
+# --- Name builders (branch on RUN_ID for byte-compat) ----------------------
+# Postgres container name. Primary → par-e2e-postgres; worktree → -<RUN_ID>.
+e2e_pg_container() {
+  local rid
+  rid=$(e2e_run_id)
+  if [ -z "$rid" ]; then
+    printf 'par-e2e-postgres'
+  else
+    printf 'par-e2e-postgres-%s' "$rid"
+  fi
+}
+
+# S3 bucket name. Primary → platform-artifacts; worktree → -<RUN_ID>.
+e2e_s3_bucket() {
+  local rid
+  rid=$(e2e_run_id)
+  if [ -z "$rid" ]; then
+    printf '%s' "$S3_BUCKET_BASE"
+  else
+    printf '%s-%s' "$S3_BUCKET_BASE" "$rid"
+  fi
+}
+
+# Path to the per-run contract file under the worktree's own .tmp/.
+e2e_env_file() {
+  printf '%s/.tmp/e2e.env' "$(e2e_root_dir)"
+}
+
+# Directory holding the SQL migrations.
+e2e_migrations_dir() {
+  printf '%s/infrastructure/database/migrations' "$(e2e_root_dir)"
+}
+
+# docker-compose file (for the shared LocalStack service).
+e2e_compose_file() {
+  printf '%s/docker-compose.yml' "$(e2e_root_dir)"
+}
+
+# Discover the host port mapped to a container's 5432/tcp. Handles IPv4+IPv6
+# lines (takes the first) on both Docker Desktop (macOS) and Linux.
+e2e_discover_pg_port() {
+  local container="$1"
+  docker port "$container" 5432/tcp 2>/dev/null | head -1 | sed -E 's/.*:([0-9]+)$/\1/'
+}
+
+# Ensure the shared LocalStack container is up and S3 is answering. Idempotent;
+# safe to call concurrently (guarded by a running-check, then compose up).
+e2e_ensure_localstack() {
+  if docker ps --format '{{.Names}}' | grep -qx "$LOCALSTACK_CONTAINER_NAME"; then
+    return 0
+  fi
+  # `|| true`: two concurrent cold provisions may both race `compose up` on the
+  # shared fixed container_name and one returns non-zero — tolerate it and let
+  # the readiness loop below be the real gate.
+  docker compose -f "$(e2e_compose_file)" up -d localstack >/dev/null 2>&1 || true
+  local attempts=0
+  until docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 ls >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "❌ LocalStack did not become ready" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}

--- a/scripts/e2e/free-port.py
+++ b/scripts/e2e/free-port.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Print N free TCP ports, space-separated on one line.
+
+Binds N sockets to 127.0.0.1:0 and collects every assigned port *before*
+closing any of them, so the N ports are guaranteed distinct within one call.
+Space-separated output lets a caller do `read A B < <(free-port.py 2)`.
+
+There is an unavoidable TOCTOU window between closing the sockets here and the
+consumer binding the port; that is acceptable for the per-worktree harness
+(the DB port is allocated race-free by Docker, and the API/embedding consumers
+fail loudly on a bind collision rather than corrupting anything).
+"""
+from __future__ import annotations
+
+import socket
+import sys
+
+
+def free_ports(n: int) -> list[int]:
+    socks = []
+    try:
+        for _ in range(n):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", 0))
+            socks.append(s)
+        return [s.getsockname()[1] for s in socks]
+    finally:
+        for s in socks:
+            s.close()
+
+
+def main() -> int:
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    if n < 1:
+        print("usage: free-port.py [N>=1]", file=sys.stderr)
+        return 2
+    print(" ".join(str(p) for p in free_ports(n)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e/provision.sh
+++ b/scripts/e2e/provision.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Provision an isolated test-infra "run" for the current checkout (issue #112).
+#
+# Used by both `make worker-test` (DB + S3) and `make e2e-test` (+ API/embedding
+# ports). Writes $ROOT_DIR/.tmp/e2e.env — the contract file every other target
+# sources so they all target THIS run's resources.
+#
+# Primary checkout (RUN_ID empty)  → today's fixed names/ports (byte-identical).
+# Worktree (RUN_ID non-empty)      → own container/bucket + dynamic ports.
+#
+# Env inputs:  ROOT_DIR, MAIN_ROOT (exported by Make; else derived)
+#              E2E_NEED_API=1  → also allocate API + embedding-mock ports
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/e2e/common.sh
+. "$SCRIPT_DIR/common.sh"
+
+command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required for tests" >&2; exit 1; }
+
+RUN_ID=$(e2e_run_id)
+PG_CONTAINER=$(e2e_pg_container)
+BUCKET=$(e2e_s3_bucket)
+ENV_FILE=$(e2e_env_file)
+MIGRATIONS_DIR=$(e2e_migrations_dir)
+NEED_API="${E2E_NEED_API:-}"
+
+# If we abort before finishing (e.g. a migration/seed failure), remove a freshly
+# created worktree container so a failed run never leaks one. Primary (empty
+# RUN_ID) is left alone — it's reused, not disposable.
+PROVISION_DONE=
+_provision_cleanup() {
+  if [ -n "$RUN_ID" ] && [ "$PROVISION_DONE" != "1" ]; then
+    docker rm -f "$PG_CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap _provision_cleanup EXIT
+
+mkdir -p "$(dirname "$ENV_FILE")"
+
+# --- Shared LocalStack -----------------------------------------------------
+e2e_ensure_localstack
+
+# --- Postgres --------------------------------------------------------------
+if [ -z "$RUN_ID" ]; then
+  # Primary checkout: fixed container on fixed port 55433 (today's behavior).
+  DB_PORT=55433
+  if docker ps --format '{{.Names}}' | grep -qx "$PG_CONTAINER"; then
+    : # already running
+  elif docker ps -a --format '{{.Names}}' | grep -qx "$PG_CONTAINER"; then
+    docker start "$PG_CONTAINER" >/dev/null
+  else
+    echo "▶ Creating test Postgres container $PG_CONTAINER (port $DB_PORT)..."
+    docker run -d --name "$PG_CONTAINER" \
+      --label par-e2e=1 --label par-run= \
+      -e POSTGRES_USER="$E2E_DB_USER" \
+      -e POSTGRES_PASSWORD="$E2E_DB_PASSWORD" \
+      -e POSTGRES_DB="$E2E_DB_NAME" \
+      -p "${DB_PORT}:5432" \
+      "$E2E_PG_IMAGE" >/dev/null
+  fi
+else
+  # Worktree: reuse-if-healthy, else recreate on an OS-allocated host port.
+  if docker ps --format '{{.Names}}' | grep -qx "$PG_CONTAINER" \
+      && docker exec "$PG_CONTAINER" pg_isready -U "$E2E_DB_USER" >/dev/null 2>&1; then
+    : # healthy — reuse (fast inner loop for E2E_KEEP re-runs)
+  else
+    # Stale/stopped same-named container from a crashed run would make
+    # `docker run --name` fail with "name already in use" — remove it first.
+    docker rm -f "$PG_CONTAINER" >/dev/null 2>&1 || true
+    echo "▶ Creating test Postgres container $PG_CONTAINER (RUN_ID=$RUN_ID, dynamic port)..."
+    docker run -d --name "$PG_CONTAINER" \
+      --label par-e2e=1 --label "par-run=$RUN_ID" \
+      -e POSTGRES_USER="$E2E_DB_USER" \
+      -e POSTGRES_PASSWORD="$E2E_DB_PASSWORD" \
+      -e POSTGRES_DB="$E2E_DB_NAME" \
+      -p 0:5432 \
+      "$E2E_PG_IMAGE" >/dev/null
+  fi
+  DB_PORT=$(e2e_discover_pg_port "$PG_CONTAINER")
+  if [ -z "$DB_PORT" ]; then
+    echo "❌ Could not discover host port for $PG_CONTAINER" >&2
+    exit 1
+  fi
+fi
+
+# Wait for readiness.
+for _ in $(seq 1 60); do
+  docker exec "$PG_CONTAINER" pg_isready -U "$E2E_DB_USER" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+docker exec "$PG_CONTAINER" pg_isready -U "$E2E_DB_USER" >/dev/null 2>&1 || {
+  echo "❌ Test Postgres ($PG_CONTAINER) did not become ready" >&2
+  exit 1
+}
+
+DB_DSN="postgresql://${E2E_DB_USER}:${E2E_DB_PASSWORD}@${E2E_DB_HOST}:${DB_PORT}/${E2E_DB_NAME}"
+
+# Wait for the HOST port forward to actually accept connections. `docker exec
+# pg_isready` only proves the container's INTERNAL socket is up — the published
+# host port can lag, especially when two containers are created concurrently.
+# Without this, the host-side migrations below race the port forward and silently
+# no-op (errors swallowed), leaving an empty schema.
+host_ready=
+for _ in $(seq 1 60); do
+  if PGPASSWORD="$E2E_DB_PASSWORD" psql -h "$E2E_DB_HOST" -p "$DB_PORT" \
+      -U "$E2E_DB_USER" -d "$E2E_DB_NAME" -tAc 'SELECT 1' >/dev/null 2>&1; then
+    host_ready=1
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "$host_ready" ]; then
+  echo "❌ Postgres host port $DB_PORT for $PG_CONTAINER never accepted connections" >&2
+  exit 1
+fi
+
+# --- Migrations + seed -----------------------------------------------------
+# Apply the full numbered glob every time, errors suppressed — exactly like the
+# old test-db-up. Re-applying on an existing schema is a no-op (CREATE/ALTER
+# error → swallowed by `|| true`), and applying every run is self-healing: a
+# partially-applied schema from a crashed/interrupted prior run is repaired on
+# the next provision. (We deliberately do NOT skip on a schema-present check —
+# there's no migration-version table, so `tasks` existing can't prove the LATER
+# migrations ran.)
+for f in "$MIGRATIONS_DIR"/[0-9][0-9][0-9][0-9]_*.sql; do
+  PGPASSWORD="$E2E_DB_PASSWORD" psql -h "$E2E_DB_HOST" -p "$DB_PORT" \
+    -U "$E2E_DB_USER" -d "$E2E_DB_NAME" -f "$f" -q 2>/dev/null || true
+done
+# Fail loudly if migrations didn't establish the schema (rather than letting the
+# seed below blow up with a cryptic "relation does not exist").
+if [ -z "$(PGPASSWORD="$E2E_DB_PASSWORD" psql -h "$E2E_DB_HOST" -p "$DB_PORT" \
+    -U "$E2E_DB_USER" -d "$E2E_DB_NAME" -tAc "SELECT to_regclass('public.provider_keys')" 2>/dev/null)" ]; then
+  echo "❌ Migrations did not establish schema on $PG_CONTAINER (port $DB_PORT)" >&2
+  exit 1
+fi
+# Seed provider + model rows (idempotent; matches today's test-db-up inline seed,
+# which the numbered-migration glob does NOT cover — test_seed.sql is never applied
+# by the Make path). Always run: cheap and ON CONFLICT-safe even on reuse.
+PGPASSWORD="$E2E_DB_PASSWORD" psql -h "$E2E_DB_HOST" -p "$DB_PORT" \
+  -U "$E2E_DB_USER" -d "$E2E_DB_NAME" -q \
+  -c "INSERT INTO provider_keys (provider_id, api_key) VALUES ('anthropic', 'e2e-placeholder') ON CONFLICT (provider_id) DO NOTHING;" \
+  -c "INSERT INTO models (model_id, provider_id, display_name, is_active, input_microdollars_per_million, output_microdollars_per_million) VALUES ('claude-sonnet-4-6', 'anthropic', 'Claude Sonnet 4.6', true, 3000000, 15000000) ON CONFLICT (provider_id, model_id) DO NOTHING;"
+
+# --- S3 bucket -------------------------------------------------------------
+docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 mb "s3://${BUCKET}" >/dev/null 2>&1 || true
+
+# --- API + embedding ports (e2e-test only) ---------------------------------
+API_PORT=""
+EMB_PORT=""
+if [ -n "$NEED_API" ]; then
+  if [ -z "$RUN_ID" ]; then
+    API_PORT=8081
+    EMB_PORT=18099
+  else
+    read -r API_PORT EMB_PORT < <("${PYTHON:-python3}" "$SCRIPT_DIR/free-port.py" 2)
+  fi
+fi
+
+# --- Write the contract file -----------------------------------------------
+{
+  echo "RUN_ID=$RUN_ID"
+  echo "E2E_DB_HOST=$E2E_DB_HOST"
+  echo "E2E_DB_PORT=$DB_PORT"
+  echo "E2E_DB_NAME=$E2E_DB_NAME"
+  echo "E2E_DB_USER=$E2E_DB_USER"
+  echo "E2E_DB_PASSWORD=$E2E_DB_PASSWORD"
+  echo "E2E_DB_DSN=$DB_DSN"
+  echo "E2E_PG_CONTAINER=$PG_CONTAINER"
+  echo "E2E_PG_IMAGE=$E2E_PG_IMAGE"
+  echo "S3_ENDPOINT_URL=$S3_ENDPOINT_URL"
+  echo "S3_BUCKET_NAME=$BUCKET"
+  echo "LOCALSTACK_CONTAINER_NAME=$LOCALSTACK_CONTAINER_NAME"
+  echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+  echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+  echo "AWS_REGION=$AWS_REGION"
+  echo "E2E_EMBEDDING_MOCK_PROVIDER_ID=$E2E_EMBEDDING_MOCK_PROVIDER_ID"
+  if [ -n "$NEED_API" ]; then
+    echo "E2E_API_PORT=$API_PORT"
+    echo "E2E_API_BASE=http://localhost:${API_PORT}/v1"
+    echo "E2E_EMBEDDING_MOCK_PORT=$EMB_PORT"
+    echo "E2E_EMBEDDING_MOCK_ENDPOINT=http://127.0.0.1:${EMB_PORT}/v1/embeddings"
+  fi
+} > "$ENV_FILE"
+
+# Provisioning succeeded — disarm the failure-cleanup trap.
+PROVISION_DONE=1
+
+echo "✓ Provisioned run '${RUN_ID:-primary}': DB :$DB_PORT ($PG_CONTAINER), bucket $BUCKET${NEED_API:+, API :$API_PORT, embed :$EMB_PORT}"
+echo "  contract: $ENV_FILE"

--- a/scripts/e2e/provision.sh
+++ b/scripts/e2e/provision.sh
@@ -153,7 +153,20 @@ if [ -n "$NEED_API" ]; then
     API_PORT=8081
     EMB_PORT=18099
   else
-    read -r API_PORT EMB_PORT < <("${PYTHON:-python3}" "$SCRIPT_DIR/free-port.py" 2)
+    # Reuse the prior run's ports if an e2e.env survived (E2E_KEEP=1 or a crash):
+    # a still-running kept API stays on E2E_API_PORT, so the Makefile finds it
+    # healthy and does NOT spawn a second bootRun — which would orphan the first
+    # (its pid file gets overwritten) and break API↔mock port agreement. If the
+    # old API is actually dead, its port is free again and the Makefile starts a
+    # fresh one there. (No `head`: e2e.env has one line per key, and dropping it
+    # avoids the grep|head SIGPIPE under `pipefail`.)
+    if [ -f "$ENV_FILE" ]; then
+      API_PORT=$(grep -E '^E2E_API_PORT=' "$ENV_FILE" | cut -d= -f2 || true)
+      EMB_PORT=$(grep -E '^E2E_EMBEDDING_MOCK_PORT=' "$ENV_FILE" | cut -d= -f2 || true)
+    fi
+    if [ -z "$API_PORT" ] || [ -z "$EMB_PORT" ]; then
+      read -r API_PORT EMB_PORT < <("${PYTHON:-python3}" "$SCRIPT_DIR/free-port.py" 2)
+    fi
   fi
 fi
 

--- a/scripts/e2e/provision.sh
+++ b/scripts/e2e/provision.sh
@@ -25,12 +25,15 @@ ENV_FILE=$(e2e_env_file)
 MIGRATIONS_DIR=$(e2e_migrations_dir)
 NEED_API="${E2E_NEED_API:-}"
 
-# If we abort before finishing (e.g. a migration/seed failure), remove a freshly
-# created worktree container so a failed run never leaks one. Primary (empty
-# RUN_ID) is left alone — it's reused, not disposable.
+# If we abort before finishing (e.g. a migration/seed failure), remove the
+# worktree container WE CREATED this run so a failed run never leaks one. Only
+# fires for a freshly-created worktree container — never a reused one (it may be
+# serving a kept API or a concurrent step) and never the primary (empty RUN_ID),
+# which is reused, not disposable.
 PROVISION_DONE=
+CONTAINER_CREATED=
 _provision_cleanup() {
-  if [ -n "$RUN_ID" ] && [ "$PROVISION_DONE" != "1" ]; then
+  if [ -n "$RUN_ID" ] && [ "$PROVISION_DONE" != "1" ] && [ -n "$CONTAINER_CREATED" ]; then
     docker rm -f "$PG_CONTAINER" >/dev/null 2>&1 || true
   fi
 }
@@ -76,6 +79,7 @@ else
       -e POSTGRES_DB="$E2E_DB_NAME" \
       -p 0:5432 \
       "$E2E_PG_IMAGE" >/dev/null
+    CONTAINER_CREATED=1
   fi
   DB_PORT=$(e2e_discover_pg_port "$PG_CONTAINER")
   if [ -z "$DB_PORT" ]; then
@@ -84,8 +88,9 @@ else
   fi
 fi
 
-# Wait for readiness.
-for _ in $(seq 1 60); do
+# Wait for readiness (up to ~60s — generous so concurrent container starts under
+# load don't time out spuriously).
+for _ in $(seq 1 120); do
   docker exec "$PG_CONTAINER" pg_isready -U "$E2E_DB_USER" >/dev/null 2>&1 && break
   sleep 0.5
 done

--- a/scripts/e2e/reap.sh
+++ b/scripts/e2e/reap.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# GC test-infra leftovers from crashed agents (issue #112).
+#
+# Sledgehammer by design: removes EVERY container labeled par-e2e=1 and EVERY
+# per-run bucket (platform-artifacts-<slug>). A leaked container from a crashed
+# agent is usually still running, so we cannot distinguish "live" from "stale"
+# reliably — run this as fleet hygiene when agents are idle. A single active
+# agent never needs it: deterministic per-worktree names mean a re-run replaces
+# its own container. Never touches the shared `platform-artifacts` bucket.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/e2e/common.sh
+. "$SCRIPT_DIR/common.sh"
+
+command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required" >&2; exit 1; }
+
+# --- Containers ------------------------------------------------------------
+ids=$(docker ps -aq --filter label=par-e2e=1 || true)
+if [ -n "$ids" ]; then
+  echo "▶ Removing $(printf '%s\n' "$ids" | grep -c . | tr -d ' ') labeled test container(s)..."
+  # shellcheck disable=SC2086
+  docker rm -f $ids >/dev/null 2>&1 || true
+else
+  echo "  no labeled test containers to reap"
+fi
+
+# --- Per-run buckets (never the shared base bucket) ------------------------
+if docker ps --format '{{.Names}}' | grep -qx "$LOCALSTACK_CONTAINER_NAME"; then
+  buckets=$(docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 ls 2>/dev/null \
+    | awk '{print $3}' | grep -E "^${S3_BUCKET_BASE}-." || true)
+  for b in $buckets; do
+    echo "▶ Dropping per-run bucket $b"
+    docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 rb "s3://${b}" --force >/dev/null 2>&1 || true
+  done
+fi
+
+echo "✓ Reap complete"

--- a/scripts/e2e/reap.sh
+++ b/scripts/e2e/reap.sh
@@ -16,13 +16,22 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 command -v docker >/dev/null 2>&1 || { echo "❌ Docker is required" >&2; exit 1; }
 
 # --- Containers ------------------------------------------------------------
-ids=$(docker ps -aq --filter label=par-e2e=1 || true)
+# Only per-WORKTREE containers (non-empty par-run label) — never the primary
+# `par-e2e-postgres` (par-run is empty there). The primary container is owned by
+# the primary checkout's own teardown / `make e2e-clean`; reap is for crashed
+# worktree agents. `--filter label=par-run` can't express "non-empty" (it
+# matches the key even when the value is ""), so inspect each candidate.
+ids=""
+for id in $(docker ps -aq --filter label=par-e2e=1 || true); do
+  run=$(docker inspect -f '{{ index .Config.Labels "par-run" }}' "$id" 2>/dev/null || true)
+  [ -n "$run" ] && ids="$ids $id"
+done
 if [ -n "$ids" ]; then
-  echo "▶ Removing $(printf '%s\n' "$ids" | grep -c . | tr -d ' ') labeled test container(s)..."
+  echo "▶ Removing $(echo $ids | wc -w | tr -d ' ') worktree test container(s)..."
   # shellcheck disable=SC2086
   docker rm -f $ids >/dev/null 2>&1 || true
 else
-  echo "  no labeled test containers to reap"
+  echo "  no worktree test containers to reap"
 fi
 
 # --- Per-run buckets (never the shared base bucket) ------------------------

--- a/scripts/e2e/teardown.sh
+++ b/scripts/e2e/teardown.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tear down the current run's test infra (issue #112). Idempotent and safe to
+# call even when nothing was provisioned. Sources $ROOT_DIR/.tmp/e2e.env so it
+# always targets THIS run's container/bucket/API.
+#
+# E2E_KEEP=1  → leave everything up (fast fix→test loop; next run reuses it).
+#
+# Primary checkout: `docker stop` the shared container (reuse, byte-identical
+# with today's `e2e-down`). Worktree: `docker rm -f` the container and drop the
+# run's bucket (disposable). Never drops the shared `platform-artifacts` bucket.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=scripts/e2e/common.sh
+. "$SCRIPT_DIR/common.sh"
+
+ROOT=$(e2e_root_dir)
+ENV_FILE=$(e2e_env_file)
+TMP_DIR="$ROOT/.tmp"
+
+if [ "${E2E_KEEP:-}" = "1" ]; then
+  echo "↺ E2E_KEEP=1 — leaving run infra up for reuse"
+  exit 0
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  exit 0
+fi
+
+# Load the run's identifiers.
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+# --- API (if this run started one) -----------------------------------------
+if [ -f "$TMP_DIR/e2e-api.pid" ]; then
+  pid=$(cat "$TMP_DIR/e2e-api.pid" 2>/dev/null || true)
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  rm -f "$TMP_DIR/e2e-api.pid"
+fi
+# Best-effort port sweep (lsof may be absent on minimal Linux).
+if [ -n "${E2E_API_PORT:-}" ] && command -v lsof >/dev/null 2>&1; then
+  p=$(lsof -ti ":$E2E_API_PORT" 2>/dev/null || true)
+  [ -n "$p" ] && kill $p 2>/dev/null || true
+fi
+
+# --- Postgres --------------------------------------------------------------
+# Remove the container on BOTH primary and worktree — a test run cleans up fully
+# by default, regardless of checkout. E2E_KEEP=1 (handled above) is the opt-out
+# for a fast fix→test loop. CI runs pytest directly (not this Make path), so it's
+# unaffected; the legacy `make e2e-up`/`e2e-down` targets still stop-and-reuse the
+# primary container for manual lifecycles.
+docker rm -f "$E2E_PG_CONTAINER" >/dev/null 2>&1 || true
+
+# --- S3 bucket (worktree only; never the shared base bucket) ---------------
+if [ -n "${RUN_ID:-}" ] && [ -n "${S3_BUCKET_NAME:-}" ] && [ "$S3_BUCKET_NAME" != "$S3_BUCKET_BASE" ]; then
+  docker exec "$LOCALSTACK_CONTAINER_NAME" awslocal s3 rb "s3://${S3_BUCKET_NAME}" --force >/dev/null 2>&1 || true
+fi
+
+rm -f "$ENV_FILE"
+echo "✓ Tore down run '${RUN_ID:-primary}'"

--- a/scripts/e2e/teardown.sh
+++ b/scripts/e2e/teardown.sh
@@ -34,19 +34,27 @@ set -a
 set +a
 
 # --- API (if this run started one) -----------------------------------------
+# Only kill a pid whose command still looks like our API/Gradle process. A stale
+# pid file (crashed run) or a freed dynamic API port could otherwise have been
+# recycled by an unrelated process, and we must not kill that.
+_looks_like_api() {
+  ps -p "$1" -o command= 2>/dev/null | grep -qiE 'bootrun|gradle|[j]ava'
+}
 if [ -f "$TMP_DIR/e2e-api.pid" ]; then
   pid=$(cat "$TMP_DIR/e2e-api.pid" 2>/dev/null || true)
-  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && _looks_like_api "$pid"; then
     kill "$pid" 2>/dev/null || true
     for _ in $(seq 1 20); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
     kill -9 "$pid" 2>/dev/null || true
   fi
   rm -f "$TMP_DIR/e2e-api.pid"
 fi
-# Best-effort port sweep (lsof may be absent on minimal Linux).
+# Best-effort port sweep — catches the JVM that actually holds the port (the pid
+# file may track the gradle wrapper). lsof may be absent on minimal Linux.
 if [ -n "${E2E_API_PORT:-}" ] && command -v lsof >/dev/null 2>&1; then
-  p=$(lsof -ti ":$E2E_API_PORT" 2>/dev/null || true)
-  [ -n "$p" ] && kill $p 2>/dev/null || true
+  for p in $(lsof -ti ":$E2E_API_PORT" 2>/dev/null || true); do
+    _looks_like_api "$p" && kill "$p" 2>/dev/null || true
+  done
 fi
 
 # --- Postgres --------------------------------------------------------------

--- a/services/worker-service/tests/test_custom_tool_integration.py
+++ b/services/worker-service/tests/test_custom_tool_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 import sys
 from pathlib import Path
 
@@ -35,8 +36,22 @@ async def _wait_for_port(host: str, port: int, timeout_seconds: float = 10.0) ->
             await asyncio.sleep(0.1)
 
 
-async def _start_test_server(host: str = "127.0.0.1", port: int = 9100):
-    """Start the custom tool test server as a subprocess."""
+def _free_port(host: str = "127.0.0.1") -> int:
+    """Pick an ephemeral free TCP port.
+
+    Per-call allocation (not a fixed port) so two test runs in parallel git
+    worktrees don't collide on the MCP test-server port — see issue #112.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+async def _start_test_server(host: str = "127.0.0.1", port: int | None = None):
+    """Start the custom tool test server as a subprocess on a free port."""
+    if port is None:
+        port = _free_port(host)
     process = await asyncio.create_subprocess_exec(
         str(PYTHON_BIN), "-u", str(CUSTOM_TOOL_SERVER_SCRIPT),
         "--host", host, "--port", str(port),
@@ -63,7 +78,7 @@ class TestMcpSessionManagerIntegration:
     @pytest.mark.asyncio
     async def test_connect_and_discover_tools(self):
         """Connect to a real MCP server and discover its tools."""
-        process, server_url = await _start_test_server(port=9100)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",
@@ -93,7 +108,7 @@ class TestMcpSessionManagerIntegration:
     @pytest.mark.asyncio
     async def test_call_tool_echo(self):
         """Invoke a tool on the MCP server and verify the result."""
-        process, server_url = await _start_test_server(port=9101)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",
@@ -113,7 +128,7 @@ class TestMcpSessionManagerIntegration:
     @pytest.mark.asyncio
     async def test_call_tool_add_numbers(self):
         """Invoke add_numbers tool and verify arithmetic result."""
-        process, server_url = await _start_test_server(port=9102)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",
@@ -147,7 +162,7 @@ class TestMcpSessionManagerIntegration:
     @pytest.mark.asyncio
     async def test_connect_multiple_servers_one_fails(self):
         """If one server fails to connect, all sessions are cleaned up."""
-        process, server_url = await _start_test_server(port=9103)
+        process, server_url = await _start_test_server()
         try:
             good_config = ToolServerConfig(
                 name="good-server",
@@ -171,7 +186,7 @@ class TestMcpSessionManagerIntegration:
     @pytest.mark.asyncio
     async def test_session_lifecycle_connect_close(self):
         """Session can be opened and closed cleanly."""
-        process, server_url = await _start_test_server(port=9104)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",
@@ -195,7 +210,7 @@ class TestSchemaConversionIntegration:
         """Discover real tools and convert their schemas to StructuredTool."""
         from executor.schema_converter import mcp_tools_to_structured_tools
 
-        process, server_url = await _start_test_server(port=9105)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",
@@ -241,7 +256,7 @@ class TestBearerAuthIntegration:
     @pytest.mark.asyncio
     async def test_bearer_token_accepted_by_noauth_server(self):
         """A bearer token does not break connections to a no-auth server."""
-        process, server_url = await _start_test_server(port=9106)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="auth-test",
@@ -266,7 +281,7 @@ class TestBearerAuthIntegration:
     @pytest.mark.asyncio
     async def test_no_auth_mode_sends_no_header(self):
         """In 'none' auth mode, no Authorization header is sent."""
-        process, server_url = await _start_test_server(port=9107)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="noauth-test",
@@ -308,7 +323,7 @@ class TestMixedToolsIntegration:
         )
 
         # Get custom tools from MCP server
-        process, server_url = await _start_test_server(port=9108)
+        process, server_url = await _start_test_server()
         try:
             config = ToolServerConfig(
                 name="test-tools",

--- a/services/worker-service/tests/test_mcp_http_integration.py
+++ b/services/worker-service/tests/test_mcp_http_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import socket
 import sys
 
 import pytest
@@ -14,6 +15,15 @@ from mcp.client.streamable_http import streamable_http_client
 WORKER_SERVICE_DIR = Path(__file__).resolve().parents[1]
 PYTHON_BIN = Path(sys.executable)
 HTTP_SERVER_SCRIPT = WORKER_SERVICE_DIR / "tests" / "fixtures" / "http_test_server.py"
+
+
+def _free_port(host: str = "127.0.0.1") -> int:
+    """Pick an ephemeral free TCP port so parallel worktree runs don't collide
+    on a fixed server port — see issue #112."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
 
 
 async def _wait_for_port(host: str, port: int, timeout_seconds: float = 5.0) -> None:
@@ -34,7 +44,7 @@ class TestMcpHttpIntegration:
     @pytest.mark.asyncio
     async def test_client_can_connect_to_local_http_server_and_call_tools(self) -> None:
         host = "127.0.0.1"
-        port = 8765
+        port = _free_port(host)
         process = await asyncio.create_subprocess_exec(
             str(PYTHON_BIN),
             "-u",

--- a/tests/e2e-scripts/test_e2e_scripts.py
+++ b/tests/e2e-scripts/test_e2e_scripts.py
@@ -13,6 +13,7 @@ stdlib only.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -101,17 +102,36 @@ def test_free_port_zero_exits_two():
 # --------------------------------------------------------------------------- #
 # 2. e2e_run_id derivation
 # --------------------------------------------------------------------------- #
+def test_e2e_run_id_primary_is_empty():
+    out = _eval_common("e2e_run_id", {"ROOT_DIR": "/repo", "MAIN_ROOT": "/repo"})
+    assert out == ""
+
+
 @pytest.mark.parametrize(
-    "root_dir, main_root, expected",
+    "root_dir, prefix",
     [
-        ("/repo", "/repo", ""),                          # primary checkout
-        ("/x/Feature_Foo", "/repo", "feature-foo"),      # uppercase + underscore
-        ("/x/--wt 1.2--", "/repo", "wt-1-2"),            # punctuation + trim dashes
+        ("/x/Feature_Foo", "feature-foo"),   # uppercase + underscore slug
+        ("/x/--wt 1.2--", "wt-1-2"),         # punctuation + trim dashes
+        ("/x/___", "wt"),                    # all-punctuation basename -> wt-<hash>
     ],
 )
-def test_e2e_run_id(root_dir, main_root, expected):
-    out = _eval_common("e2e_run_id", {"ROOT_DIR": root_dir, "MAIN_ROOT": main_root})
-    assert out == expected
+def test_e2e_run_id_worktree_is_slug_plus_hash(root_dir, prefix):
+    # A worktree RUN_ID is a readable slug prefix + a full-path hash suffix.
+    out = _eval_common("e2e_run_id", {"ROOT_DIR": root_dir, "MAIN_ROOT": "/repo"})
+    assert re.fullmatch(rf"{re.escape(prefix)}-[0-9]+", out), out
+
+
+def test_e2e_run_id_is_deterministic():
+    env = {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
+    assert _eval_common("e2e_run_id", env) == _eval_common("e2e_run_id", env)
+
+
+def test_e2e_run_id_distinct_for_same_basename_different_path():
+    # The bug the hash fixes: two worktrees sharing a leaf name must NOT collide.
+    a = _eval_common("e2e_run_id", {"ROOT_DIR": "/a/feature", "MAIN_ROOT": "/repo"})
+    b = _eval_common("e2e_run_id", {"ROOT_DIR": "/b/feature", "MAIN_ROOT": "/repo"})
+    assert a != b, (a, b)
+    assert a.startswith("feature-") and b.startswith("feature-")
 
 
 # --------------------------------------------------------------------------- #
@@ -126,7 +146,7 @@ def test_pg_container_worktree():
     out = _eval_common(
         "e2e_pg_container", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
     )
-    assert out == "par-e2e-postgres-feature-foo"
+    assert re.fullmatch(r"par-e2e-postgres-feature-foo-[0-9]+", out), out
 
 
 def test_s3_bucket_primary():
@@ -138,7 +158,7 @@ def test_s3_bucket_worktree():
     out = _eval_common(
         "e2e_s3_bucket", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
     )
-    assert out == "platform-artifacts-feature-foo"
+    assert re.fullmatch(r"platform-artifacts-feature-foo-[0-9]+", out), out
 
 
 def test_env_file_path_uses_root_dir():
@@ -180,7 +200,10 @@ def test_make_run_id_matches_script_for_worktree():
     script_run_id = _eval_common(
         "e2e_run_id", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
     )
-    assert make_run_id == script_run_id == "feature-foo"
+    # Parity is the point: Make and the script must derive the SAME RUN_ID
+    # (slug + full-path hash) on this machine.
+    assert make_run_id == script_run_id
+    assert re.fullmatch(r"feature-foo-[0-9]+", script_run_id), script_run_id
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/e2e-scripts/test_e2e_scripts.py
+++ b/tests/e2e-scripts/test_e2e_scripts.py
@@ -1,0 +1,262 @@
+"""Unit tests for the per-worktree E2E test harness scripts (issue #112).
+
+Covers the Docker-free contracts of:
+  - scripts/e2e/free-port.py   (free port allocation / arg validation)
+  - scripts/e2e/common.sh      (RUN_ID slug + name/bucket/env-file builders)
+  - scripts/e2e/teardown.sh    (no-op safety when nothing was provisioned, E2E_KEEP)
+  - Makefile RUN_ID derivation  (parity with common.sh:e2e_run_id)
+
+provision.sh / reap.sh require a real Docker daemon and are intentionally NOT
+exercised here so the default suite stays Docker-free and CI-safe. Python 3.11,
+stdlib only.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# tests/e2e-scripts/test_e2e_scripts.py -> parents[2] == repo root.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+E2E_DIR = REPO_ROOT / "scripts" / "e2e"
+FREE_PORT = E2E_DIR / "free-port.py"
+COMMON_SH = E2E_DIR / "common.sh"
+TEARDOWN_SH = E2E_DIR / "teardown.sh"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _run_free_port(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(FREE_PORT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _eval_common(func: str, env_overrides: dict[str, str]) -> str:
+    """Source common.sh, run a single helper function, return stripped stdout."""
+    env = dict(os.environ)
+    env.update(env_overrides)
+    result = subprocess.run(
+        ["bash", "-c", f". {COMMON_SH}; {func}"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"`{func}` exited {result.returncode}; stderr={result.stderr!r}"
+    )
+    return result.stdout.strip()
+
+
+# --------------------------------------------------------------------------- #
+# 1. free-port.py
+# --------------------------------------------------------------------------- #
+def test_free_port_returns_five_distinct_bindable_ports():
+    proc = _run_free_port(["5"])
+    assert proc.returncode == 0, proc.stderr
+
+    # Single line of output.
+    assert proc.stdout.count("\n") == 1
+    tokens = proc.stdout.split()
+    assert len(tokens) == 5, f"expected 5 tokens, got {tokens!r}"
+
+    ports = [int(t) for t in tokens]  # all parse as ints
+    assert all(0 < p < 65536 for p in ports)
+    assert len(set(ports)) == 5, f"ports not distinct: {ports}"
+
+    # Each is (currently) bindable. A tiny TOCTOU window is acceptable.
+    for p in ports:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", p))
+        finally:
+            s.close()
+
+
+def test_free_port_default_is_one_port():
+    proc = _run_free_port([])
+    assert proc.returncode == 0, proc.stderr
+    tokens = proc.stdout.split()
+    assert len(tokens) == 1
+    assert proc.stdout.count("\n") == 1
+    int(tokens[0])  # parses
+
+
+def test_free_port_zero_exits_two():
+    proc = _run_free_port(["0"])
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+    assert "usage" in proc.stderr.lower()
+
+
+# --------------------------------------------------------------------------- #
+# 2. e2e_run_id derivation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "root_dir, main_root, expected",
+    [
+        ("/repo", "/repo", ""),                          # primary checkout
+        ("/x/Feature_Foo", "/repo", "feature-foo"),      # uppercase + underscore
+        ("/x/--wt 1.2--", "/repo", "wt-1-2"),            # punctuation + trim dashes
+    ],
+)
+def test_e2e_run_id(root_dir, main_root, expected):
+    out = _eval_common("e2e_run_id", {"ROOT_DIR": root_dir, "MAIN_ROOT": main_root})
+    assert out == expected
+
+
+# --------------------------------------------------------------------------- #
+# 3. name / bucket / env-file builders branch on primary vs worktree
+# --------------------------------------------------------------------------- #
+def test_pg_container_primary():
+    out = _eval_common("e2e_pg_container", {"ROOT_DIR": "/repo", "MAIN_ROOT": "/repo"})
+    assert out == "par-e2e-postgres"
+
+
+def test_pg_container_worktree():
+    out = _eval_common(
+        "e2e_pg_container", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
+    )
+    assert out == "par-e2e-postgres-feature-foo"
+
+
+def test_s3_bucket_primary():
+    out = _eval_common("e2e_s3_bucket", {"ROOT_DIR": "/repo", "MAIN_ROOT": "/repo"})
+    assert out == "platform-artifacts"
+
+
+def test_s3_bucket_worktree():
+    out = _eval_common(
+        "e2e_s3_bucket", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
+    )
+    assert out == "platform-artifacts-feature-foo"
+
+
+def test_env_file_path_uses_root_dir():
+    out = _eval_common(
+        "e2e_env_file", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
+    )
+    assert out == "/x/Feature_Foo/.tmp/e2e.env"
+
+
+# --------------------------------------------------------------------------- #
+# 4. Make <-> script parity for RUN_ID
+# --------------------------------------------------------------------------- #
+def test_make_run_id_matches_script_for_worktree():
+    if shutil.which("make") is None:
+        pytest.skip("make not on PATH")
+
+    make_proc = subprocess.run(
+        [
+            "make",
+            "--no-print-directory",
+            "-p",
+            "ROOT_DIR=/x/Feature_Foo",
+            "MAIN_ROOT=/repo",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    # `make -p` dumps the database even when no default goal runs; non-zero exit
+    # can occur if a goal fails, but the variable database still prints. Parse it.
+    run_id_lines = [
+        ln for ln in make_proc.stdout.splitlines() if ln.startswith("RUN_ID :=")
+    ]
+    assert run_id_lines, (
+        f"no `RUN_ID :=` line in make -p output; stderr={make_proc.stderr!r}"
+    )
+    make_run_id = run_id_lines[-1].split(":=", 1)[1].strip()
+
+    script_run_id = _eval_common(
+        "e2e_run_id", {"ROOT_DIR": "/x/Feature_Foo", "MAIN_ROOT": "/repo"}
+    )
+    assert make_run_id == script_run_id == "feature-foo"
+
+
+# --------------------------------------------------------------------------- #
+# 5. teardown.sh safety (Docker-free paths)
+# --------------------------------------------------------------------------- #
+def test_teardown_noop_when_env_file_absent(tmp_path):
+    """No .tmp/e2e.env -> exit 0, no docker calls. We shadow `docker` with a
+    stub on PATH that fails loudly if invoked, proving the script never reaches
+    a docker call on this path."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text("#!/bin/sh\necho 'DOCKER WAS CALLED' >&2\nexit 99\n")
+    docker_stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["ROOT_DIR"] = str(tmp_path)
+    env["MAIN_ROOT"] = str(tmp_path)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    proc = subprocess.run(
+        ["bash", str(TEARDOWN_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "DOCKER WAS CALLED" not in proc.stderr
+    # Silent no-op: nothing of substance on stdout.
+    assert proc.stdout.strip() == ""
+
+
+def test_teardown_keep_preserves_env_file(tmp_path):
+    """E2E_KEEP=1 -> exit 0, leave everything (env file must survive)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text("#!/bin/sh\necho 'DOCKER WAS CALLED' >&2\nexit 99\n")
+    docker_stub.chmod(0o755)
+
+    tmp_dir = tmp_path / ".tmp"
+    tmp_dir.mkdir()
+    env_file = tmp_dir / "e2e.env"
+    env_file.write_text("RUN_ID=feature-foo\nE2E_PG_CONTAINER=par-e2e-postgres-feature-foo\n")
+
+    env = dict(os.environ)
+    env["ROOT_DIR"] = str(tmp_path)
+    env["MAIN_ROOT"] = str(tmp_path)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["E2E_KEEP"] = "1"
+
+    proc = subprocess.run(
+        ["bash", str(TEARDOWN_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "DOCKER WAS CALLED" not in proc.stderr
+    # The keep path must not delete the contract file.
+    assert env_file.exists(), "E2E_KEEP=1 must not remove .tmp/e2e.env"
+
+
+# --------------------------------------------------------------------------- #
+# Docker-gated smoke test (skipped in CI / default suite)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker not available; provision/reap require a real daemon",
+)
+def test_common_sh_is_sourceable_with_docker_present():
+    """When docker exists, common.sh still sources cleanly and exposes helpers.
+    This does NOT call docker; it only guards against syntax regressions in the
+    Docker-aware portion of common.sh. Provision/reap themselves are excluded."""
+    out = _eval_common(
+        "type e2e_ensure_localstack >/dev/null && echo ok",
+        {"ROOT_DIR": "/repo", "MAIN_ROOT": "/repo"},
+    )
+    assert out == "ok"


### PR DESCRIPTION
Closes #112.

## Problem
Test infra assumed **one run per machine**: Postgres `par-e2e-postgres` on 55433, E2E API on 8081, embedding mock on 18099, and a single `platform-artifacts` S3 bucket were fixed single-instance names that `test-db-up`/`e2e-up` deliberately reused. Two agents in separate git worktrees running `make worker-test` / `make e2e-test` concurrently clobbered each other — they shared the DB (and the integration tests scrub fixed `tenant_id`/`agent_id` scopes, deleting each other's rows), the API port, and the bucket.

## Approach
Namespace each run by the worktree, keyed by `RUN_ID` (readable slug + a hash of the full checkout path; **empty on the primary checkout** so its names/ports stay byte-identical):

| Resource | Primary checkout | Worktree |
|---|---|---|
| Postgres | `par-e2e-postgres` :55433 | `par-e2e-postgres-<run-id>`, `-p 0:5432` → discovered host port |
| API | :8081 | dynamically allocated |
| Embedding mock | :18099 | dynamically allocated |
| S3 bucket | `platform-artifacts` (shared) | `platform-artifacts-<run-id>` |
| LocalStack | one shared `:4566` | same shared instance |

A generated `<root>/.tmp/e2e.env` is the contract every target sources, so teardown always targets *this* run's resources. All per-run containers carry `--label par-e2e=1 --label par-run=<run-id>`.

## What's in here
- **`scripts/e2e/`** — `provision.sh`, `teardown.sh`, `reap.sh`, `free-port.py`, `common.sh`, behind thin Makefile wrappers.
- **`worker-test` / `e2e-test`** rewired to provision → run → teardown-always (rc/PIPESTATUS preserved).
- Each run **disposes its DB container by default** (both checkouts); **`E2E_KEEP=1`** opts into reuse for a fast fix→test loop; **`PYTEST_ARGS`** runs a single test through the isolated harness; **`make e2e-reap`** GCs crashed-agent (worktree) leftovers. The shared `platform-artifacts` bucket + LocalStack are never torn down.
- **`conftest.py` unchanged** (already env-driven) → CI, which runs `pytest` directly, stays byte-identical.
- **MCP integration tests** now bind **ephemeral ports** instead of fixed (9100–9108, 8765) — they collided under concurrent worktree runs. New `AGENTS.md` rule so future tests don't reintroduce fixed ports.
- **Docs:** `AGENTS.md` + `docs/LOCAL_DEVELOPMENT.md` document the per-worktree model, the teardown contract, the knobs, the primary-only manual targets, and a "prefer a worktree for concurrent PR work" rule.
- **18 script unit tests** in `tests/e2e-scripts/` (`make e2e-scripts-test`).

## Commits
1. `6aee0cd` — core per-worktree isolation (scripts, Makefile rewire, MCP ephemeral-port fixes, docs, unit tests).
2. `2048a6c` — reuse kept API/embedding ports across `E2E_KEEP` loops (no orphaned `bootRun`).
3. `09992a6` — lifecycle hardening: trap only removes containers it created; `reap` spares the primary; teardown command-verifies before killing a pid / recycled port; `pg_isready` wait 30s→60s.
4. `ed0bebd` — unique `RUN_ID` per worktree (slug + full-path hash) so same-basename worktrees don't collide; always gate on LocalStack S3 readiness.
5. `3cf6dc6` — docs: mark manual `e2e-up`/`down`/`clean` primary-checkout-only; add the "prefer worktree" rule.

(Codex review findings on commits 1/3/4/5 were all addressed in the follow-up commits above.)

## Verification
- Concurrent `make worker-test` and `make e2e-test` across **two worktrees** — both green, distinct containers/ports/buckets, clean teardown (multiple rounds).
- `E2E_KEEP=1 make e2e-test` loop reuses the API (run 2 prints no "Starting E2E API"; no orphan).
- Primary-checkout runs byte-identical (55433/8081/18099/`platform-artifacts`); container disposed by default, kept under `E2E_KEEP=1`.
- `make e2e-reap` removes worktree containers + per-run buckets, keeps the primary container and shared bucket.
- 18 script unit tests pass; shellcheck clean.
- **CI green on the head commit** (Worker Integration + full E2E on Ubuntu — the Linux cross-platform guard — both pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)