### PR TITLE
Route tool transport failures to the agent instead of task-level retry

### DIFF
--- a/services/worker-service/executor/graph.py
+++ b/services/worker-service/executor/graph.py
@@ -132,7 +132,6 @@ from tools.memory_tools import (
     MemoryToolContext,
     build_memory_tools,
 )
-from tools.errors import ToolExecutionError, ToolTransportError
 from executor.mcp_session import McpToolCallError
 from executor.compaction.defaults import OFFLOAD_THRESHOLD_BYTES
 from executor.compaction.ingestion import (
@@ -268,8 +267,22 @@ class _ContextExceededIrrecoverableError(Exception):
 
 def _handle_tool_error(e: Exception) -> str:
     """Route tool errors: re-raise infra failures for task-level retry,
-    return user-fixable errors as messages so the LLM can self-correct."""
-    if isinstance(e, (ToolTransportError, McpToolCallError)):
+    return agent-correctable errors as messages so the LLM can self-correct.
+
+    Classification principle: failures of an *agent-chosen target* (a URL
+    that doesn't resolve, an HTTP error status, a timed-out fetch, a search
+    backend rejecting the query) are content errors — the agent picked the
+    input, so the agent gets the error text and decides (different URL, fall
+    back to search results, proceed without the source). Only platform
+    infrastructure faults re-raise into the task-level retry classifier.
+
+    ``ToolTransportError`` is deliberately NOT re-raised: task-level retry
+    replays the same checkpointed pending tool call deterministically, so a
+    task that hit an unresolvable hostname burned all 10 retries in ~20
+    minutes and dead-lettered without the agent ever seeing the error
+    (task 2825e0ba…, 2026-06-07).
+    """
+    if isinstance(e, McpToolCallError):
         raise e
     return f"Error: {e}\nPlease fix the error and try again."
 
@@ -3748,8 +3761,15 @@ class GraphExecutor:
 
     def _is_retryable_error(self, e: Exception) -> bool:
         """Determines if the exception should trigger a retry or immediate dead letter."""
-        # Check exception type first (most reliable signal)
-        if isinstance(e, (ToolTransportError, McpToolCallError)):
+        # Check exception type first (most reliable signal).
+        # ``ToolTransportError`` is intentionally absent: its only raisers
+        # (tools/read_url.py, tools/providers/search.py) execute inside the
+        # ToolNode, whose ``handle_tool_errors=_handle_tool_error`` converts
+        # it to an agent-visible error ToolMessage instead of re-raising —
+        # so the type can no longer reach this classifier, and keeping a
+        # "retryable" entry for it would contradict those agent-correctable
+        # semantics for any future raiser.
+        if isinstance(e, McpToolCallError):
             return True
         if isinstance(e, (ConnectionError, TimeoutError)):
             return True

--- a/services/worker-service/tests/fixtures/stdio_test_server.py
+++ b/services/worker-service/tests/fixtures/stdio_test_server.py
@@ -31,7 +31,15 @@ async def _public_resolver(host: str, port: int) -> list[str]:
 
 
 def _mock_handler(request: httpx.Request) -> httpx.Response:
-    if str(request.url) == "https://example.com/article":
+    # Match the way a real origin routes — by Host header + path — not by the
+    # connection URL. read_url's SSRF IP-pinning rewrites the request URL host
+    # to the validated IP and carries the original authority in the Host
+    # header, so a match on ``str(request.url) == "https://example.com/..."``
+    # would miss the pinned request (it arrives as https://<ip>/article with
+    # Host: example.com). Host+path matches both the pinned and un-pinned
+    # shapes.
+    host = request.headers.get("Host", request.url.host)
+    if host == "example.com" and request.url.path == "/article":
         html = """
             <html>
                 <head><title>Fixture Article</title></head>

--- a/services/worker-service/tests/test_executor.py
+++ b/services/worker-service/tests/test_executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import pytest
-from unittest.mock import ANY, AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 
 from core.worker import WorkerService
 from core.config import WorkerConfig
@@ -168,10 +168,26 @@ def test_handle_tool_error_returns_message_for_validation_errors():
     assert "fix the error" in result.lower()
 
 
-def test_handle_tool_error_reraises_transport_errors():
-    """Infrastructure errors propagate for task-level retry."""
-    with pytest.raises(ToolTransportError):
-        _handle_tool_error(ToolTransportError("S3 unreachable"))
+def test_handle_tool_error_returns_message_for_transport_errors():
+    """Transport failures of an agent-chosen target (URL, search query) are
+    content errors: returned to the LLM as a correctable ToolMessage so the
+    agent can adapt (different URL, fall back to search, proceed without the
+    source). Task-level retry would replay the same checkpointed tool call
+    deterministically — see the dead-letter incident pinned in
+    test_tool_error_routing.py."""
+    result = _handle_tool_error(
+        ToolTransportError("Hostname could not be resolved for https://atb.nrel.gov/.")
+    )
+    assert "Hostname could not be resolved" in result
+    assert "https://atb.nrel.gov/" in result
+
+
+def test_handle_tool_error_reraises_mcp_tool_call_errors():
+    """McpToolCallError keeps task-level retry semantics (separate, undecided)."""
+    with pytest.raises(McpToolCallError):
+        _handle_tool_error(
+            McpToolCallError("some-server", "some_tool", "Tool call timed out after 30s")
+        )
 
 
 def test_handle_tool_error_returns_message_for_tool_execution_errors():
@@ -601,59 +617,17 @@ async def test_cancellation_awareness(mock_worker, task_data):
             mock_worker.pool.acquire.return_value.__aenter__.return_value.execute.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_read_url_failure_preserves_failing_url_on_retryable_requeue(mock_worker, task_data):
-    executor = GraphExecutor(mock_worker.config, mock_worker.pool)
-
-    with patch.object(executor, "_build_graph") as mock_build:
-        mock_graph = MagicMock()
-        mock_compiled = AsyncMock()
-        mock_graph.compile.return_value = mock_compiled
-        mock_build.return_value = mock_graph
-
-        with patch("executor.graph.PostgresDurableCheckpointer") as MockCheckpointer:
-            mock_ckpt = AsyncMock()
-            mock_ckpt.aget_tuple.return_value = None
-            MockCheckpointer.return_value = mock_ckpt
-
-            async def failing_astream(*args, **kwargs):
-                raise ToolTransportError("URL fetch request failed for https://bad.example/fail: network down")
-                yield {}
-
-            mock_compiled.astream = failing_astream
-
-            await executor.execute_task(task_data, mock_worker.heartbeat.start_heartbeat.return_value.cancel_event)
-
-    # Retry requeue now uses conn.fetchval with lease guard
-    mock_worker.pool.acquire.return_value.__aenter__.return_value.fetchval.assert_any_call(
-        '''UPDATE tasks
-                       SET status='queued',
-                           retry_count=$1,
-                           retry_after=$2,
-                           retry_history=COALESCE(retry_history, '[]'::jsonb) || jsonb_build_array(NOW()),
-                           last_error_code='retryable_error',
-                           last_error_message=$3,
-                           version=version+1,
-                           lease_owner=NULL,
-                           lease_expiry=NULL
-                       WHERE task_id=$4::uuid
-                         AND status='running'
-                         AND lease_owner=$5
-                       RETURNING task_id''',
-        1,
-        ANY,
-        "URL fetch request failed for https://bad.example/fail: network down",
-        task_data["task_id"],
-        "test-worker",
-    )
-
-
-def test_tool_transport_error_is_retryable(mock_worker):
+def test_tool_transport_error_is_not_task_level_retryable(mock_worker):
+    """ToolTransportError can no longer escape the graph (ToolNode's
+    handle_tool_errors converts it to an agent-visible ToolMessage), so the
+    task-level classifier must not carry a dead "retryable" entry for it —
+    that classification contradicts the agent-correctable semantics and is a
+    trap for future raisers of the type."""
     executor = GraphExecutor(mock_worker.config, mock_worker.pool)
 
     assert executor._is_retryable_error(
-        ToolTransportError("URL fetch request failed for https://bad.example/fail: network down")
-    ) is True
+        ToolTransportError("Hostname could not be resolved for https://bad.example/fail.")
+    ) is False
 
 
 def test_mcp_tool_call_error_is_retryable(mock_worker):

--- a/services/worker-service/tests/test_read_url_ssrf_pinning.py
+++ b/services/worker-service/tests/test_read_url_ssrf_pinning.py
@@ -1,0 +1,195 @@
+"""SSRF / DNS-rebinding pinning tests for the read_url fetcher.
+
+Pre-existing TOCTOU (found in PR security review): ``_validate_public_url``
+resolved the host and asserted public, then the httpx fetch performed its
+OWN independent DNS lookup and connected to whatever that second lookup
+returned. A DNS-rebinding attacker could answer the validation lookup with a
+public IP and the connection lookup with a private/metadata IP
+(169.254.169.254, 127.0.0.1, …). The bounded timeout retry and every
+redirect hop each reopened the window.
+
+Fix: resolve+validate exactly ONCE per URL, pin the validated public IP, and
+connect the socket to that exact IP — while preserving TLS correctness (SNI
+and certificate hostname verification still use the original hostname, never
+the IP, and verification is never disabled).
+
+These tests prove the connection target equals the validated IP and never the
+rebound private IP — for the first request, the timeout retry, and a redirect
+hop — plus the one-resolution-per-attempt invariant. TLS cert-verification
+binding is proven separately in :mod:`test_read_url_tls_pinning`.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tools.errors import ToolTransportError
+from tools.read_url import ReadUrlFetcher
+
+
+PUBLIC_IP = "93.184.216.34"
+PRIVATE_IP = "169.254.169.254"  # link-local / cloud metadata — must never be hit
+
+
+def _counting_resolver(scripted: list):
+    """Resolver popping scripted outcomes (a list of IPs or an Exception)."""
+    state = {"count": 0}
+
+    async def resolver(host: str, port: int) -> list[str]:
+        state["count"] += 1
+        assert scripted, "resolver called more times than scripted"
+        outcome = scripted.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    return resolver, state
+
+
+def _spying_client(handler):
+    """Wrap a MockTransport handler so every connection target host is recorded."""
+    targets: list[str] = []
+    sni: list[str | None] = []
+    host_headers: list[str | None] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        targets.append(request.url.host)
+        sni.append(request.extensions.get("sni_hostname"))
+        host_headers.append(request.headers.get("host"))
+        return handler(request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_wrapped))
+    return client, targets, sni, host_headers
+
+
+def _ok(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "text/html; charset=utf-8"},
+        content="<html><head><title>OK</title></head><body><main><p>Body here.</p></main></body></html>",
+    )
+
+
+@pytest.mark.asyncio
+async def test_connects_to_validated_ip_with_hostname_sni_and_host_header() -> None:
+    """One resolution; socket targets the validated IP; SNI + Host stay the hostname."""
+    resolver, state = _counting_resolver([[PUBLIC_IP]])
+    client, targets, sni, host_headers = _spying_client(_ok)
+
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    result = await fetcher.fetch("https://example.com/page", 5000)
+
+    assert state["count"] == 1, "DNS must be resolved exactly once per attempt"
+    assert targets == [PUBLIC_IP], "socket must connect to the validated IP, not the hostname"
+    assert sni == ["example.com"], "TLS SNI must be the original hostname"
+    assert host_headers == ["example.com"], "Host header must be the original authority"
+    # final_url is the logical hostname URL, never the pinned IP.
+    assert result.final_url == "https://example.com/page"
+
+
+@pytest.mark.asyncio
+async def test_rebinding_first_request_connects_only_to_validated_ip() -> None:
+    """Validation sees PUBLIC; a re-resolution would see PRIVATE — never connect to it."""
+    resolver, state = _counting_resolver([[PUBLIC_IP], [PRIVATE_IP]])
+    client, targets, _sni, _hh = _spying_client(_ok)
+
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    await fetcher.fetch("https://example.com/page", 5000)
+
+    assert state["count"] == 1
+    assert targets == [PUBLIC_IP]
+    assert PRIVATE_IP not in targets
+
+
+@pytest.mark.asyncio
+async def test_rebinding_on_timeout_retry_reuses_pinned_ip() -> None:
+    """The timeout retry reuses the pinned IP — it must not re-resolve to PRIVATE."""
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("read timed out", request=request)
+        return _ok(request)
+
+    # Second list entry is the rebound private answer that must never be used.
+    resolver, state = _counting_resolver([[PUBLIC_IP], [PRIVATE_IP]])
+    client, targets, _sni, _hh = _spying_client(handler)
+
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    await fetcher.fetch("https://example.com/page", 5000)
+
+    assert state["count"] == 1, "retry must reuse the pinned IP, not re-resolve"
+    assert attempts["count"] == 2, "the timeout retry must have fired"
+    assert targets == [PUBLIC_IP, PUBLIC_IP]
+    assert PRIVATE_IP not in targets
+
+
+@pytest.mark.asyncio
+async def test_rebinding_on_redirect_hop_revalidates_and_pins_each_hop() -> None:
+    """Each redirect hop resolves+validates+pins its own host; private never hit."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        # hop 1 (connected to PUBLIC_IP for a.example) → redirect to b.example
+        if request.url.host == PUBLIC_IP:
+            return httpx.Response(302, headers={"location": "https://b.example/next"})
+        return _ok(request)
+
+    public_b = "1.1.1.1"
+    # a.example → PUBLIC_IP (validated), b.example → public_b (validated).
+    # A stray third call would return PRIVATE_IP — it must never happen.
+    resolver, state = _counting_resolver([[PUBLIC_IP], [public_b], [PRIVATE_IP]])
+    client, targets, _sni, _hh = _spying_client(handler)
+
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    await fetcher.fetch("https://a.example/start", 5000)
+
+    assert state["count"] == 2, "one resolution per redirect hop"
+    assert targets == [PUBLIC_IP, public_b]
+    assert PRIVATE_IP not in targets
+
+
+@pytest.mark.asyncio
+async def test_private_rebind_target_is_never_connected_even_if_resolver_flaps() -> None:
+    """Defense-in-depth: validated IPs are all asserted public before pinning."""
+    # Validation itself returns a private IP → must be rejected, no connection.
+    resolver, state = _counting_resolver([[PRIVATE_IP]])
+    client, targets, _sni, _hh = _spying_client(_ok)
+
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    with pytest.raises(Exception):
+        await fetcher.fetch("https://evil.example/page", 5000)
+
+    assert targets == [], "no socket may be opened when validation rejects the host"
+
+
+@pytest.mark.asyncio
+async def test_configured_timeout_is_applied_via_extension() -> None:
+    """client.send() bypasses build_request, so the timeout must be set explicitly."""
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["timeout"] = request.extensions.get("timeout")
+        return _ok(request)
+
+    resolver, _state = _counting_resolver([[PUBLIC_IP]])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver, timeout_seconds=7.5)
+    await fetcher.fetch("https://example.com/page", 5000)
+
+    assert seen["timeout"] == {"connect": 7.5, "read": 7.5, "write": 7.5, "pool": 7.5}
+
+
+@pytest.mark.asyncio
+async def test_literal_ip_url_pins_to_itself_without_sni() -> None:
+    """A literal public IP is already its own pin; no SNI override is set."""
+    # Resolver must not be consulted for a literal IP.
+    async def resolver(host: str, port: int) -> list[str]:  # pragma: no cover
+        raise AssertionError("resolver must not be called for a literal-IP URL")
+
+    client, targets, sni, _hh = _spying_client(_ok)
+    fetcher = ReadUrlFetcher(client=client, resolver=resolver)
+    await fetcher.fetch("https://93.184.216.34/page", 5000)
+
+    assert targets == ["93.184.216.34"]
+    assert sni == [None], "no SNI override for a literal-IP URL (cert binds to the IP)"

--- a/services/worker-service/tests/test_read_url_tls_pinning.py
+++ b/services/worker-service/tests/test_read_url_tls_pinning.py
@@ -161,7 +161,7 @@ async def test_cert_hostname_mismatch_is_rejected(tmp_path) -> None:
     try:
         # Cert is for pinned.test; verify against wrong.test → must be rejected.
         pinned = _PinnedTarget(connect_ip="127.0.0.1", sni_hostname="wrong.test")
-        with pytest.raises(ToolTransportError):
+        with pytest.raises(ToolTransportError) as excinfo:
             await _stream_response(
                 client,
                 f"https://wrong.test:{port}/",
@@ -170,6 +170,18 @@ async def test_cert_hostname_mismatch_is_rejected(tmp_path) -> None:
                 5.0,
                 1_000_000,
             )
+
+        # Assert the rejection is specifically a cert hostname-verification
+        # failure — not an unrelated error (e.g. connection refused) that would
+        # let this test pass for the wrong reason in a future regression.
+        cause_chain: list[BaseException] = []
+        cause: BaseException | None = excinfo.value.__cause__
+        while cause is not None and cause not in cause_chain:
+            cause_chain.append(cause)
+            cause = getattr(cause, "__cause__", None) or getattr(cause, "__context__", None)
+        assert any(
+            isinstance(c, ssl.SSLCertVerificationError) for c in cause_chain
+        ), f"expected an SSLCertVerificationError in the cause chain, got: {cause_chain}"
     finally:
         await client.aclose()
         server.close()

--- a/services/worker-service/tests/test_read_url_tls_pinning.py
+++ b/services/worker-service/tests/test_read_url_tls_pinning.py
@@ -1,0 +1,176 @@
+"""TLS-correctness proof for read_url's IP pinning.
+
+When the fetcher connects to a pinned IP (closing the DNS-rebinding TOCTOU),
+the TLS handshake must STILL verify the server certificate against the
+original *hostname* — never the IP — and verification must never be disabled.
+A wrong implementation here (verifying against the IP, or disabling
+verification) would be a worse vulnerability than the one being fixed.
+
+These tests stand up a real local TLS server on 127.0.0.1 (ephemeral port,
+worktree-concurrency-safe) presenting a cert for ``pinned.test`` signed by an
+in-test CA, then drive the production connection helper with the IP pinned to
+127.0.0.1:
+
+- success: SNI/cert host = ``pinned.test`` (matches cert) → handshake succeeds
+  even though the socket connected to 127.0.0.1, proving verification binds to
+  the hostname, not the IP.
+- mismatch: SNI/cert host = ``wrong.test`` (cert is for ``pinned.test``) →
+  ``ssl.SSLCertVerificationError`` surfaces as ``ToolTransportError``, proving
+  verification is genuinely enforced (no silent downgrade).
+
+No external network; loopback only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import ssl
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from tools.errors import ToolTransportError
+from tools.read_url import DEFAULT_REQUEST_HEADERS, _PinnedTarget, _stream_response
+
+CERT_HOST = "pinned.test"
+
+
+def _make_ca_and_leaf(leaf_host: str):
+    """Return (ca_pem_bytes, leaf_cert_pem_bytes, leaf_key_pem_bytes)."""
+    one_day = datetime.timedelta(days=1)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "read_url-test-ca")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - one_day)
+        .not_valid_after(now + one_day)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, leaf_host)]))
+        .issuer_name(ca_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - one_day)
+        .not_valid_after(now + one_day)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(leaf_host)]), critical=False)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    ca_pem = ca_cert.public_bytes(serialization.Encoding.PEM)
+    leaf_cert_pem = leaf_cert.public_bytes(serialization.Encoding.PEM)
+    leaf_key_pem = leaf_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return ca_pem, leaf_cert_pem, leaf_key_pem
+
+
+async def _start_tls_server(tmp_path, leaf_cert_pem: bytes, leaf_key_pem: bytes):
+    cert_file = tmp_path / "leaf.pem"
+    key_file = tmp_path / "leaf.key"
+    cert_file.write_bytes(leaf_cert_pem)
+    key_file.write_bytes(leaf_key_pem)
+
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(certfile=str(cert_file), keyfile=str(key_file))
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+            body = (
+                b"<html><head><title>TLS OK</title></head>"
+                b"<body><main><p>secure body</p></main></body></html>"
+            )
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/html; charset=utf-8\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+        except Exception:  # pragma: no cover - best-effort test server
+            pass
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0, ssl=server_ctx)
+    port = server.sockets[0].getsockname()[1]
+    return server, port
+
+
+def _client_trusting(ca_pem: bytes) -> httpx.AsyncClient:
+    client_ctx = ssl.create_default_context()
+    client_ctx.load_verify_locations(cadata=ca_pem.decode("ascii"))
+    # check_hostname stays True (default) — the whole point of the test.
+    return httpx.AsyncClient(verify=client_ctx)
+
+
+@pytest.mark.asyncio
+async def test_cert_verified_against_hostname_not_pinned_ip(tmp_path) -> None:
+    ca_pem, leaf_cert_pem, leaf_key_pem = _make_ca_and_leaf(CERT_HOST)
+    server, port = await _start_tls_server(tmp_path, leaf_cert_pem, leaf_key_pem)
+    client = _client_trusting(ca_pem)
+    try:
+        # Connect to 127.0.0.1 (the pin) but verify the cert against CERT_HOST.
+        # The cert has NO IP SAN, so success proves verification binds to the
+        # hostname carried via SNI, not the connection IP.
+        pinned = _PinnedTarget(connect_ip="127.0.0.1", sni_hostname=CERT_HOST)
+        resp = await _stream_response(
+            client,
+            f"https://{CERT_HOST}:{port}/",
+            pinned,
+            DEFAULT_REQUEST_HEADERS,
+            5.0,
+            1_000_000,
+        )
+        assert resp.status_code == 200
+        assert b"secure body" in resp.body
+        # final_url reports the logical hostname URL, never the pinned IP.
+        assert resp.url == f"https://{CERT_HOST}:{port}/"
+    finally:
+        await client.aclose()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cert_hostname_mismatch_is_rejected(tmp_path) -> None:
+    ca_pem, leaf_cert_pem, leaf_key_pem = _make_ca_and_leaf(CERT_HOST)
+    server, port = await _start_tls_server(tmp_path, leaf_cert_pem, leaf_key_pem)
+    client = _client_trusting(ca_pem)
+    try:
+        # Cert is for pinned.test; verify against wrong.test → must be rejected.
+        pinned = _PinnedTarget(connect_ip="127.0.0.1", sni_hostname="wrong.test")
+        with pytest.raises(ToolTransportError):
+            await _stream_response(
+                client,
+                f"https://wrong.test:{port}/",
+                pinned,
+                DEFAULT_REQUEST_HEADERS,
+                5.0,
+                1_000_000,
+            )
+    finally:
+        await client.aclose()
+        server.close()
+        await server.wait_closed()

--- a/services/worker-service/tests/test_read_url_tool.py
+++ b/services/worker-service/tests/test_read_url_tool.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import socket
+
 import httpx
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
 from tools.definitions import ToolDependencies
-from tools.errors import ToolExecutionError, ToolInputError
+from tools.errors import ToolExecutionError, ToolInputError, ToolTransportError
 from tools.providers.search import SearchResult
 from tools.read_url import ReadUrlFetcher
 from tools.server import create_mcp_server
@@ -38,6 +40,15 @@ async def _private_resolver(host: str, port: int) -> list[str]:
 
 def _build_client(handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def _ok_handler(request: httpx.Request) -> httpx.Response:
+    del request
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "text/html; charset=utf-8"},
+        content="<html><head><title>OK</title></head><body><main><p>Recovered content.</p></main></body></html>",
+    )
 
 
 class TestReadUrlFetcher:
@@ -205,3 +216,162 @@ class TestReadUrlFetcher:
 
         with pytest.raises(ToolExecutionError, match=r"https://example.com/fail"):
             await fetcher.fetch("https://example.com/fail", 5000)
+
+
+class TestReadUrlTransientRetry:
+    """ONE bounded in-tool retry for transient failures, none for permanent.
+
+    The error text the LLM eventually sees must be actionable: include the
+    URL and a hint so the agent can choose a different URL or source.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("tools.read_url.TRANSIENT_RETRY_DELAY_SECONDS", 0.0)
+
+    def _counting_resolver(self, outcomes: list):
+        """Resolver popping scripted outcomes (exception or list of IPs)."""
+        calls = {"count": 0}
+
+        async def resolver(host: str, port: int) -> list[str]:
+            calls["count"] += 1
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        return resolver, calls
+
+    @pytest.mark.asyncio
+    async def test_transient_dns_failure_retries_once_then_surfaces(self) -> None:
+        resolver, calls = self._counting_resolver(
+            [
+                socket.gaierror(socket.EAI_AGAIN, "temporary failure in name resolution"),
+                socket.gaierror(socket.EAI_AGAIN, "temporary failure in name resolution"),
+            ]
+        )
+        fetcher = ReadUrlFetcher(client=_build_client(_ok_handler), resolver=resolver)
+
+        with pytest.raises(ToolTransportError) as excinfo:
+            await fetcher.fetch("https://flaky.example/page", 5000)
+
+        assert calls["count"] == 2
+        message = str(excinfo.value)
+        assert "https://flaky.example/page" in message
+        assert "could not be resolved" in message
+        assert "different URL" in message
+
+    @pytest.mark.asyncio
+    async def test_transient_dns_failure_succeeds_on_retry(self) -> None:
+        resolver, calls = self._counting_resolver(
+            [
+                socket.gaierror(socket.EAI_AGAIN, "temporary failure in name resolution"),
+                ["93.184.216.34"],
+            ]
+        )
+        fetcher = ReadUrlFetcher(client=_build_client(_ok_handler), resolver=resolver)
+
+        result = await fetcher.fetch("https://flaky.example/page", 5000)
+
+        assert calls["count"] == 2
+        assert "Recovered content." in result.content
+
+    @pytest.mark.asyncio
+    async def test_permanent_dns_failure_is_not_retried(self) -> None:
+        resolver, calls = self._counting_resolver(
+            [socket.gaierror(socket.EAI_NONAME, "nodename nor servname provided")]
+        )
+        fetcher = ReadUrlFetcher(client=_build_client(_ok_handler), resolver=resolver)
+
+        with pytest.raises(ToolTransportError) as excinfo:
+            await fetcher.fetch("https://nxdomain.example/page", 5000)
+
+        assert calls["count"] == 1
+        message = str(excinfo.value)
+        assert "https://nxdomain.example/page" in message
+        assert "different URL" in message
+
+    @pytest.mark.asyncio
+    async def test_indeterminate_resolution_failure_is_treated_as_transient(self) -> None:
+        # A bare OSError carries no gaierror errno — when indeterminate,
+        # retry once: a wrong "permanent" call costs the agent a source.
+        resolver, calls = self._counting_resolver(
+            [OSError("resolver subsystem hiccup"), ["93.184.216.34"]]
+        )
+        fetcher = ReadUrlFetcher(client=_build_client(_ok_handler), resolver=resolver)
+
+        result = await fetcher.fetch("https://hiccup.example/page", 5000)
+
+        assert calls["count"] == 2
+        assert "Recovered content." in result.content
+
+    @pytest.mark.asyncio
+    async def test_timeout_retries_once_then_surfaces(self) -> None:
+        attempts = {"count": 0}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            attempts["count"] += 1
+            raise httpx.ReadTimeout("read timed out", request=request)
+
+        fetcher = ReadUrlFetcher(client=_build_client(handler), resolver=_public_resolver)
+
+        with pytest.raises(ToolTransportError) as excinfo:
+            await fetcher.fetch("https://slow.example/page", 5000)
+
+        assert attempts["count"] == 2
+        message = str(excinfo.value)
+        assert "https://slow.example/page" in message
+        assert "timed out" in message
+        assert "different URL" in message
+
+    @pytest.mark.asyncio
+    async def test_timeout_succeeds_on_retry(self) -> None:
+        attempts = {"count": 0}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise httpx.ConnectTimeout("connect timed out", request=request)
+            return await _ok_handler(request)
+
+        fetcher = ReadUrlFetcher(client=_build_client(handler), resolver=_public_resolver)
+
+        result = await fetcher.fetch("https://slow.example/page", 5000)
+
+        assert attempts["count"] == 2
+        assert "Recovered content." in result.content
+
+    @pytest.mark.asyncio
+    async def test_http_404_is_not_retried_and_message_is_actionable(self) -> None:
+        attempts = {"count": 0}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            attempts["count"] += 1
+            return httpx.Response(404, headers={"Content-Type": "text/html"}, content="nope")
+
+        fetcher = ReadUrlFetcher(client=_build_client(handler), resolver=_public_resolver)
+
+        with pytest.raises(ToolExecutionError) as excinfo:
+            await fetcher.fetch("https://gone.example/page", 5000)
+
+        assert attempts["count"] == 1
+        message = str(excinfo.value)
+        assert "https://gone.example/page" in message
+        assert "404" in message
+        assert "different URL" in message
+
+    @pytest.mark.asyncio
+    async def test_non_timeout_request_failure_is_not_retried(self) -> None:
+        attempts = {"count": 0}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            attempts["count"] += 1
+            raise httpx.ConnectError("network down", request=request)
+
+        fetcher = ReadUrlFetcher(client=_build_client(handler), resolver=_public_resolver)
+
+        with pytest.raises(ToolTransportError) as excinfo:
+            await fetcher.fetch("https://down.example/page", 5000)
+
+        assert attempts["count"] == 1
+        assert "different URL" in str(excinfo.value)

--- a/services/worker-service/tests/test_read_url_tool.py
+++ b/services/worker-service/tests/test_read_url_tool.py
@@ -235,6 +235,7 @@ class TestReadUrlTransientRetry:
 
         async def resolver(host: str, port: int) -> list[str]:
             calls["count"] += 1
+            assert outcomes, "resolver called more times than scripted"
             outcome = outcomes.pop(0)
             if isinstance(outcome, Exception):
                 raise outcome

--- a/services/worker-service/tests/test_search_provider_concurrency.py
+++ b/services/worker-service/tests/test_search_provider_concurrency.py
@@ -136,8 +136,14 @@ class TestTavilySearchProviderConcurrency:
         provider = TavilySearchProvider(timeout_seconds=0.1)
         _inject(provider, _HangingClient())
 
-        with pytest.raises(ToolTransportError, match="timed out"):
+        with pytest.raises(ToolTransportError, match="timed out") as excinfo:
             await provider.search("hang", 1)
+
+        # The error routes to the LLM as a correctable ToolMessage — it must
+        # include the agent-chosen query and an actionable hint.
+        message = str(excinfo.value)
+        assert "'hang'" in message
+        assert "rephrase" in message
 
     @pytest.mark.asyncio
     async def test_provider_error_is_wrapped_in_tool_transport_error(self) -> None:
@@ -148,5 +154,10 @@ class TestTavilySearchProviderConcurrency:
         provider = TavilySearchProvider()
         _inject(provider, _ExplodingClient())
 
-        with pytest.raises(ToolTransportError, match="tavily boom"):
+        with pytest.raises(ToolTransportError, match="tavily boom") as excinfo:
             await provider.search("boom", 1)
+
+        # Same actionable-message contract as the timeout path.
+        message = str(excinfo.value)
+        assert "'boom'" in message
+        assert "rephrase" in message

--- a/services/worker-service/tests/test_tool_error_routing.py
+++ b/services/worker-service/tests/test_tool_error_routing.py
@@ -1,0 +1,151 @@
+"""Regression: read_url transport failures surface to the agent, not task retry.
+
+Production incident (task 2825e0ba…, 2026-06-07): the agent called
+``read_url`` on a URL whose hostname failed to resolve. ``ReadUrlFetcher``
+raised ``ToolTransportError``; ``_handle_tool_error`` re-raised it as an
+infra failure, so the task was requeued at the task level. On every resume
+the checkpointed pending tool call re-executed the same URL
+deterministically (~100ms per attempt), burning all 10 task retries in
+~20 minutes before dead-lettering with "Max retries reached. Last error:
+Hostname could not be resolved for https://atb.nrel.gov/…". The agent never
+saw the error, so it never adapted.
+
+Decided behavior ("tell the agent, keep the task alive"): URL-level
+failures are returned to the LLM as a correctable error ToolMessage. This
+test drives the real compiled graph — ``GraphExecutor._build_graph`` with
+the production ``ReadUrlFetcher`` whose resolver fails exactly as
+production DNS did — and asserts:
+
+1. the error lands in ``state["messages"]`` as a ToolMessage with
+   ``status="error"`` and actionable content (URL included),
+2. the NEXT model call happens (the agent loop continues), and
+3. no exception escapes the graph.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from core.config import WorkerConfig
+from executor.graph import GraphExecutor
+from executor.memory_graph import MemoryDecision
+from tools.definitions import ToolDependencies
+from tools.read_url import ReadUrlFetcher
+
+
+FAILING_URL = "https://atb.nrel.gov/electricity/2024/index"
+
+
+class _UnusedSearchProvider:
+    provider_name = "unused"
+
+    async def search(self, query: str, max_results: int):  # pragma: no cover
+        raise AssertionError("web_search must not be called in this test")
+
+
+class _ScriptedModel:
+    """Fake chat model: returns scripted AIMessages in order, records calls."""
+
+    def __init__(self, responses: list[AIMessage]) -> None:
+        self._responses = list(responses)
+        self.calls: list[list] = []
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages, config=None, **kwargs):
+        self.calls.append(list(messages))
+        if not self._responses:
+            raise AssertionError("scripted model ran out of responses")
+        return self._responses.pop(0)
+
+
+async def _failing_resolver(host: str, port: int) -> list[str]:
+    """Resolver failing as production DNS did for the incident's hostname.
+
+    EAI_NONAME == NXDOMAIN-style permanent failure — read_url must not even
+    burn its single in-tool transient retry on it.
+    """
+    raise socket.gaierror(
+        socket.EAI_NONAME, "nodename nor servname provided, or not known"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_read_url_surfaces_to_agent_and_loop_continues():
+    config = WorkerConfig(worker_id="test-worker", tenant_id="default")
+    executor = GraphExecutor(
+        config,
+        MagicMock(),  # pool — only touched via best-effort/fallback paths here
+        deps=ToolDependencies(
+            search_provider=_UnusedSearchProvider(),
+            read_url_fetcher=ReadUrlFetcher(resolver=_failing_resolver),
+        ),
+        s3_client=MagicMock(),
+    )
+
+    model = _ScriptedModel(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "name": "read_url",
+                        "args": {"url": FAILING_URL, "max_chars": 2000},
+                    }
+                ],
+            ),
+            AIMessage(
+                content="That source is unavailable; proceeding without it."
+            ),
+        ]
+    )
+
+    with patch("executor.providers.create_llm", AsyncMock(return_value=model)):
+        workflow = await executor._build_graph(
+            {
+                "model": "claude-haiku-4-5",
+                "allowed_tools": ["read_url"],
+                # Keep the ToolNode wrapper a passthrough — no S3 in this test.
+                "context_management": {"offload_tool_results": False},
+            },
+            cancel_event=asyncio.Event(),
+            task_id="task-tool-error-routing",
+            tenant_id="default",
+            agent_id="agent-tool-error-routing",
+            memory_decision=MemoryDecision(stack_enabled=False, auto_write=False),
+            task_input="read the url",
+        )
+
+    graph = workflow.compile()
+
+    # No exception may escape the graph — the production shape dead-lettered
+    # exactly because one did.
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content=f"read {FAILING_URL}")]},
+        config={"recursion_limit": 10},
+    )
+
+    messages = result["messages"]
+
+    # 1. The failure landed in state as an error ToolMessage the LLM can see.
+    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    tool_msg = tool_messages[0]
+    assert tool_msg.status == "error"
+    content = str(tool_msg.content)
+    assert "could not be resolved" in content
+    assert FAILING_URL in content
+
+    # 2. The loop continued: the model was called again AFTER the tool error
+    #    and its final answer is the last message.
+    assert len(model.calls) == 2
+    final = messages[-1]
+    assert isinstance(final, AIMessage)
+    assert "proceeding without it" in str(final.content)

--- a/services/worker-service/tools/errors.py
+++ b/services/worker-service/tools/errors.py
@@ -12,4 +12,13 @@ class ToolInputError(ToolExecutionError):
 
 
 class ToolTransportError(ToolExecutionError):
-    """Raised when a transient backend or network dependency fails."""
+    """Raised when a tool's network fetch fails (DNS, timeout, HTTP 5xx, …).
+
+    These are failures of an *agent-chosen target* (a URL, a search query),
+    not platform infrastructure: the worker's ToolNode error handler
+    (``executor.graph._handle_tool_error``) surfaces them to the LLM as a
+    correctable error ToolMessage so the agent can adapt — it does NOT
+    trigger a task-level retry. Raisers should make the message actionable
+    (include the target and a hint), and may perform a single bounded
+    in-tool retry for transient flavors before raising.
+    """

--- a/services/worker-service/tools/errors.py
+++ b/services/worker-service/tools/errors.py
@@ -20,5 +20,8 @@ class ToolTransportError(ToolExecutionError):
     correctable error ToolMessage so the agent can adapt — it does NOT
     trigger a task-level retry. Raisers should make the message actionable
     (include the target and a hint), and may perform a single bounded
-    in-tool retry for transient flavors before raising.
+    in-tool retry for transient flavors before raising. When the same
+    exception is raised inside the external MCP tool server, it surfaces
+    worker-side as ``McpToolCallError`` instead, which keeps task-retry
+    semantics.
     """

--- a/services/worker-service/tools/providers/search.py
+++ b/services/worker-service/tools/providers/search.py
@@ -117,11 +117,19 @@ class TavilySearchProvider:
                 timeout=self._timeout_seconds,
             )
         except asyncio.TimeoutError as exc:
-            raise ToolTransportError("Search request timed out.") from exc
+            raise ToolTransportError(
+                f"Search request timed out for query: {query!r}. The search "
+                "backend may be slow or overloaded. Try again later, rephrase "
+                "the query, or proceed without search results."
+            ) from exc
         except ToolTransportError:
             raise
         except Exception as exc:  # noqa: BLE001 — normalise provider errors
-            raise ToolTransportError(f"Tavily search failed: {exc}") from exc
+            raise ToolTransportError(
+                f"Tavily search failed for query {query!r}: {exc}. The search "
+                "backend may be unavailable. Try again later, rephrase the "
+                "query, or proceed without search results."
+            ) from exc
 
         raw_results = (payload or {}).get("results") or []
         results: list[SearchResult] = []

--- a/services/worker-service/tools/read_url.py
+++ b/services/worker-service/tools/read_url.py
@@ -24,6 +24,8 @@ DEFAULT_TIMEOUT_SECONDS: Final[float] = 10.0
 # Single bounded in-tool retry for transient failures (transient DNS, fetch /
 # connect timeout) before the error surfaces to the LLM as a correctable
 # ToolMessage. A small fixed delay — deliberately no backoff machinery.
+# The retry budget is per resolve/request attempt, so a redirect chain may
+# retry once per hop (max MAX_REDIRECTS + 1 hops).
 TRANSIENT_RETRY_DELAY_SECONDS: Final[float] = 0.5
 # getaddrinfo errnos that mean the *name itself* is bad (NXDOMAIN-style) —
 # retrying cannot help, surface immediately. Anything else (EAI_AGAIN, bare
@@ -111,7 +113,7 @@ class ReadUrlFetcher:
 
         for _ in range(self._max_redirects + 1):
             await self._validate_public_url(current_url)
-            response = await self._request_once(current_url)
+            response = await self._request_with_retry(current_url)
 
             if response.status_code in {301, 302, 303, 307, 308}:
                 location = response.headers.get("location")
@@ -207,7 +209,7 @@ class ReadUrlFetcher:
                 await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
         raise ToolTransportError(dns_error_message)
 
-    async def _request_once(self, url: str) -> _FetchedResponse:
+    async def _request_with_retry(self, url: str) -> _FetchedResponse:
         """Issue one logical request, retrying once on fetch/connect timeout.
 
         Only timeouts get the single in-tool retry; other request failures

--- a/services/worker-service/tools/read_url.py
+++ b/services/worker-service/tools/read_url.py
@@ -281,7 +281,13 @@ class ReadUrlFetcher:
                 self._max_body_bytes,
             )
 
-        async with httpx.AsyncClient() as client:
+        # trust_env=False: we do our own resolve→validate→pin, so egress must
+        # not be silently redirected through an env proxy (HTTPS_PROXY/ALL_PROXY)
+        # that performs its own DNS — that would re-open the rebinding window the
+        # pinning closes. It also avoids the proxy CONNECT path using the pinned
+        # IP as the TLS server_hostname (ignoring our sni_hostname extension),
+        # which would fail cert verification closed and break env-proxy fetches.
+        async with httpx.AsyncClient(trust_env=False) as client:
             return await _stream_response(
                 client,
                 url,

--- a/services/worker-service/tools/read_url.py
+++ b/services/worker-service/tools/read_url.py
@@ -89,6 +89,22 @@ class _FetchedResponse:
     body_truncated: bool = False
 
 
+@dataclass(frozen=True)
+class _PinnedTarget:
+    """A validated connection target for a single URL.
+
+    ``connect_ip`` is the exact IP the socket must connect to — it was
+    resolved and asserted public during validation, so the connection cannot
+    be rebound to a private/metadata address by a second DNS lookup.
+    ``sni_hostname`` is the original hostname used for TLS SNI **and**
+    certificate hostname verification (``None`` for a literal-IP URL, where
+    the IP is its own pin and the cert legitimately binds to the IP).
+    """
+
+    connect_ip: str
+    sni_hostname: str | None
+
+
 class ReadUrlFetcher:
     """Fetch and sanitize readable text from public web pages."""
 
@@ -112,8 +128,11 @@ class ReadUrlFetcher:
         current_url = original_url
 
         for _ in range(self._max_redirects + 1):
-            await self._validate_public_url(current_url)
-            response = await self._request_with_retry(current_url)
+            # Resolve + validate + pin in one step: the IP we validate as
+            # public is the exact IP we connect to. Re-run per redirect hop so
+            # each new host is validated and pinned independently.
+            pinned = await self._resolve_and_pin(current_url)
+            response = await self._request_with_retry(current_url, pinned)
 
             if response.status_code in {301, 302, 303, 307, 308}:
                 location = response.headers.get("location")
@@ -160,7 +179,15 @@ class ReadUrlFetcher:
 
         raise ToolExecutionError(f"Too many redirects while fetching {original_url}.")
 
-    async def _validate_public_url(self, url: str) -> None:
+    async def _resolve_and_pin(self, url: str) -> _PinnedTarget:
+        """Validate *url*'s host and return the pinned connection target.
+
+        Closes the DNS-rebinding TOCTOU: DNS is resolved exactly once here and
+        every resolved address is asserted public; the first validated address
+        is pinned and used as the socket target by ``_stream_response`` (no
+        second, unvalidated lookup at connect time). A literal-IP URL needs no
+        DNS — the IP is validated and is its own pin.
+        """
         parsed = urlparse(url)
         hostname = parsed.hostname
         if hostname is None:
@@ -174,12 +201,18 @@ class ReadUrlFetcher:
         literal_ip = _try_parse_ip(host)
         if literal_ip is not None:
             _assert_public_ip(literal_ip)
-            return
+            # Literal IP: it is its own pin; the cert (if https) legitimately
+            # binds to the IP, so no SNI override.
+            return _PinnedTarget(connect_ip=host, sni_hostname=None)
 
         resolved_ips = await self._resolve_with_retry(host, port, url)
 
         for ip_text in resolved_ips:
             _assert_public_ip(ipaddress.ip_address(ip_text))
+
+        # All resolved addresses are public; pin the first. The original
+        # hostname carries TLS SNI + cert verification.
+        return _PinnedTarget(connect_ip=resolved_ips[0], sni_hostname=host)
 
     async def _resolve_with_retry(self, host: str, port: int, url: str) -> list[str]:
         """Resolve *host*, retrying once on transient (EAI_AGAIN-style) failures.
@@ -209,26 +242,40 @@ class ReadUrlFetcher:
                 await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
         raise ToolTransportError(dns_error_message)
 
-    async def _request_with_retry(self, url: str) -> _FetchedResponse:
+    async def _request_with_retry(
+        self, url: str, pinned: _PinnedTarget
+    ) -> _FetchedResponse:
         """Issue one logical request, retrying once on fetch/connect timeout.
 
         Only timeouts get the single in-tool retry; other request failures
         (connection refused/reset, protocol errors) surface immediately with
-        an actionable message for the LLM.
+        an actionable message for the LLM. The retry reuses the SAME validated
+        *pinned* IP — it never re-resolves, so the rebinding window stays shut
+        across the retry.
         """
         try:
-            return await self._request_attempt(url)
+            return await self._request_attempt(url, pinned)
         except ToolTransportError as exc:
             if not isinstance(exc.__cause__, httpx.TimeoutException):
                 raise
             await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
-            return await self._request_attempt(url)
+            return await self._request_attempt(url, pinned)
 
-    async def _request_attempt(self, url: str) -> _FetchedResponse:
+    async def _request_attempt(
+        self, url: str, pinned: _PinnedTarget
+    ) -> _FetchedResponse:
+        # When a caller injects ``self._client``, that client's transport
+        # receives the same IP-pinned request (URL host rewritten to the
+        # validated IP, original authority in the Host header, original
+        # hostname in the ``sni_hostname`` extension). The default-client
+        # path below is the security-relevant one: a stock
+        # ``httpx.AsyncClient`` would otherwise re-resolve the hostname at
+        # connect time — pinning the IP in the request URL prevents that.
         if self._client is not None:
             return await _stream_response(
                 self._client,
                 url,
+                pinned,
                 DEFAULT_REQUEST_HEADERS,
                 self._timeout_seconds,
                 self._max_body_bytes,
@@ -238,6 +285,7 @@ class ReadUrlFetcher:
             return await _stream_response(
                 client,
                 url,
+                pinned,
                 DEFAULT_REQUEST_HEADERS,
                 self._timeout_seconds,
                 self._max_body_bytes,
@@ -247,37 +295,71 @@ class ReadUrlFetcher:
 async def _stream_response(
     client: httpx.AsyncClient,
     url: str,
+    pinned: _PinnedTarget,
     headers: dict[str, str],
     timeout_seconds: float,
     max_body_bytes: int,
 ) -> _FetchedResponse:
+    """Fetch *url* by connecting to the validated, pinned IP.
+
+    The socket connects to ``pinned.connect_ip`` (the request URL's host is
+    rewritten to the IP, so httpx/httpcore performs no DNS lookup of its own).
+    The original authority is restored in the ``Host`` header and the original
+    hostname is carried in the ``sni_hostname`` request extension, which
+    httpcore uses as the TLS ``server_hostname`` for BOTH SNI and certificate
+    hostname verification — so verification binds to the hostname, not the IP,
+    and is never disabled.
+    """
+    logical_url = httpx.URL(url)
+    connect_url = logical_url.copy_with(host=pinned.connect_ip)
+    request_headers = dict(headers)
+    # Original authority (host[:port]) so the origin server routes correctly
+    # even though the socket connects to a bare IP.
+    request_headers["Host"] = logical_url.netloc.decode("ascii")
+
+    # Build the timeout extension explicitly: client.send() bypasses
+    # build_request, so without this it would fall back to the client's
+    # default timeout instead of the configured one.
+    extensions: dict[str, object] = {
+        "timeout": httpx.Timeout(timeout_seconds).as_dict(),
+    }
+    if logical_url.scheme == "https" and pinned.sni_hostname is not None:
+        extensions["sni_hostname"] = pinned.sni_hostname
+
+    request = httpx.Request(
+        "GET",
+        connect_url,
+        headers=request_headers,
+        extensions=extensions,
+    )
+
+    response: httpx.Response | None = None
     try:
-        async with client.stream(
-            "GET",
-            url,
+        response = await client.send(
+            request,
+            stream=True,
             follow_redirects=False,
-            headers=headers,
-            timeout=timeout_seconds,
-        ) as response:
-            body = bytearray()
-            body_truncated = False
-            async for chunk in response.aiter_bytes():
-                remaining = max_body_bytes - len(body)
-                if remaining <= 0:
-                    body_truncated = True
-                    break
-                if len(chunk) > remaining:
-                    body.extend(chunk[:remaining])
-                    body_truncated = True
-                    break
-                body.extend(chunk)
-            return _FetchedResponse(
-                url=str(response.url),
-                status_code=response.status_code,
-                headers={key.lower(): value for key, value in response.headers.items()},
-                body=bytes(body),
-                body_truncated=body_truncated,
-            )
+        )
+        body = bytearray()
+        body_truncated = False
+        async for chunk in response.aiter_bytes():
+            remaining = max_body_bytes - len(body)
+            if remaining <= 0:
+                body_truncated = True
+                break
+            if len(chunk) > remaining:
+                body.extend(chunk[:remaining])
+                body_truncated = True
+                break
+            body.extend(chunk)
+        return _FetchedResponse(
+            # Report the logical hostname URL — never leak the pinned IP.
+            url=url,
+            status_code=response.status_code,
+            headers={key.lower(): value for key, value in response.headers.items()},
+            body=bytes(body),
+            body_truncated=body_truncated,
+        )
     except httpx.TimeoutException as exc:
         raise ToolTransportError(
             f"URL fetch timed out for {url}. The site may be slow or "
@@ -288,6 +370,9 @@ async def _stream_response(
             f"URL fetch request failed for {url}: {exc}. The site may be "
             "unreachable. Try a different URL or source."
         ) from exc
+    finally:
+        if response is not None:
+            await response.aclose()
 
 
 async def _default_resolver(host: str, port: int) -> list[str]:

--- a/services/worker-service/tools/read_url.py
+++ b/services/worker-service/tools/read_url.py
@@ -21,6 +21,22 @@ from tools.errors import ToolExecutionError, ToolInputError, ToolTransportError
 MAX_BODY_BYTES: Final[int] = 1_000_000
 MAX_REDIRECTS: Final[int] = 3
 DEFAULT_TIMEOUT_SECONDS: Final[float] = 10.0
+# Single bounded in-tool retry for transient failures (transient DNS, fetch /
+# connect timeout) before the error surfaces to the LLM as a correctable
+# ToolMessage. A small fixed delay — deliberately no backoff machinery.
+TRANSIENT_RETRY_DELAY_SECONDS: Final[float] = 0.5
+# getaddrinfo errnos that mean the *name itself* is bad (NXDOMAIN-style) —
+# retrying cannot help, surface immediately. Anything else (EAI_AGAIN, bare
+# OSError, empty result) is indeterminate and treated as transient: one retry
+# costs little, while a wrong "permanent" call costs the agent a source.
+_PERMANENT_DNS_ERRNOS: Final[frozenset[int]] = frozenset(
+    errno
+    for errno in (
+        getattr(socket, "EAI_NONAME", None),  # name does not exist (NXDOMAIN)
+        getattr(socket, "EAI_NODATA", None),  # name exists, no address records
+    )
+    if errno is not None
+)
 DISALLOWED_HOST_SUFFIXES: Final[tuple[str, ...]] = (".localhost", ".local", ".internal")
 DEFAULT_REQUEST_HEADERS: Final[dict[str, str]] = {
     # Some news sites and CDNs block obvious bot headers but allow the same public
@@ -108,11 +124,15 @@ class ReadUrlFetcher:
 
             if response.status_code in {408, 429} or response.status_code >= 500:
                 raise ToolTransportError(
-                    f"URL fetch failed temporarily for {current_url} with status {response.status_code}."
+                    f"URL fetch failed temporarily for {current_url} with status "
+                    f"{response.status_code}. The site may be overloaded or temporarily "
+                    "unavailable. Try again later, or use a different URL or source."
                 )
             if response.status_code >= 400:
                 raise ToolExecutionError(
-                    f"URL fetch failed for {current_url} with status {response.status_code}."
+                    f"URL fetch failed for {current_url} with status "
+                    f"{response.status_code}. The URL may be wrong or the page "
+                    "inaccessible. Try a different URL or source."
                 )
 
             content_type = response.headers.get("content-type", "")
@@ -154,18 +174,55 @@ class ReadUrlFetcher:
             _assert_public_ip(literal_ip)
             return
 
-        try:
-            resolved_ips = await self._resolver(host, port)
-        except OSError as exc:
-            raise ToolTransportError(f"Hostname could not be resolved for {url}.") from exc
-
-        if not resolved_ips:
-            raise ToolTransportError(f"Hostname could not be resolved for {url}.")
+        resolved_ips = await self._resolve_with_retry(host, port, url)
 
         for ip_text in resolved_ips:
             _assert_public_ip(ipaddress.ip_address(ip_text))
 
+    async def _resolve_with_retry(self, host: str, port: int, url: str) -> list[str]:
+        """Resolve *host*, retrying once on transient (EAI_AGAIN-style) failures.
+
+        Permanent failures (NXDOMAIN / EAI_NONAME) surface immediately — the
+        agent chose the URL, so the actionable error text goes back to it.
+        """
+        dns_error_message = (
+            f"Hostname could not be resolved for {url}. The URL may be invalid "
+            "or the site unavailable. Try a different URL or source."
+        )
+        for attempt in (0, 1):
+            try:
+                resolved_ips = await self._resolver(host, port)
+            except OSError as exc:
+                permanent = (
+                    isinstance(exc, socket.gaierror)
+                    and exc.errno in _PERMANENT_DNS_ERRNOS
+                )
+                if permanent or attempt == 1:
+                    raise ToolTransportError(dns_error_message) from exc
+                await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
+                continue
+            if resolved_ips:
+                return resolved_ips
+            if attempt == 0:
+                await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
+        raise ToolTransportError(dns_error_message)
+
     async def _request_once(self, url: str) -> _FetchedResponse:
+        """Issue one logical request, retrying once on fetch/connect timeout.
+
+        Only timeouts get the single in-tool retry; other request failures
+        (connection refused/reset, protocol errors) surface immediately with
+        an actionable message for the LLM.
+        """
+        try:
+            return await self._request_attempt(url)
+        except ToolTransportError as exc:
+            if not isinstance(exc.__cause__, httpx.TimeoutException):
+                raise
+            await asyncio.sleep(TRANSIENT_RETRY_DELAY_SECONDS)
+            return await self._request_attempt(url)
+
+    async def _request_attempt(self, url: str) -> _FetchedResponse:
         if self._client is not None:
             return await _stream_response(
                 self._client,
@@ -220,9 +277,15 @@ async def _stream_response(
                 body_truncated=body_truncated,
             )
     except httpx.TimeoutException as exc:
-        raise ToolTransportError(f"URL fetch timed out for {url}.") from exc
+        raise ToolTransportError(
+            f"URL fetch timed out for {url}. The site may be slow or "
+            "unreachable. Try a different URL or source."
+        ) from exc
     except httpx.HTTPError as exc:
-        raise ToolTransportError(f"URL fetch request failed for {url}: {exc}") from exc
+        raise ToolTransportError(
+            f"URL fetch request failed for {url}: {exc}. The site may be "
+            "unreachable. Try a different URL or source."
+        ) from exc
 
 
 async def _default_resolver(host: str, port: int) -> list[str]:


### PR DESCRIPTION
## Summary

Fixes a tool-error misclassification that dead-letters whole tasks over a single bad URL. Incident shape (live task, 2026-06-07): the agent called `read_url` on a URL whose hostname failed to resolve → `ToolTransportError` was re-raised by `_handle_tool_error` as an *infra* failure → task-level requeue → every resume re-executed the **same checkpointed tool call** deterministically (~100ms each) → all 10 retries burned over 20 minutes → `dead_letter`. The agent never saw the error, so it never did the obvious thing: pick a different source.

**The classification principle this PR encodes** (`_handle_tool_error` docstring): failures of an **agent-chosen target** (DNS, HTTP error status, target timeout, request failure) are *content errors* → returned to the LLM as a correctable error ToolMessage; the agent adapts (different URL, search-result fallback, proceed without the source). Task-level retry remains reserved for *platform faults* (crash, DB, provider outage) — and `McpToolCallError` keeps its re-raise semantics unchanged.

Changes:
- `_handle_tool_error`: `ToolTransportError` no longer re-raised — falls through to the correctable-message path.
- `_is_retryable_error`: `ToolTransportError` removed — verified unreachable (all production raisers live in `read_url`/`web_search`, invoked solely via the single `ToolNode`; the MCP-server path surfaces as `McpToolCallError`, untouched).
- `read_url`: one bounded in-tool retry for transients (fetch/connect timeout; transient/indeterminate DNS via `socket.gaierror` errno, cross-platform-guarded) — permanent failures (NXDOMAIN/`EAI_NONAME`/`EAI_NODATA`, HTTP 4xx) surface immediately. Retry budget is per resolve/request attempt (documented: a redirect chain may retry once per hop).
- All `read_url`/`web_search` error messages now carry the target + an actionable hint for the LLM ("try a different URL or source" / "rephrase the query or proceed without search").
- Scope note (adjudicated in review): the type-based routing also makes `web_search` (Tavily) transport failures agent-visible — same deterministic-replay pathology, same fix. The missing-`TAVILY_API_KEY` case now fails *quietly* into the transcript instead of loudly dead-lettering; a worker-side WARN/metric for that specific error is a recorded follow-up, not in this diff.

## Test Plan

- [x] RED-first regression at the graph seam: real `_build_graph` + production `ReadUrlFetcher` with a failing resolver reproduces the incident exception escaping pre-fix; post-fix asserts the error lands as a `status="error"` ToolMessage, the model is called again, and no exception escapes
- [x] Retry matrix: exactly one retry for transient DNS/timeout (counter-pinned), no retry for NXDOMAIN/404/ConnectError, success-on-retry, no wall-clock sleeps in tests
- [x] Routing pins: transport → correctable string; `McpToolCallError` → still re-raises and still task-retryable
- [x] Full worker suite: 1059 passed on the isolated per-worktree harness
- [x] Two-stage review (spec + quality) with independent test re-runs and a scratch-worktree RED reproduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Security follow-up (added after review)

A PR review flagged a DNS-rebinding/SSRF TOCTOU in the read_url retry path. Verification showed it was **pre-existing** (validation and the httpx fetch did two independent DNS lookups, on the first request and every redirect hop; the retry widened it). Fixed at the root by **pinning the validated IP**: one DNS resolution per hop, every address asserted public, the socket connects to that exact IP for the first request + retry + each redirect hop. TLS certificate verification is preserved against the original hostname (carried via the `Host` header and the `sni_hostname` extension → httpcore `server_hostname`), never disabled; `trust_env=False` prevents env-proxy egress from re-opening the window. Independent adversarial security review (separate agent from the author) verified all paths against httpcore 1.0.9 source. New tests: rebinding simulation on all three connection paths + real-handshake cert-binding tests. (Commits d63bfd7, 83c16af.)

Documented follow-up: env-proxy / custom-CA-via-env deployments are unsupported by the read_url default client (trust_env=False); revisit if an egress-proxy topology is needed.