### PR TITLE
build: pin docker-compose project name for the shared dev stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ COMPOSE_FILE := $(ROOT_DIR)/docker-compose.yml
 # (whose directory name differs) adopt the same stack instead of colliding on
 # container_name with a directory-derived project.
 COMPOSE_PROJECT ?= persistent-agent-runtime
+# Export so the e2e helper scripts (scripts/e2e/common.sh:e2e_compose_project)
+# read the same value and never target a different project than the Makefile.
+export COMPOSE_PROJECT
 LOCALSTACK_CONTAINER_NAME ?= persistent-agent-runtime-localstack
 S3_ENDPOINT_URL ?= http://localhost:4566
 S3_BUCKET_NAME ?= platform-artifacts

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ PYTHON ?= $(shell \
 
 DB_CONTAINER_NAME ?= persistent-agent-runtime-postgres
 COMPOSE_FILE := $(ROOT_DIR)/docker-compose.yml
+# The dev stack (postgres :55432 + LocalStack :4566) is one shared global stack with
+# fixed container names. Pin the compose project name so invocations from git worktrees
+# (whose directory name differs) adopt the same stack instead of colliding on
+# container_name with a directory-derived project.
+COMPOSE_PROJECT ?= persistent-agent-runtime
 LOCALSTACK_CONTAINER_NAME ?= persistent-agent-runtime-localstack
 S3_ENDPOINT_URL ?= http://localhost:4566
 S3_BUCKET_NAME ?= platform-artifacts
@@ -767,7 +772,7 @@ db-up:
 		exit 1; \
 	fi
 	@DB_USER="$(DB_USER)" DB_PASSWORD="$(DB_PASSWORD)" DB_NAME="$(DB_NAME)" DB_PORT="$(DB_PORT)" \
-		docker compose -f $(COMPOSE_FILE) up -d postgres localstack
+		docker compose -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) up -d postgres localstack
 	@echo "$(YELLOW)⏳ Waiting for PostgreSQL to accept connections...$(NC)"
 	@attempts=0; \
 	until docker exec $(DB_CONTAINER_NAME) env PGPASSWORD="$(DB_PASSWORD)" pg_isready -h 127.0.0.1 -p 5432 -U "$(DB_USER)" -d "$(DB_NAME)" >/dev/null 2>&1; do \
@@ -792,11 +797,11 @@ db-up:
 
 db-down:
 	@echo "$(YELLOW)🛑 Stopping Database and LocalStack containers...$(NC)"
-	@docker compose -f $(COMPOSE_FILE) down
+	@docker compose -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) down
 	@echo "$(GREEN)✅ Containers stopped$(NC)"
 
 db-status:
-	@docker compose -f $(COMPOSE_FILE) ps
+	@docker compose -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) ps
 
 db-migrate: db-up
 	@echo "$(YELLOW)🛠️  Applying migrations to Database...$(NC)"
@@ -926,7 +931,7 @@ test-db-up:
 		true; \
 	else \
 		DB_USER="$(DB_USER)" DB_PASSWORD="$(DB_PASSWORD)" DB_NAME="$(DB_NAME)" DB_PORT="$(DB_PORT)" \
-			docker compose -f $(COMPOSE_FILE) up -d localstack; \
+			docker compose -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) up -d localstack; \
 		attempts=0; \
 		until docker exec $(LOCALSTACK_CONTAINER_NAME) awslocal s3 ls >/dev/null 2>&1; do \
 			attempts=$$((attempts + 1)); \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,15 @@ services:
       timeout: 10s
       retries: 10
 
+# Explicit, project-independent volume names. The services already use fixed
+# container_names; pin the volumes the same way so the dev stack's data identity
+# does not depend on the Compose project name. Without this, Compose prefixes
+# unnamed volumes with the project (e.g. <dir-basename>_pgdata from a worktree),
+# so a project change would silently start PostgreSQL on a fresh empty volume.
+# These names match the canonical `persistent-agent-runtime_*` volumes that
+# existing default installs already have, so this is a no-op for them.
 volumes:
   pgdata:
+    name: persistent-agent-runtime_pgdata
   localstackdata:
+    name: persistent-agent-runtime_localstackdata

--- a/scripts/e2e/common.sh
+++ b/scripts/e2e/common.sh
@@ -112,6 +112,13 @@ e2e_compose_file() {
   printf '%s/docker-compose.yml' "$(e2e_root_dir)"
 }
 
+# Compose project name for the shared dev stack. MUST be pinned: from a git
+# worktree, compose would otherwise derive the project from the directory name
+# and collide on the fixed container_name owned by the real project.
+e2e_compose_project() {
+  printf 'persistent-agent-runtime'
+}
+
 # Discover the host port mapped to a container's 5432/tcp. Handles IPv4+IPv6
 # lines (takes the first) on both Docker Desktop (macOS) and Linux.
 e2e_discover_pg_port() {
@@ -126,7 +133,7 @@ e2e_ensure_localstack() {
     # `|| true`: two concurrent cold provisions may both race `compose up` on the
     # shared fixed container_name and one returns non-zero — tolerate it and let
     # the readiness loop below be the real gate.
-    docker compose -f "$(e2e_compose_file)" up -d localstack >/dev/null 2>&1 || true
+    docker compose -f "$(e2e_compose_file)" -p "$(e2e_compose_project)" up -d localstack >/dev/null 2>&1 || true
   fi
   # ALWAYS wait for S3 to actually answer — a running container does NOT imply a
   # ready S3 endpoint. If a concurrent provision just started LocalStack, the

--- a/scripts/e2e/common.sh
+++ b/scripts/e2e/common.sh
@@ -114,9 +114,13 @@ e2e_compose_file() {
 
 # Compose project name for the shared dev stack. MUST be pinned: from a git
 # worktree, compose would otherwise derive the project from the directory name
-# and collide on the fixed container_name owned by the real project.
+# and collide on the fixed container_name owned by the real project. Honor an
+# exported COMPOSE_PROJECT override so this stays in lockstep with the Makefile's
+# `COMPOSE_PROJECT ?= persistent-agent-runtime` (otherwise an override there and
+# the hardcoded name here would target two different projects that both claim the
+# fixed `persistent-agent-runtime-localstack` container).
 e2e_compose_project() {
-  printf 'persistent-agent-runtime'
+  printf '%s' "${COMPOSE_PROJECT:-persistent-agent-runtime}"
 }
 
 # Discover the host port mapped to a container's 5432/tcp. Handles IPv4+IPv6


### PR DESCRIPTION
## Summary

`make start` / `db-up` / `db-down` / `db-status` / `test-db-up` and the e2e shared-LocalStack provisioning let `docker compose` derive its project name from the working directory. From a **git worktree** (whose directory name ≠ the repo name), that produced a different compose project which then collided on the dev stack's fixed `container_name`s:

```
Container persistent-agent-runtime-postgres ... is already in use
make: *** [db-up] Error 1
```

— forcing a `COMPOSE_PROJECT_NAME=persistent-agent-runtime make start` workaround for any live-stack work from a worktree.

Pin the project name explicitly and thread `-p` through every shared-stack compose call, mirroring the pattern the **Langfuse** stack in the same Makefile already uses (`-p $(LANGFUSE_DOCKER_PROJECT)`):

- `Makefile`: new `COMPOSE_PROJECT ?= persistent-agent-runtime`; `-p $(COMPOSE_PROJECT)` on `db-up`, `db-down`, `db-status`, `test-db-up`.
- `scripts/e2e/common.sh`: new `e2e_compose_project()`; `-p` on the shared-LocalStack `compose up`.

A worktree now **adopts** the one shared dev stack instead of colliding. No-op for the primary checkout (already that project name) and overridable via `?=`. This is orthogonal to the per-worktree **test** infra (#112), which isolates via dynamically-named containers — this only pins the deliberately-shared dev/global stack.

## Test plan

- [x] Audited every `docker compose -f $(COMPOSE_FILE)` call — all four now pass `-p`; the Langfuse stack already pinned its own project.
- [x] From a git worktree with **no** env override: `make db-up` adopts the running `persistent-agent-runtime` containers (previously errored "already in use"); `make db-status` reports the shared stack; no directory-named compose project is created.
- [ ] CI green (expected no-op on the single-checkout runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)